### PR TITLE
correct unit cap (cap 12) pin content

### DIFF
--- a/PDK_Abstraction/FinFET14nm_Mock_PDK/fabric_Cap.py
+++ b/PDK_Abstraction/FinFET14nm_Mock_PDK/fabric_Cap.py
@@ -106,7 +106,8 @@ class UnitCell(CanvasCap):
             self.addVia( self.v2_nx, net, None, grid_x, grid_y)
 
         pin = 'PLUS'
-        self.addWire( self.m1, 'PLUS', pin, self.last_x1_track, (grid_y0, -1), (grid_y1, 1))
+        # Don't port m1 per Yaguang instructions
+        self.addWire( self.m1, 'PLUS', None, self.last_x1_track, (grid_y0, -1), (grid_y1, 1))
         # don't port m3 (or port one or the other)
         self.addWire( self.m3, 'PLUS', None, self.last_x1_track, (grid_y0, -1), (grid_y1, 1))
 

--- a/PlaceRouteHierFlow/cap_placer/capplacer.cpp
+++ b/PlaceRouteHierFlow/cap_placer/capplacer.cpp
@@ -366,7 +366,7 @@ void Placer_Router_Cap::Placer_Router_Cap_function(vector<int> & ki, vector<pair
   cout<<"step6b"<<endl;
   WriteViewerJSON (fpath ,unit_capacitor, final_gds, drc_info, opath);
   cout<<"step7"<<endl;
-  //PrintPlacer_Router_Cap(outfile);
+  PrintPlacer_Router_Cap(outfile);
   cout<<"step8"<<endl;
 
 
@@ -563,6 +563,53 @@ Placer_Router_Cap::ExtractData (const string& fpath, const string& unit_capacito
     CheckOutBlock.orient = PnRDB::Omark(0); //need modify
     cout<<"Extract Data Step 5"<<endl;
 
+    std::set<std::string> internal_metal_layer;
+    std::vector<std::string> internal_metal;    
+
+    for(unsigned int i=0;i<uc.interMetals.size();i++){
+
+       internal_metal_layer.insert(uc.interMetals[i].metal);
+
+    }
+
+   for(auto it = internal_metal_layer.begin();it!=internal_metal_layer.end();it++){
+
+      internal_metal.push_back(*it);
+   
+   }
+
+   for(unsigned int i=0;i < Caps.size(); i++){
+
+      int temp_x = Caps[i].x - unit_cap_demension.first/2+offset_x;
+      int temp_y = Caps[i].y - unit_cap_demension.second/2+offset_y;
+
+      x[0] = temp_x;
+      x[1] = temp_x;
+      x[2] = temp_x + unit_cap_demension.first;
+      x[3] = temp_x + unit_cap_demension.first;
+      x[4] = x[0];
+
+      y[0] = temp_y;
+      y[1] = temp_y + unit_cap_demension.second;
+      y[2] = temp_y + unit_cap_demension.second;
+      y[3] = temp_y;
+      y[4] = y[0];
+	
+      minmax.update( x, y);
+
+      for(unsigned int j=0;j<internal_metal.size();j++){
+         PnRDB::contact temp_contact;
+         temp_contact.metal = internal_metal[j];
+         //std::cout<<"Cap internal metal layer "<<temp_contact.metal<<std::endl;
+         fillContact (temp_contact, x, y);
+         CheckOutBlock.interMetals.push_back(temp_contact);
+      }
+
+   }
+
+
+
+/*
     for (unsigned int i = 0; i < Caps.size(); i++) {
 
         int temp_x = Caps[i].x - unit_cap_demension.first/2+offset_x;
@@ -586,13 +633,14 @@ Placer_Router_Cap::ExtractData (const string& fpath, const string& unit_capacito
 
             PnRDB::contact temp_contact;
             temp_contact.metal = uc.interMetals[j].metal;
+            std::cout<<"Cap internal metal layer "<<temp_contact.metal<<std::endl;
 	    fillContact (temp_contact, x, y);
             CheckOutBlock.interMetals.push_back(temp_contact);
 
         }
         
     }
-
+*/
     cout<<"Extract Data Step 7"<<endl;
 
 
@@ -1169,6 +1217,8 @@ void Placer_Router_Cap::addVia(net &temp_net, pair<double,double> &coord, const 
 
   pair<double,double> via_coord;
 
+  std::cout<<"adding via in cap at metal "<< HV_via_metal <<" "<<HV_via_metal_index<<std::endl;
+
   const auto& vm = drc_info.Via_model.at(HV_via_metal_index);
 
   temp_net.via.push_back(coord);                      
@@ -1308,6 +1358,7 @@ void Placer_Router_Cap::GetPhysicalInfo_merged_net(
 		  coord.first = Caps[n.cap_index[k]].x + sign*(unit_cap_demension.first/2-shifting_x);
 		  coord.second = Caps[n.cap_index[k]].y - sign*(unit_cap_demension.second/2-shifting_y);
 		  addVia(n,coord,drc_info,HV_via_metal,HV_via_metal_index,0);
+                  std::cout<<"Cap print "<<"sign "<<sign<<" ("<<coord.first<<" "<<coord.second<<") "<<std::endl;
 
 		  if( lr == 1) {
                       n.start_conection_coord.push_back(coord);

--- a/PlaceRouteHierFlow/testcase_example/switched_capacitor_filter.lef
+++ b/PlaceRouteHierFlow/testcase_example/switched_capacitor_filter.lef
@@ -1024,8 +1024,6 @@ MACRO cap_12f
     DIRECTION INOUT ;
     USE SIGNAL ;
     PORT
-      LAYER M1 ;
-        RECT 2.3840 -0.0360 2.4160 2.4720 ;
       LAYER M2 ;
         RECT -0.0360 -0.0160 2.4360 0.0160 ;
     END


### PR DESCRIPTION
@stevenmburns 

Although visually there is no via bug in the switched capacitor combination, I did find the bug exists. 

The reason is due to the error in the lef file.
After the M1 port in cap_12 is removed, the via bug should be fixed. (There is an assumption, only M2 pins are provided for unit cap.)

By the way, the location of the via generated by the layout visualization tool is not correct.

Yaguang