### PR TITLE
Demo subgraph isomorphism based find_repeated_subckts

### DIFF
--- a/Circuit/circuit/core.py
+++ b/Circuit/circuit/core.py
@@ -159,17 +159,15 @@ class Circuit(networkx.Graph):
                 pinmap = {y: f'pin{x}' for x, y in enumerate(
                     (net for net in ckt.nets \
                         if not all(neighbor in ckt.nodes for neighbor in self.neighbors(net))))}
-                subckt = SubCircuit(f'XREP{index}',
-                    *list(pinmap.values()))
+                subckt, index = SubCircuit(f'XREP{index}', *list(pinmap.values())), index + 1
                 for element in ckt.elements:
                     subckt.add_element(element.__class__(element.name,
                         *[pinmap[x] if x in pinmap else x for x in element.pins.values()]))
-                index = index + 1
                 subckts.append(subckt)
                 matches = self.find_subgraph_matches(subckt.circuit)
+                worklist = [element for element in worklist if not any(element.name in match for match in matches)]
                 if replace:
                     self._replace_matches_with_subckt(matches, subckt)
-                worklist = [elem for match in matches for elem in match.values() if self._is_element(elem)]
         return subckts
 
     def replace_matching_subckts(self, subckts, node_match=None, edge_match=None):

--- a/Circuit/circuit/core.py
+++ b/Circuit/circuit/core.py
@@ -114,8 +114,8 @@ class Circuit(networkx.Graph):
         return element
 
     def remove_element(self, element):
-        self.remove_nodes_from([x for x in self.neighbors(element) if self.degree(x) == 1])
-        self.remove_node(element)
+        self.remove_nodes_from([x for x in self.neighbors(element.name) if self.degree(x) == 1])
+        self.remove_node(element.name)
 
     @staticmethod
     def default_node_match(x, y):
@@ -147,14 +147,14 @@ class Circuit(networkx.Graph):
         worklist = list(self.elements)
         while len(worklist) > 0:
             ckt = Circuit()
