### PR TITLE
Fix/pnr makefiles

### DIFF
--- a/Build/ThirdParty/Pandoc/README.md
+++ b/Build/ThirdParty/Pandoc/README.md
@@ -9,9 +9,9 @@ You also get the latex distribution as well.
 # To generate the report in PDF format
 
 ```bash
-(cd ~/DARPA/ALIGN.wiki/2019-Q1-Quarterly-Report-from-Intel/; tar cvfh - .) | docker run --rm --mount source=wikiVol,target=/wiki -i ubuntu bash -c "cd /wiki && tar xvf -"
+(cd ~/DARPA/ALIGN.wiki/2019-Q3-Quarterly-Report-from-Intel/; tar cvfh - .) | docker run --rm --mount source=wikiVol,target=/wiki -i ubuntu bash -c "cd /wiki && tar xvf -"
 
-docker run --rm --mount source=wikiVol,target=/data pandoc/latex 2019-Q1-Quarterly-Report-from-Intel.md -f gfm -o x.pdf
+docker run --rm --mount source=wikiVol,target=/data pandoc/latex 2019-Q3-Quarterly-Report-----DARPA-IDEA-ALIGN.md -f gfm -o x.pdf
 
 docker run --rm --mount source=wikiVol,target=/wiki ubuntu bash -c "cd /wiki && tar cvf - x.pdf" | tar xvf - 
 ```

