### PR TITLE
Replace usages of g.node[] with g.nodes[]

### DIFF
--- a/sub_circuit_identification/src/match_graph.py
+++ b/sub_circuit_identification/src/match_graph.py
@@ -248,8 +248,8 @@ def preprocess_stack(G):
                 if edge_wt == 4 and len(list(G.neighbors(net))) == 2:
                     for next_node in G.neighbors(net):
                         logging.info(" checking nodes: %s , %s",node,next_node)
-                        if not next_node == node and G.node[next_node][
-                                "inst_type"] == G.node[node][
+                        if not next_node == node and G.nodes[next_node][
+                                "inst_type"] == G.nodes[node][
                                     "inst_type"] and G.get_edge_data(
                                         next_node, net)['weight'] == 1:
                             common_nets = set(G.neighbors(node)) & set(
@@ -267,13 +267,13 @@ def preprocess_stack(G):
                                         ['weight'] >= 2:
 
                                     lequivalent = 0
-                                    for param, value in G.node[next_node][
+                                    for param, value in G.nodes[next_node][
                                             "values"].items():
                                         if param == 'l':
                                             #print("param1",node,param,value)
                                             lequivalent = float(
                                                 convert_unit(value))
-                                    for param, value in G.node[node][
+                                    for param, value in G.nodes[node][
                                             "values"].items():
                                         if param == 'l':
                                             lequivalent += float(
@@ -291,7 +291,7 @@ def preprocess_stack(G):
         G.add_edge(node, attr[0], weight=attr[1])
 
     for node, attr in modified_nodes.items():
-        G.node[node]["values"]['l'] = attr
+        G.nodes[node]["values"]['l'] = attr
 
     for node in remove_nodes:
         G.remove_node(node)

--- a/sub_circuit_identification/src/read_netlist.py
+++ b/sub_circuit_identification/src/read_netlist.py
@@ -506,7 +506,7 @@ class SpiceParser:
         logging.info(
             "Created bipartitie graph with Total no of Nodes: %i edges: %i",
             len(circuit_graph), circuit_graph.number_of_edges())
-        #print(circuit_graph.node['xM03|MN0']["ports"])
+        #print(circuit_graph.nodes['xM03|MN0']["ports"])
         return circuit_graph
 
 
@@ -576,7 +576,7 @@ if __name__ == '__main__':
                 sp = SpiceParser(NETLIST_DIR + '/' + netlist)
 
             final_circuit_graph = sp.sp_parser()
-            #print(final_circuit_graph.node['xM03|MN0']["ports"])
+            #print(final_circuit_graph.nodes['xM03|MN0']["ports"])
             if final_circuit_graph:
                 ckt_name = netlist.split('.')[0]
                 logging.info("Saving graph: %s", ckt_name)

--- a/sub_circuit_identification/src/util.py
+++ b/sub_circuit_identification/src/util.py
@@ -28,7 +28,7 @@ def plt_graph(subgraph,sub_block_name):
     copy_graph=subgraph
     for node,attr in list(copy_graph.nodes(data=True)):
         #print(node)
-        #print(copy_graph.node[node])
+        #print(copy_graph.nodes[node])
         if 'source' in attr["inst_type"]:
             #print("deleting source node",node)
             #   copy_graph.nodes(node)['inst_type']:


### PR DESCRIPTION
Errors in CI due to networkx deprecating g.node[] in favor of g.nodes[]