-            element = worklist.pop(0)
-            ckt.add_element(element)
-            for net in self.neighbors(element.name):
-                for elem in self.neighbors(net):
-                    if elem in ckt.nodes: continue
-                    ckt.add_element(self.element(elem))
-                    if len(self.find_subgraph_matches(ckt)) <= 1:
-                        ckt.remove_element(elem)
+            root = worklist.pop(0)
+            ckt.add_element(root)
+            # TODO: Try to minimize # nets added instead of blindly matching elements
+            for element in worklist:
+                if all(x not in ckt for x in self.neighbors(element.name)): continue
+                ckt.add_element(element)
+                if len(self.find_subgraph_matches(ckt)) <= 1:
+                    ckt.remove_element(element)
             if len(ckt.elements) > 1:
                 pinmap = {y: f'pin{x}' for x, y in enumerate(
                     (net for net in ckt.nets \

--- a/Circuit/circuit/core.py
+++ b/Circuit/circuit/core.py
@@ -113,6 +113,10 @@ class Circuit(networkx.Graph):
                 self.nodes[element.name]['instance'] = element
         return element
 
+    def remove_element(self, element):
+        self.remove_nodes_from([x for x in self.neighbors(element) if self.degree(x) == 1])
+        self.remove_node(element)
+
     @staticmethod
     def default_node_match(x, y):
         return issubclass(type(x.get('instance')), type(y.get('instance')))
@@ -146,15 +150,11 @@ class Circuit(networkx.Graph):
             element = worklist.pop(0)
             ckt.add_element(element)
             for net in self.neighbors(element.name):
-                ckt.add_edge(element.name, net)
                 for elem in self.neighbors(net):
                     if elem in ckt.nodes: continue
                     ckt.add_element(self.element(elem))
                     if len(self.find_subgraph_matches(ckt)) <= 1:
-                        ckt.remove_nodes_from([x for x in ckt.neighbors(elem) if ckt.degree(x) == 1])
-                        ckt.remove_node(elem)
-                if ckt.degree(net) == 1 and net not in element.pins.values():
-                    ckt.remove_node(net)
+                        ckt.remove_element(elem)
             if len(ckt.elements) > 1:
                 pinmap = {y: f'pin{x}' for x, y in enumerate(
                     (net for net in ckt.nets \

--- a/Circuit/circuit/core.py
+++ b/Circuit/circuit/core.py
@@ -121,7 +121,7 @@ class Circuit(networkx.Graph):
     def default_edge_match(x, y):
         return x.get('pin') == y.get('pin')
 
-    def find_matching_subgraphs(self, graph, node_match=None, edge_match=None):
+    def find_subgraph_matches(self, graph, node_match=None, edge_match=None):
         if node_match is None:
             node_match = self.default_node_match
         if edge_match is None:
@@ -131,7 +131,7 @@ class Circuit(networkx.Graph):
         return list(matcher.subgraph_isomorphisms_iter())
 
     def find_repeated_subgraphs(self):
-        matches = []
+        graphs = []
         worklist = list(self.elements)
         while len(worklist) > 0:
             ckt = Circuit()
@@ -140,19 +140,19 @@ class Circuit(networkx.Graph):
             for net in self.neighbors(element.name):
                 for elem in self.neighbors(net):
                     ckt.add_element(self.nodes[elem]['instance'])
-                    if len(self.find_matching_subgraphs(ckt)) == 1:
+                    if len(self.find_subgraph_matches(ckt)) == 1:
                         ckt.remove_nodes_from([x for x in ckt.neighbors(elem) if ckt.degree(x) == 1])
                         ckt.remove_node(elem)
             if len(ckt.elements) > 1:
-                matches.append(ckt)
-                worklist = [elem for match in self.find_matching_subgraphs(ckt) for elem in match.values() if self._is_element(elem)]
-        return matches
+                graphs.append(ckt)
+                worklist = [elem for match in self.find_subgraph_matches(ckt) for elem in match.values() if self._is_element(elem)]
+        return graphs
 
     def replace_matching_subckts(self, subckts, node_match=None, edge_match=None):
         if not isinstance(subckts, Iterable):
             subckts = [subckts]
         for subckt in subckts:
-            matches = self.find_matching_subgraphs(subckt.circuit, node_match, edge_match)
+            matches = self.find_subgraph_matches(subckt.circuit, node_match, edge_match)
             self._replace_matches_with_subckt(matches, subckt)
 
     def _replace_matches_with_subckt(self, matches, subckt):

--- a/Circuit/circuit/core.py
+++ b/Circuit/circuit/core.py
@@ -210,7 +210,7 @@ class Circuit(networkx.Graph):
         # Pick circuit elements that have some net-name based overlap with ckt subgraph
         matchlist = [element for element in worklist if element.name not in ckt and any(x in ckt for x in self.neighbors(element.name))]
         # Sort circuit elements to minimize the number of (net) nodes added to ckt subgraph
-        matchlist.sort(key=lambda element: len([x not in ckt for x in self.neighbors(element.name)]))
+        matchlist.sort(key=lambda element: sum([x not in ckt for x in self.neighbors(element.name)]))
         return matchlist
 
     # Algorithms to flatten netlist

--- a/Circuit/circuit/core.py
+++ b/Circuit/circuit/core.py
@@ -134,6 +134,9 @@ class Circuit(networkx.Graph):
                 ret.append(match)
         return ret
 
+    def replace_repeated_subckts(self):
+        return self.find_repeated_subckts(True)
+
     def find_repeated_subckts(self, replace=False):
         index = 0
         subckts = []

--- a/Circuit/tests/ota.sp
+++ b/Circuit/tests/ota.sp
@@ -3,15 +3,21 @@
 
 .subckt ota vbiasn vbiasp1 vbiasp2 vinn vinp voutn voutp
 .param no_of_fin = 10
+
 m4 id id 0 0 nmos_rvt w=270e-9 l=20e-9 nfin={no_of_fin}
 m3 net10 id 0 0 nmos_rvt w=270e-9 l=20e-9 nfin=50
+
 m10 voutn vbiasn net8 0 nmos_rvt w=270e-9 l=20e-9 nfin=25
 m2 voutp vbiasn net014 0 nmos_rvt w=270e-9 l=20e-9 nfin=25
+
 m6 voutp vbiasp net012 net012 pmos_rvt w=270e-9 l=20e-9 nfin=15
 m7 voutn vbiasp net06 net06 pmos_rvt w=270e-9 l=20e-9 nfin=15
+
 m8 net012 vbiasp1 vdd! vdd! pmos_rvt w=270e-9 l=20e-9 nfin={no_of_fin}
 m9 net06 vbiasp1 vdd! vdd! pmos_rvt w=270e-9 l=20e-9 nfin={no_of_fin}
+
 m0 net014 vinn net10 0 nmos_rvt w=270e-9 l=20e-9 nfin=75
 m1 net8 vinp net10 0 nmos_rvt w=270e-9 l=20e-9 nfin=75
+
 .ends ota
 ** End of subcircuit definition.

--- a/Circuit/tests/ota.sp
+++ b/Circuit/tests/ota.sp
@@ -1,6 +1,16 @@
 .model nmos_rvt nmos
 .model pmos_rvt pmos
 
+*        m8|P   P|m9
+*           |   |
+*        m6|P   P|m7
+*           |   |
+*        m2|N   N|m10
+*           |   |
+*        m0|N   N|m1
+*   |         |
+* m4|N       N|m3
+
 .subckt ota vbiasn vbiasp1 vbiasp2 vinn vinp voutn voutp
 .param no_of_fin = 10
 

--- a/Circuit/tests/test_combined.py
+++ b/Circuit/tests/test_combined.py
@@ -61,4 +61,4 @@ def test_subckt_matching():
     assert len(subckts) == 1
     assert len(subckts[0].elements) == 4
     elements = {x.name for x in subckts[0].elements}
-    assert elements == {'M10', 'M7', 'M9', 'M0'} or elements == {'M2', 'M6', 'M8', 'M1'}
+    assert elements == {'M10', 'M7', 'M9', 'M1'} or elements == {'M2', 'M6', 'M8', 'M0'}

--- a/Circuit/tests/test_combined.py
+++ b/Circuit/tests/test_combined.py
@@ -57,6 +57,6 @@ def test_subckt_matching():
     # Extract ckt
     ckt = parser.library['OTA'].circuit
     ckt.flatten()
-    subgraphs = ckt.find_repeated_subgraphs()
-    assert len(subgraphs) == 1
-    assert len(subgraphs[0].elements) == 4
+    subckts = ckt.find_repeated_subckts(replace=True)
+    assert len(subckts) == 1
+    assert len(subckts[0].elements) == 3

--- a/Circuit/tests/test_combined.py
+++ b/Circuit/tests/test_combined.py
@@ -57,6 +57,6 @@ def test_subckt_matching():
     # Extract ckt
     ckt = parser.library['OTA'].circuit
     ckt.flatten()
-    subckts = ckt.find_repeated_subckts(replace=True)
+    subckts = ckt.replace_repeated_subckts()
     assert len(subckts) == 1
     assert len(subckts[0].elements) == 3

--- a/Circuit/tests/test_combined.py
+++ b/Circuit/tests/test_combined.py
@@ -18,7 +18,7 @@ def test_combined():
     assert ckt.elements == [X1, X2]
     assert ckt.nets == ['net10', 'net12', 'net14']
 
-def test_subckt_matching():
+def test_replace_matching_subckts():
     # parse subckts
     parser = circuit.SpiceParser()
     with open('tests/basic_template.sp') as fp:
@@ -49,7 +49,7 @@ def test_subckt_matching():
     #         uc.writeJSON(fp)
     # Generate placer, router input
 
-def test_subckt_matching():
+def test_replace_repeated_subckts():
     # parse netlist
     parser = circuit.SpiceParser()
     with open('tests/ota.sp') as fp:

--- a/Circuit/tests/test_combined.py
+++ b/Circuit/tests/test_combined.py
@@ -57,5 +57,6 @@ def test_subckt_matching():
     # Extract ckt
     ckt = parser.library['OTA'].circuit
     ckt.flatten()
-    print([x.name for x in ckt.find_repeated_subgraphs()[0].elements])
-    assert False
+    subgraphs = ckt.find_repeated_subgraphs()
+    assert len(subgraphs) == 1
+    assert len(subgraphs[0].elements) == 4

--- a/Circuit/tests/test_combined.py
+++ b/Circuit/tests/test_combined.py
@@ -59,4 +59,6 @@ def test_subckt_matching():
     ckt.flatten()
     subckts = ckt.replace_repeated_subckts()
     assert len(subckts) == 1
-    assert len(subckts[0].elements) == 3
+    assert len(subckts[0].elements) == 4
+    print([x.name for x in subckts[0].elements])
+    print([x.name for x in ckt.elements])

--- a/Circuit/tests/test_combined.py
+++ b/Circuit/tests/test_combined.py
@@ -60,5 +60,5 @@ def test_subckt_matching():
     subckts = ckt.replace_repeated_subckts()
     assert len(subckts) == 1
     assert len(subckts[0].elements) == 4
-    print([x.name for x in subckts[0].elements])
-    print([x.name for x in ckt.elements])
+    elements = {x.name for x in subckts[0].elements}
+    assert elements == {'M10', 'M7', 'M9', 'M0'} or elements == {'M2', 'M6', 'M8', 'M1'}

--- a/Circuit/tests/test_core.py
+++ b/Circuit/tests/test_core.py
@@ -156,11 +156,11 @@ def test_find_subgraph_matches(simple_netlist, matching_subckt, ThreeTerminalDev
     subckt2.add_element(ThreeTerminalDevice('X1', 'pin1', 'pin3', 'pin4'))
     subckt2.add_element(ThreeTerminalDevice('X2', 'pin2', 'pin3', 'pin5'))
     assert len(ckt.find_subgraph_matches(subckt2.circuit)) == 0
-    # Validate overtly aggressive match. 3 of 4 matches are probably useless from a circuit standpoint
+    # Validate filtering of redundant subgraphs (There are 4 matches. Only 1 should be returned)
     subckt3 = SubCircuit('test_subckt3', 'pin1', 'pin2', 'pin3', 'pin4')
     subckt3.add_element(TwoTerminalDevice('X1', 'pin1', 'pin2'))
     subckt3.add_element(TwoTerminalDevice('X2', 'pin3', 'pin4'))
-    assert len(ckt.find_subgraph_matches(subckt3.circuit)) == 4
+    assert len(ckt.find_subgraph_matches(subckt3.circuit)) == 1
 
 def test_replace_matching_subgraphs(simple_netlist, matching_subckt):
     ckt, subckt = simple_netlist, matching_subckt

--- a/Circuit/tests/test_core.py
+++ b/Circuit/tests/test_core.py
@@ -149,23 +149,23 @@ def matching_subckt(ThreeTerminalDevice):
 def test_find_matching_subgraphs(simple_netlist, matching_subckt, ThreeTerminalDevice, TwoTerminalDevice):
     ckt, subckt = simple_netlist, matching_subckt
     # Validate true match
-    assert len(ckt.find_matching_subgraphs(subckt)) == 1
-    assert ckt.find_matching_subgraphs(subckt)[0] == {'X3': 'X1', 'net3': 'pin3', 'net1': 'pin1', 'X4': 'X2', 'net2': 'pin2'}
+    assert len(ckt.find_matching_subgraphs(subckt.circuit)) == 1
+    assert ckt.find_matching_subgraphs(subckt.circuit)[0] == {'X3': 'X1', 'net3': 'pin3', 'net1': 'pin1', 'X4': 'X2', 'net2': 'pin2'}
     # Validate false match
     subckt2 = SubCircuit('test_subckt2', 'pin1', 'pin2', 'pin3', 'pin4', 'pin5')
     subckt2.add_element(ThreeTerminalDevice('X1', 'pin1', 'pin3', 'pin4'))
     subckt2.add_element(ThreeTerminalDevice('X2', 'pin2', 'pin3', 'pin5'))
-    assert len(ckt.find_matching_subgraphs(subckt2)) == 0
+    assert len(ckt.find_matching_subgraphs(subckt2.circuit)) == 0
     # Validate overtly aggressive match. 3 of 4 matches are probably useless from a circuit standpoint
     subckt3 = SubCircuit('test_subckt3', 'pin1', 'pin2', 'pin3', 'pin4')
     subckt3.add_element(TwoTerminalDevice('X1', 'pin1', 'pin2'))
     subckt3.add_element(TwoTerminalDevice('X2', 'pin3', 'pin4'))
-    assert len(ckt.find_matching_subgraphs(subckt3)) == 4
+    assert len(ckt.find_matching_subgraphs(subckt3.circuit)) == 4
 
 def test_replace_matching_subgraphs(simple_netlist, matching_subckt):
     ckt, subckt = simple_netlist, matching_subckt
     matches = [{'X3': 'X1', 'net3': 'pin3', 'net1': 'pin1', 'X4': 'X2', 'net2': 'pin2'}]
-    ckt.replace_matching_subgraphs(subckt)
+    ckt.replace_matching_subckts(subckt)
     assert all(x not in ckt.nodes for x in matches[0].keys() if x.startswith('X'))
     assert 'X_test_subckt_0' in ckt.nodes
     new_edges = [('X_test_subckt_0', 'net3', {'pin3'}), ('X_test_subckt_0', 'net1', {'pin1'}), ('X_test_subckt_0', 'net2', {'pin2'})]

--- a/Circuit/tests/test_core.py
+++ b/Circuit/tests/test_core.py
@@ -146,21 +146,21 @@ def matching_subckt(ThreeTerminalDevice):
     subckt.add_element(ThreeTerminalDevice('X2', 'pin3', 'pin1', 'pin2', myparameter='{myparameter}'))
     return subckt
 
-def test_find_matching_subgraphs(simple_netlist, matching_subckt, ThreeTerminalDevice, TwoTerminalDevice):
+def test_find_subgraph_matches(simple_netlist, matching_subckt, ThreeTerminalDevice, TwoTerminalDevice):
     ckt, subckt = simple_netlist, matching_subckt
     # Validate true match
-    assert len(ckt.find_matching_subgraphs(subckt.circuit)) == 1
-    assert ckt.find_matching_subgraphs(subckt.circuit)[0] == {'X3': 'X1', 'net3': 'pin3', 'net1': 'pin1', 'X4': 'X2', 'net2': 'pin2'}
+    assert len(ckt.find_subgraph_matches(subckt.circuit)) == 1
+    assert ckt.find_subgraph_matches(subckt.circuit)[0] == {'X3': 'X1', 'net3': 'pin3', 'net1': 'pin1', 'X4': 'X2', 'net2': 'pin2'}
     # Validate false match
     subckt2 = SubCircuit('test_subckt2', 'pin1', 'pin2', 'pin3', 'pin4', 'pin5')
     subckt2.add_element(ThreeTerminalDevice('X1', 'pin1', 'pin3', 'pin4'))
     subckt2.add_element(ThreeTerminalDevice('X2', 'pin2', 'pin3', 'pin5'))
-    assert len(ckt.find_matching_subgraphs(subckt2.circuit)) == 0
+    assert len(ckt.find_subgraph_matches(subckt2.circuit)) == 0
     # Validate overtly aggressive match. 3 of 4 matches are probably useless from a circuit standpoint
     subckt3 = SubCircuit('test_subckt3', 'pin1', 'pin2', 'pin3', 'pin4')
     subckt3.add_element(TwoTerminalDevice('X1', 'pin1', 'pin2'))
     subckt3.add_element(TwoTerminalDevice('X2', 'pin3', 'pin4'))
-    assert len(ckt.find_matching_subgraphs(subckt3.circuit)) == 4
+    assert len(ckt.find_subgraph_matches(subckt3.circuit)) == 4
 
 def test_replace_matching_subgraphs(simple_netlist, matching_subckt):
     ckt, subckt = simple_netlist, matching_subckt


### PR DESCRIPTION
Quick & dirty implementation of find_repeated_subckts. 

Algorithm attempts to maximize the number of elements while minimizing the number of nets in discovered subckts.

Calling replace_repeated_subckts will also modify the existing graph in addition to returning the discovered subckts.