--- a/PlaceRouteHierFlow/.gitignore
+++ b/PlaceRouteHierFlow/.gitignore
@@ -8,3 +8,5 @@ router/FastSteinerUM/*.o
 router/FastSteinerUM/*.a
 router/FastSteinerUM/gen
 router/FastSteinerUM/steiner
+*.gcno
+*.gcda

--- a/PlaceRouteHierFlow/Makefile
+++ b/PlaceRouteHierFlow/Makefile
@@ -1,29 +1,35 @@
 
 MAKE=make
-LDFLAGS=-Wl,--no-as-needed -ldl --coverate
+
 # To compile locally, override LP_DIR as follows:  %> LP_DIR=<path_to_lpsolve> make
 LP_DIR?=/usr/local/lib/lpsolve
 LIB_LP = $(LP_DIR)/lp_solve_5.5.2.5_dev_ux64
 SOURCE_LP= $(LP_DIR)/lp_solve_5.5
 BOOST_LP?=/usr/include
 
-export CXXFLAGS = -g -w -Wall -std=c++14 -O3 -lm -ldl -m64 -pthread -I$(LIB_LP) -I$(SOURCE_LP) -I$(BOOST_LP) --coverage
+COVERAGE?=
+OPTS?=-g -O3
+WARNS?=-w -Wall
+
+export CXXFLAGS = $(OPTS) $(WARNS) -std=c++14 -m64 -pthread -I$(LIB_LP) -I$(SOURCE_LP) -I$(BOOST_LP) $(COVERAGE)
 export CXX=g++
 export JSON?=/opt/json
+export LDFLAGS = -lm -ldl -pthread $(COVERAGE)
+
+PnRDB_path=PnRDB
+Capplacer_path=cap_placer
+placer_path=placer
+router_path=router
 
 PnRDB_objs=PnRDB/PnRdatabase.o PnRDB/readfile.o
-PnRDB_path=PnRDB
-placer_path=placer
-Capplacer_path=cap_placer
 Capplacer_objs=cap_placer/capplacer.o
-router_path=router
 placer_objs=placer/Placer.o placer/ConstGraph.o placer/design.o placer/SeqPair.o placer/Aplace.o
 router_objs=router/Router.o router/GlobalRouter.o router/Graph.o router/Grid.o router/RawRouter.o router/DetailRouter.o router/PowerRouter.o router/GlobalGrid.o router/GlobalGraph.o router/GcellGlobalRouter.o router/GcellDetailRouter.o
 
-all: subsystem main.o pnr_compiler
+all: subsystem pnr_compiler
 
 pnr_compiler: $(PnRDB_objs) $(placer_objs) $(router_objs) $(Capplacer_objs) main.o
-	$(CXX) $(CXXFLAGS) -o pnr_compiler $(PnRDB_objs) $(placer_objs) $(router_objs) $(Capplacer_objs) main.o -ldl
+	$(CXX) -o pnr_compiler $(PnRDB_objs) $(placer_objs) $(router_objs) $(Capplacer_objs) main.o $(LDFLAGS)
 
 subsystem:
 	$(MAKE) -C $(PnRDB_path);

--- a/PlaceRouteHierFlow/Makefile
+++ b/PlaceRouteHierFlow/Makefile
@@ -10,10 +10,11 @@ BOOST_LP?=/usr/include
 COVERAGE?=
 OPTS?=-g -O3
 WARNS?=-w -Wall
+JSON?=/opt/json
 
-export CXXFLAGS = $(OPTS) $(WARNS) -std=c++14 -m64 -pthread -I$(LIB_LP) -I$(SOURCE_LP) -I$(BOOST_LP) $(COVERAGE)
+export CXXFLAGS = $(OPTS) $(WARNS) -std=c++14 -m64 -pthread -I$(LIB_LP) -I$(SOURCE_LP) -I$(BOOST_LP) -I$(JSON)/include $(COVERAGE)
 export CXX=g++
-export JSON?=/opt/json
+
 export LDFLAGS = -lm -ldl -pthread $(COVERAGE)
 
 PnRDB_path=PnRDB

--- a/PlaceRouteHierFlow/Makefile
+++ b/PlaceRouteHierFlow/Makefile
@@ -1,18 +1,16 @@
 
 MAKE=make
-LDFLAGS="-Wl,--no-as-needed -ldl"
+LDFLAGS=-Wl,--no-as-needed -ldl --coverate
 # To compile locally, override LP_DIR as follows:  %> LP_DIR=<path_to_lpsolve> make
 LP_DIR?=/usr/local/lib/lpsolve
+LIB_LP = $(LP_DIR)/lp_solve_5.5.2.5_dev_ux64
 SOURCE_LP= $(LP_DIR)/lp_solve_5.5
 BOOST_LP?=/usr/include
 
-CC=g++ -g -w -Wall -std=c++14 -O3 -lm -ldl -m64 -pthread -I$(SOURCE_LP) -I$(BOOST_LP)
-CXX=$(CC)
+export CXXFLAGS = -g -w -Wall -std=c++14 -O3 -lm -ldl -m64 -pthread -I$(LIB_LP) -I$(SOURCE_LP) -I$(BOOST_LP) --coverage
+export CXX=g++
+export JSON?=/opt/json
 
-#CC=g++ -w -Wall -std=c++11 -g -DRFLAG
-
-#SOURCE=./
-JSON?=/opt/json
 PnRDB_objs=PnRDB/PnRdatabase.o PnRDB/readfile.o
 PnRDB_path=PnRDB
 placer_path=placer
@@ -25,7 +23,7 @@ router_objs=router/Router.o router/GlobalRouter.o router/Graph.o router/Grid.o r
 all: subsystem main.o pnr_compiler
 
 pnr_compiler: $(PnRDB_objs) $(placer_objs) $(router_objs) $(Capplacer_objs) main.o
-	$(CC) -o pnr_compiler $(PnRDB_objs) $(placer_objs) $(router_objs) $(Capplacer_objs) main.o -ldl
+	$(CXX) $(CXXFLAGS) -o pnr_compiler $(PnRDB_objs) $(placer_objs) $(router_objs) $(Capplacer_objs) main.o -ldl
 
 subsystem:
 	$(MAKE) -C $(PnRDB_path);
@@ -34,21 +32,9 @@ subsystem:
 	$(MAKE) -C $(Capplacer_path);
 
 main.o:		main.cpp $(PnRDB_path)/datatype.h $(PnRDB_path)/PnRdatabase.h $(placer_path)/Placer.h $(router_path)/Router.h $(Capplacer_path)/capplacer.h
-	$(CC) -c main.cpp -I$(JSON)/include
+	$(CXX) $(CXXFLAGS) -c main.cpp -I$(JSON)/include
 
 clean:
 	rm -rf *.o $(PnRDB_path)/*.o $(placer_path)/*.o pnr_compiler *.pl *.plt *gds all_*
 	make -C $(router_path) clean
 	make -C $(Capplacer_path) clean
-
-#main.o:		main.cpp datatype.h readfile.h PnRdatabase.h
-#		$(CC) -c main.cpp  
-#
-#readfile.o :    readfile.cpp readfile.h
-#		$(CC) -c readfile.cpp 
-#
-#PnRdatabase.o:	PnRdatabase.h readfile.h datatype.h 
-#		$(CC) -c PnRdatabase.cpp
-#
-#clean:		
-#		/bin/rm -f *.o

--- a/PlaceRouteHierFlow/PnRDB/Makefile
+++ b/PlaceRouteHierFlow/PnRDB/Makefile
@@ -1,16 +1,10 @@
-
-# Need JSON, CXX, and CXXFLAGS to be defined
-
-SOURCE=./
-OBJECTS=readfile.o PnRdatabase.o main.o
+# Need CXX, and CXXFLAGS to be defined
 
 all: readfile.o PnRdatabase.o
 
 readfile.o :    readfile.cpp readfile.h
-		$(CXX) $(CXXFLAGS) -c readfile.cpp 
 
 PnRdatabase.o:	PnRdatabase.cpp PnRdatabase.h readfile.h datatype.h
-		$(CXX) $(CXXFLAGS) -c PnRdatabase.cpp -I$(JSON)/include
 
 clean:		
-		/bin/rm -f *.o tester
+	/bin/rm -f *.o tester

--- a/PlaceRouteHierFlow/PnRDB/Makefile
+++ b/PlaceRouteHierFlow/PnRDB/Makefile
@@ -1,19 +1,16 @@
-#CC=g++ -g -w -Wall -std=c++11
-CC=g++ -g -w -Wall -std=c++11 -DHFLAG
-#CC=g++ -w -Wall -std=c++11 -g -DRFLAG
 
-# JSON place can be over-ridden:  nlohmann/json
-JSON?=/opt/json
+# Need JSON, CXX, and CXXFLAGS to be defined
+
 SOURCE=./
 OBJECTS=readfile.o PnRdatabase.o main.o
 
 all: readfile.o PnRdatabase.o
 
 readfile.o :    readfile.cpp readfile.h
-		$(CC) -c readfile.cpp 
+		$(CXX) $(CXXFLAGS) -c readfile.cpp 
 
 PnRdatabase.o:	PnRdatabase.cpp PnRdatabase.h readfile.h datatype.h
-		$(CC) -c PnRdatabase.cpp -I$(JSON)/include
+		$(CXX) $(CXXFLAGS) -c PnRdatabase.cpp -I$(JSON)/include
 
 clean:		
 		/bin/rm -f *.o tester

--- a/PlaceRouteHierFlow/cap_placer/Makefile
+++ b/PlaceRouteHierFlow/cap_placer/Makefile
@@ -1,17 +1,11 @@
-SOURCE_LP = ../lpsolve/lp_solve_5.5
+# Need JSON, CXX and CXXFLAGS
 
-CC=g++ -w -Wall -std=c++11 -g -pthread -I$(SOURCE_LP)
-#CC=g++ -w -Wall -std=c++11 -g -DRFLAG
-
-# JSON place can be over-ridden:  nlohmann/json
-JSON?=/opt/json
-SOURCE=./
 OBJECTS=main.o capplacer.o
 
 all: capplacer.o 
 
 capplacer.o :	capplacer.cpp capplacer.h
-		$(CC) -c capplacer.cpp -I$(JSON)/include
+		$(CXX) $(CXXFLAGS) -c capplacer.cpp -I$(JSON)/include
 
 clean:		
 		/bin/rm -f *.o 

--- a/PlaceRouteHierFlow/cap_placer/Makefile
+++ b/PlaceRouteHierFlow/cap_placer/Makefile
@@ -1,11 +1,8 @@
-# Need JSON, CXX and CXXFLAGS
-
-OBJECTS=main.o capplacer.o
+# Need CXX and CXXFLAGS
 
 all: capplacer.o 
 
-capplacer.o :	capplacer.cpp capplacer.h
-		$(CXX) $(CXXFLAGS) -c capplacer.cpp -I$(JSON)/include
+capplacer.o : capplacer.cpp capplacer.h
 
 clean:		
-		/bin/rm -f *.o 
+	/bin/rm -f *.o 

--- a/PlaceRouteHierFlow/placer/Makefile
+++ b/PlaceRouteHierFlow/placer/Makefile
@@ -1,29 +1,30 @@
+
+# Needs CXX and CXXFLAGS to be defined
+
 BOOST_LP?=/usr/local
-CC=g++ -w -Wall -std=c++11 -g -O3 -pthread
-CC2=$(CC) -I$(BOOST_LP)
-#CC=g++ -w -Wall -std=c++11 -g -DRFLAG
+
 SOURCE=./
 OBJECTS=main.o design.o Preadfile.o SeqPair.o ConstGraph.o Aplace.o
 
 all: design.o SeqPair.o ConstGraph.o Aplace.o Placer.o
 
 Placer.o :	Placer.h
-		$(CC2) -c Placer.cpp
+		$(CXX) $(CXXFLAGS) -I$(BOOST_LP) -c Placer.cpp
 
 Preadfile.o :
-		$(CC) -c Preadfile.cpp 
+		$(CXX) $(CXXFLAGS) -c Preadfile.cpp 
 
 design.o:
-		$(CC) -c design.cpp 
+		$(CXX) $(CXXFLAGS) -c design.cpp 
 
 SeqPair.o:
-		$(CC) -c SeqPair.cpp
+		$(CXX) $(CXXFLAGS) -c SeqPair.cpp
 
 ConstGraph.o:
-		$(CC2) -c ConstGraph.cpp
+		$(CXX) $(CXXFLAGS) -I$(BOOST_LP) -c ConstGraph.cpp
 
 Aplace.o:
-		$(CC2) -c Aplace.cpp
+		$(CXX) $(CXXFLAGS) -I$(BOOST_LP) -c Aplace.cpp
 
 clean:		
 		/bin/rm -f *.o 

--- a/PlaceRouteHierFlow/placer/Makefile
+++ b/PlaceRouteHierFlow/placer/Makefile
@@ -1,30 +1,19 @@
 
 # Needs CXX and CXXFLAGS to be defined
 
-BOOST_LP?=/usr/local
-
-SOURCE=./
-OBJECTS=main.o design.o Preadfile.o SeqPair.o ConstGraph.o Aplace.o
-
 all: design.o SeqPair.o ConstGraph.o Aplace.o Placer.o
 
-Placer.o :	Placer.h
-		$(CXX) $(CXXFLAGS) -I$(BOOST_LP) -c Placer.cpp
+Placer.o : Placer.cpp Placer.h
 
-Preadfile.o :
-		$(CXX) $(CXXFLAGS) -c Preadfile.cpp 
+Preadfile.o : Preadfile.cpp
 
-design.o:
-		$(CXX) $(CXXFLAGS) -c design.cpp 
+design.o: design.cpp
 
-SeqPair.o:
-		$(CXX) $(CXXFLAGS) -c SeqPair.cpp
+SeqPair.o: SeqPair.cpp
 
-ConstGraph.o:
-		$(CXX) $(CXXFLAGS) -I$(BOOST_LP) -c ConstGraph.cpp
+ConstGraph.o: ConstGraph.cpp
 
-Aplace.o:
-		$(CXX) $(CXXFLAGS) -I$(BOOST_LP) -c Aplace.cpp
+Aplace.o: Aplace.cpp
 
 clean:		
-		/bin/rm -f *.o 
+	/bin/rm -f *.o 

--- a/PlaceRouteHierFlow/router/FastSteinerUM/Makefile
+++ b/PlaceRouteHierFlow/router/FastSteinerUM/Makefile
@@ -1,15 +1,12 @@
+# Needs CXX, CXXFLAGS, and LDFLAGS
+
 .SUFFIXES:      .o .cxx
-
-
-CPPFLAGS	?= -Wall $(DBG_FLAGS) --coverage
-CC		= g++ $(CPPFLAGS)
-#CC	= g++ -pg
-#CC	= purify g++
 
 #DBG_FLAGS  = -DDEBUG
 #DBG_FLAGS  = -DDEBUG -g
 #DBG_FLAGS  = -DDEBUG -DDEBUG2
 #DBG_FLAGS  = -DDEBUG -DDEBUG2 -g
+
 LIBS	= -lm libsteiner.a
 
 SRCS0	= unixtimer.cxx err.cxx random.cxx\
@@ -20,13 +17,13 @@ OBJS0	= $(SRCS0:.cxx=.o)
 new:    steiner gen
 
 .cxx.o:
-	$(CC) $(INCLUDES) -c $*.cxx
+	$(CXX) $(CXXFLAGS) -c $*.cxx
 
 steiner: 	 main.o libsteiner.a
-	$(CC) -o $@ $?
+	$(CXX) -o $@ $? $(LDFLAGS)
 
 gen:	gen.o libsteiner.a
-	$(CC) -o $@ $?
+	$(CXX) -o $@ $? $(LDFLAGS)
 
 libsteiner.a:	${OBJS0}
 	ar  -r -o $@ $?
@@ -35,4 +32,3 @@ clean:
 	rm -f *.o *.a
 	rm -f gen steiner
 	rm -f core
-

--- a/PlaceRouteHierFlow/router/FastSteinerUM/Makefile
+++ b/PlaceRouteHierFlow/router/FastSteinerUM/Makefile
@@ -1,7 +1,7 @@
 .SUFFIXES:      .o .cxx
 
 
-CPPFLAGS	?= -Wall $(DBG_FLAGS)
+CPPFLAGS	?= -Wall $(DBG_FLAGS) --coverage
 CC		= g++ $(CPPFLAGS)
 #CC	= g++ -pg
 #CC	= purify g++

--- a/PlaceRouteHierFlow/router/FastSteinerUM/Makefile
+++ b/PlaceRouteHierFlow/router/FastSteinerUM/Makefile
@@ -1,32 +1,26 @@
 # Needs CXX, CXXFLAGS, and LDFLAGS
 
-.SUFFIXES:      .o .cxx
+%.o : %.cxx
+	$(CXX) $(CXXFLAGS) -c $<
 
 #DBG_FLAGS  = -DDEBUG
 #DBG_FLAGS  = -DDEBUG -g
 #DBG_FLAGS  = -DDEBUG -DDEBUG2
 #DBG_FLAGS  = -DDEBUG -DDEBUG2 -g
 
-LIBS	= -lm libsteiner.a
+SRCS0 = unixtimer.cxx err.cxx random.cxx neighbors.cxx heap.cxx mst2.cxx stnr1.cxx triples.cxx
+OBJS0 = $(SRCS0:.cxx=.o)
 
-SRCS0	= unixtimer.cxx err.cxx random.cxx\
-          neighbors.cxx heap.cxx mst2.cxx\
-          stnr1.cxx triples.cxx
-OBJS0	= $(SRCS0:.cxx=.o) 
+new: libsteiner.a steiner gen
 
-new:    steiner gen
+steiner: main.o libsteiner.a
+	$(CXX) -o $@ $^ $(LDFLAGS)
 
-.cxx.o:
-	$(CXX) $(CXXFLAGS) -c $*.cxx
+gen: gen.o libsteiner.a
+	$(CXX) -o $@ $^ $(LDFLAGS)
 
-steiner: 	 main.o libsteiner.a
-	$(CXX) -o $@ $? $(LDFLAGS)
-
-gen:	gen.o libsteiner.a
-	$(CXX) -o $@ $? $(LDFLAGS)
-
-libsteiner.a:	${OBJS0}
-	ar  -r -o $@ $?
+libsteiner.a: $(OBJS0)
+	ar  -r -o $@ $^
 
 clean:
 	rm -f *.o *.a

--- a/PlaceRouteHierFlow/router/Makefile
+++ b/PlaceRouteHierFlow/router/Makefile
@@ -10,37 +10,26 @@ all: RawRouter.o Grid.o GlobalGrid.o Graph.o GlobalGraph.o GlobalRouter.o GcellG
 	$(MAKE) -C FastSteinerUM
 
 RawRouter.o: RawRouter.cpp RawRouter.h $(SOURCE_CODE_PnRDB)/datatype.h Rdatatype.h 
-	$(CXX) $(CXXFLAGS) -c RawRouter.cpp
 
 Grid.o: Grid.cpp Grid.h $(SOURCE_CODE_PnRDB)/datatype.h Rdatatype.h
-	$(CXX) $(CXXFLAGS) -c Grid.cpp
 
 GlobalGrid.o: GlobalGrid.cpp GlobalGrid.h $(SOURCE_CODE_PnRDB)/datatype.h Rdatatype.h
-	$(CXX) $(CXXFLAGS) -c GlobalGrid.cpp
 
 Graph.o: Graph.cpp Graph.h $(SOURCE_CODE_PnRDB)/datatype.h Rdatatype.h Grid.h
-	$(CXX) $(CXXFLAGS) -c Graph.cpp
 
 GlobalGraph.o: GlobalGraph.cpp GlobalGraph.h $(SOURCE_CODE_PnRDB)/datatype.h Rdatatype.h GlobalGrid.h
-	$(CXX) $(CXXFLAGS) -c GlobalGraph.cpp
 
 GlobalRouter.o: GlobalRouter.cpp $(SOURCE_CODE_PnRDB)/datatype.h Rdatatype.h Grid.h Graph.h RawRouter.h GlobalRouter.h $(LIB_LP)/lp_lib.h $(SOURCE_LP)/lp_explicit.h
-	$(CXX) $(CXXFLAGS) -c GlobalRouter.cpp
 
 GcellGlobalRouter.o: GcellGlobalRouter.cpp $(SOURCE_CODE_PnRDB)/datatype.h Rdatatype.h GlobalGrid.h GlobalGraph.h RawRouter.h GcellGlobalRouter.h $(LIB_LP)/lp_lib.h $(SOURCE_LP)/lp_explicit.h
-	$(CXX) $(CXXFLAGS) -c GcellGlobalRouter.cpp
 
 DetailRouter.o: DetailRouter.cpp $(SOURCE_CODE_PnRDB)/datatype.h Rdatatype.h Grid.h Graph.h RawRouter.h GlobalRouter.h GcellGlobalRouter.h DetailRouter.h
-	$(CXX) $(CXXFLAGS) -c DetailRouter.cpp
 
 GcellDetailRouter.o: GcellDetailRouter.cpp $(SOURCE_CODE_PnRDB)/datatype.h Rdatatype.h Grid.h Graph.h RawRouter.h GlobalRouter.h GcellGlobalRouter.h GcellDetailRouter.h GlobalGrid.h GlobalGraph.h 
-	$(CXX) $(CXXFLAGS) -c GcellDetailRouter.cpp
 
 PowerRouter.o: PowerRouter.cpp $(SOURCE_CODE_PnRDB)/datatype.h Rdatatype.h Grid.h Graph.h RawRouter.h DetailRouter.h PowerRouter.h
-	$(CXX) $(CXXFLAGS) -c PowerRouter.cpp
 
 Router.o: Router.cpp $(SOURCE_CODE_PnRDB)/datatype.h Rdatatype.h GlobalRouter.h DetailRouter.h PowerRouter.h GcellGlobalRouter.h
-	$(CXX) $(CXXFLAGS) -c Router.cpp
 
 
 #########

--- a/PlaceRouteHierFlow/router/Makefile
+++ b/PlaceRouteHierFlow/router/Makefile
@@ -1,79 +1,46 @@
-#lp_solve
-LDFLAGS="-Wl,--no-as-needed"
-# To compile locally, override LP_DIR as follows:  %> LP_DIR=<path_to_lpsolve> make
+# Needs CXX and CXXFLAGS
+
 LP_DIR?=/usr/local/lib/lpsolve
 LIB_LP = $(LP_DIR)/lp_solve_5.5.2.5_dev_ux64
 SOURCE_LP= $(LP_DIR)/lp_solve_5.5
 
-CC     = g++ -w -Wall -std=c++14 -g -O3 -lm -ldl -m64 -I$(SOURCE_LP)
-
-#GDSWriter
-###SOURCE_GDSW = ./GDSWriter
-
-#OBJS0	= main.o unixtimer.o err.o random.o neighbors.o heap.o mst2.o stnr1.o triples.o 
-#MAIN0	= steiner
-
-#Source code
-SOURCE_CODE = .
-
 SOURCE_CODE_PnRDB = ../PnRDB
 
-#OBJECTS  = main.o GdsWriter.o readfile.o grid.o GdsReader.o GdsDriver.o
-
-###all: router.o grid.o GdsWriter.o GdsReader.o GdsDriver.o .cxx.o steiner
-###
-###router.o: $(SOURCE_CODE)/router.h $(SOURCE_CODE)/grid.h
-###	$(CC) -c $(SOURCE_CODE)/router.cpp
-###
-###grid.o:  $(SOURCE_CODE)/grid.h $(SOURCE_CODE_PnRDB)/datatype.h $(SOURCE_CODE_PnRDB)/readfile.h $(SOURCE_GDSW)/GdsWriter.h $(SOURCE_GDSW)/GdsReader.h  $(SOURCE_GDSW)/GdsRecords.h $(LIB_LP)/lp_lib.h $(SOURCE_LP)/lp_explicit.h 
-###	$(CC) -c $(SOURCE_CODE)/grid.cpp 
-###
-###GdsReader.o:  $(SOURCE_GDSW)/GdsReader.h $(SOURCE_GDSW)/String.h $(SOURCE_GDSW)/GdsRecords.h $(SOURCE_CODE)/grid.h
-###	$(CC) -c $(SOURCE_GDSW)/GdsReader.cpp
-###
-###GdsDriver.o:  $(SOURCE_GDSW)/GdsDriver.h $(SOURCE_GDSW)/GdsReader.h $(SOURCE_GDSW)/String.h $(SOURCE_GDSW)/GdsRecords.h
-###	$(CC) -c $(SOURCE_GDSW)/GdsDriver.cpp
-###
-###GdsWriter.o:  $(SOURCE_GDSW)/GdsWriter.h $(SOURCE_GDSW)/String.h
-###	$(CC) -c $(SOURCE_GDSW)/GdsWriter.cpp
-### 
-
-#########2333333
 all: RawRouter.o Grid.o GlobalGrid.o Graph.o GlobalGraph.o GlobalRouter.o GcellGlobalRouter.o DetailRouter.o GcellDetailRouter.o PowerRouter.o Router.o
 	$(MAKE) -C FastSteinerUM
 
-RawRouter.o: $(SOURCE_CODE)/RawRouter.h $(SOURCE_CODE_PnRDB)/datatype.h $(SOURCE_CODE)/Rdatatype.h 
-	$(CC) -c $(SOURCE_CODE)/RawRouter.cpp
+RawRouter.o: RawRouter.cpp RawRouter.h $(SOURCE_CODE_PnRDB)/datatype.h Rdatatype.h 
+	$(CXX) $(CXXFLAGS) -c RawRouter.cpp
 
-Grid.o: $(SOURCE_CODE)/Grid.h $(SOURCE_CODE_PnRDB)/datatype.h $(SOURCE_CODE)/Rdatatype.h
-	$(CC) -c $(SOURCE_CODE)/Grid.cpp
+Grid.o: Grid.cpp Grid.h $(SOURCE_CODE_PnRDB)/datatype.h Rdatatype.h
+	$(CXX) $(CXXFLAGS) -c Grid.cpp
 
-GlobalGrid.o: $(SOURCE_CODE)/GlobalGrid.h $(SOURCE_CODE_PnRDB)/datatype.h $(SOURCE_CODE)/Rdatatype.h
-	$(CC) -c $(SOURCE_CODE)/GlobalGrid.cpp
+GlobalGrid.o: GlobalGrid.cpp GlobalGrid.h $(SOURCE_CODE_PnRDB)/datatype.h Rdatatype.h
+	$(CXX) $(CXXFLAGS) -c GlobalGrid.cpp
 
-Graph.o: $(SOURCE_CODE)/Graph.h $(SOURCE_CODE_PnRDB)/datatype.h $(SOURCE_CODE)/Rdatatype.h $(SOURCE_CODE)/Grid.h
-	$(CC) -c $(SOURCE_CODE)/Graph.cpp
+Graph.o: Graph.cpp Graph.h $(SOURCE_CODE_PnRDB)/datatype.h Rdatatype.h Grid.h
+	$(CXX) $(CXXFLAGS) -c Graph.cpp
 
-GlobalGraph.o: $(SOURCE_CODE)/GlobalGraph.h $(SOURCE_CODE_PnRDB)/datatype.h $(SOURCE_CODE)/Rdatatype.h $(SOURCE_CODE)/GlobalGrid.h
-	$(CC) -c $(SOURCE_CODE)/GlobalGraph.cpp
+GlobalGraph.o: GlobalGraph.cpp GlobalGraph.h $(SOURCE_CODE_PnRDB)/datatype.h Rdatatype.h GlobalGrid.h
+	$(CXX) $(CXXFLAGS) -c GlobalGraph.cpp
 
-GlobalRouter.o: $(SOURCE_CODE_PnRDB)/datatype.h $(SOURCE_CODE)/Rdatatype.h $(SOURCE_CODE)/Grid.h $(SOURCE_CODE)/Graph.h $(SOURCE_CODE)/RawRouter.h $(SOURCE_CODE)/GlobalRouter.h $(LIB_LP)/lp_lib.h $(SOURCE_LP)/lp_explicit.h
-	$(CC) -c $(SOURCE_CODE)/GlobalRouter.cpp
+GlobalRouter.o: GlobalRouter.cpp $(SOURCE_CODE_PnRDB)/datatype.h Rdatatype.h Grid.h Graph.h RawRouter.h GlobalRouter.h $(LIB_LP)/lp_lib.h $(SOURCE_LP)/lp_explicit.h
+	$(CXX) $(CXXFLAGS) -c GlobalRouter.cpp
 
-GcellGlobalRouter.o: $(SOURCE_CODE_PnRDB)/datatype.h $(SOURCE_CODE)/Rdatatype.h $(SOURCE_CODE)/GlobalGrid.h $(SOURCE_CODE)/GlobalGraph.h $(SOURCE_CODE)/RawRouter.h $(SOURCE_CODE)/GcellGlobalRouter.h $(LIB_LP)/lp_lib.h $(SOURCE_LP)/lp_explicit.h
-	$(CC) -c $(SOURCE_CODE)/GcellGlobalRouter.cpp
+GcellGlobalRouter.o: GcellGlobalRouter.cpp $(SOURCE_CODE_PnRDB)/datatype.h Rdatatype.h GlobalGrid.h GlobalGraph.h RawRouter.h GcellGlobalRouter.h $(LIB_LP)/lp_lib.h $(SOURCE_LP)/lp_explicit.h
+	$(CXX) $(CXXFLAGS) -c GcellGlobalRouter.cpp
 
-DetailRouter.o: $(SOURCE_CODE_PnRDB)/datatype.h $(SOURCE_CODE)/Rdatatype.h $(SOURCE_CODE)/Grid.h $(SOURCE_CODE)/Graph.h $(SOURCE_CODE)/RawRouter.h $(SOURCE_CODE)/GlobalRouter.h $(SOURCE_CODE)/GcellGlobalRouter.h $(SOURCE_CODE)/DetailRouter.h
-	$(CC) -c $(SOURCE_CODE)/DetailRouter.cpp
+DetailRouter.o: DetailRouter.cpp $(SOURCE_CODE_PnRDB)/datatype.h Rdatatype.h Grid.h Graph.h RawRouter.h GlobalRouter.h GcellGlobalRouter.h DetailRouter.h
+	$(CXX) $(CXXFLAGS) -c DetailRouter.cpp
 
-GcellDetailRouter.o: $(SOURCE_CODE_PnRDB)/datatype.h $(SOURCE_CODE)/Rdatatype.h $(SOURCE_CODE)/Grid.h $(SOURCE_CODE)/Graph.h $(SOURCE_CODE)/RawRouter.h $(SOURCE_CODE)/GlobalRouter.h $(SOURCE_CODE)/GcellGlobalRouter.h $(SOURCE_CODE)/GcellDetailRouter.h $(SOURCE_CODE)/GlobalGrid.h $(SOURCE_CODE)/GlobalGraph.h 
-	$(CC) -c $(SOURCE_CODE)/GcellDetailRouter.cpp
+GcellDetailRouter.o: GcellDetailRouter.cpp $(SOURCE_CODE_PnRDB)/datatype.h Rdatatype.h Grid.h Graph.h RawRouter.h GlobalRouter.h GcellGlobalRouter.h GcellDetailRouter.h GlobalGrid.h GlobalGraph.h 
+	$(CXX) $(CXXFLAGS) -c GcellDetailRouter.cpp
 
-PowerRouter.o: $(SOURCE_CODE_PnRDB)/datatype.h $(SOURCE_CODE)/Rdatatype.h $(SOURCE_CODE)/Grid.h $(SOURCE_CODE)/Graph.h $(SOURCE_CODE)/RawRouter.h $(SOURCE_CODE)/DetailRouter.h $(SOURCE_CODE)/PowerRouter.h
-	$(CC) -c $(SOURCE_CODE)/PowerRouter.cpp 
+PowerRouter.o: PowerRouter.cpp $(SOURCE_CODE_PnRDB)/datatype.h Rdatatype.h Grid.h Graph.h RawRouter.h DetailRouter.h PowerRouter.h
+	$(CXX) $(CXXFLAGS) -c PowerRouter.cpp
 
-Router.o: $(SOURCE_CODE_PnRDB)/datatype.h $(SOURCE_CODE)/Rdatatype.h $(SOURCE_CODE)/GlobalRouter.h $(SOURCE_CODE)/DetailRouter.h $(SOURCE_CODE)/PowerRouter.h $(SOURCE_CODE)/GcellGlobalRouter.h
-	$(CC) -c $(SOURCE_CODE)/Router.cpp
+Router.o: Router.cpp $(SOURCE_CODE_PnRDB)/datatype.h Rdatatype.h GlobalRouter.h DetailRouter.h PowerRouter.h GcellGlobalRouter.h
+	$(CXX) $(CXXFLAGS) -c Router.cpp
 
 
 #########


### PR DESCRIPTION
@Lastdayends @desmonddak 
Here is an attempt to clean up the hierarchical Makefile so that we can change compile options easily.

For example:

To add coverage:
```
make COVERAGE=--coverage
```

To change optimzation:
```
make OPTS='-g -O2'
```

To change warnings:
```
make WARNS='-Wall'
```
Also fixed up the dependencies in the router.