### PR TITLE
upto 60s for lp solver

### DIFF
--- a/PlaceRouteHierFlow/PnRDB/PnRdatabase.cpp
+++ b/PlaceRouteHierFlow/PnRDB/PnRdatabase.cpp
@@ -319,7 +319,7 @@ void PnRdatabase::CheckinHierNode(int nodeID, const PnRDB::hierNode& updatedNode
                        if(updatedNode.PowerNets[k].name == parent_node.PowerNets[l].name){
                             found = 1;
 
-                            parent_node.PowerNets[l].dummy_connected.clear();
+                            //parent_node.PowerNets[l].dummy_connected.clear();
 
                             for(unsigned int p=0;p<updatedNode.PowerNets[k].Pins.size();p++){
                                   PnRDB::connectNode temp_connectNode;
@@ -339,6 +339,7 @@ void PnRdatabase::CheckinHierNode(int nodeID, const PnRDB::hierNode& updatedNode
                       PnRDB::PowerNet temp_PowerNet;
                       temp_PowerNet = updatedNode.PowerNets[k];
                       temp_PowerNet.connected.clear();
+                      temp_PowerNet.dummy_connected.clear();
                       temp_PowerNet.Pins.clear();
                       
                       for(unsigned int p=0;p<updatedNode.PowerNets[k].Pins.size();p++){

--- a/PlaceRouteHierFlow/router/GcellDetailRouter.cpp
+++ b/PlaceRouteHierFlow/router/GcellDetailRouter.cpp
@@ -79,7 +79,7 @@ void GcellDetailRouter::printNetsInfo(){
 
 };
 
-std::vector<RouterDB::Metal> GcellDetailRouter::CpSymPath(std::vector<RouterDB::Metal> temp_path, int H, int center){
+std::vector<RouterDB::Metal> GcellDetailRouter::CpSymPath(std::vector<RouterDB::Metal> &temp_path, int H, int center){
 
 
   std::vector<RouterDB::Metal> sym_path;
@@ -1310,7 +1310,7 @@ void GcellDetailRouter::SortPins(std::vector<std::vector<RouterDB::SinkData> > &
 
 
 
-std::vector<RouterDB::Metal> GcellDetailRouter::findGlobalPath(RouterDB::Net temp_net){
+std::vector<RouterDB::Metal> GcellDetailRouter::findGlobalPath(RouterDB::Net &temp_net){
 
   std::vector<RouterDB::Metal> temp_metal;
   
@@ -1330,7 +1330,7 @@ std::vector<RouterDB::Metal> GcellDetailRouter::findGlobalPath(RouterDB::Net tem
 
 };
 
-void GcellDetailRouter::splitPath(std::vector<std::vector<RouterDB::Metal> > temp_path, RouterDB::Net& temp_net){
+void GcellDetailRouter::splitPath(std::vector<std::vector<RouterDB::Metal> > &temp_path, RouterDB::Net& temp_net){
 
   RouterDB::point temp_point = temp_path[0][0].LinePoint[0];
   int temp_metalIdx = temp_path[0][0].MetalIdx;
@@ -1395,7 +1395,7 @@ void GcellDetailRouter::splitPath(std::vector<std::vector<RouterDB::Metal> > tem
 };
 
 
-void GcellDetailRouter::lastmile_source_new(std::vector<std::vector<RouterDB::Metal> > &temp_path, std::vector<RouterDB::SinkData> temp_source){
+void GcellDetailRouter::lastmile_source_new(std::vector<std::vector<RouterDB::Metal> > &temp_path, std::vector<RouterDB::SinkData> &temp_source){
 
   RouterDB::point temp_point = temp_path[0][0].LinePoint[0];
   int temp_metal_metalidx = temp_path[0][0].MetalIdx;
@@ -1509,7 +1509,7 @@ void GcellDetailRouter::lastmile_source_new(std::vector<std::vector<RouterDB::Me
 };
 
 
-void GcellDetailRouter::lastmile_dest_new(std::vector<std::vector<RouterDB::Metal> > &temp_path, std::vector<RouterDB::SinkData> temp_source){
+void GcellDetailRouter::lastmile_dest_new(std::vector<std::vector<RouterDB::Metal> > &temp_path, std::vector<RouterDB::SinkData> &temp_source){
 
   int last_index = temp_path[0].size()-1;
   RouterDB::point temp_point = temp_path[0][last_index].LinePoint[1];
@@ -1663,7 +1663,7 @@ void GcellDetailRouter::UpdateVia(RouterDB::Via &temp_via){
 
 };
 
-void GcellDetailRouter::updateSource(std::vector<std::vector<RouterDB::Metal> > temp_path, std::vector<RouterDB::SinkData>& temp_source){
+void GcellDetailRouter::updateSource(std::vector<std::vector<RouterDB::Metal> > &temp_path, std::vector<RouterDB::SinkData>& temp_source){
 
   RouterDB::SinkData temp_sink;
   int width = 1;
@@ -1728,7 +1728,7 @@ void GcellDetailRouter::updateSource(std::vector<std::vector<RouterDB::Metal> > 
 
 };
 
-void GcellDetailRouter::returnPath(std::vector<std::vector<RouterDB::Metal> > temp_path, RouterDB::Net& temp_net){
+void GcellDetailRouter::returnPath(std::vector<std::vector<RouterDB::Metal> > &temp_path, RouterDB::Net& temp_net){
 
   for(unsigned int i=0;i<temp_path.size();i++){
        
@@ -2101,7 +2101,7 @@ void GcellDetailRouter::CreatePlistBlocks(std::vector<std::vector<RouterDB::poin
 
 
 
-void GcellDetailRouter::CreatePlistTerminals(std::vector<std::vector<RouterDB::point> >& plist, std::vector<RouterDB::terminal> Terminals){
+void GcellDetailRouter::CreatePlistTerminals(std::vector<std::vector<RouterDB::point> >& plist, std::vector<RouterDB::terminal> &Terminals){
   
   //RouterDB::point tmpP;
   //int mIdx, LLx, LLy, URx, URy;
@@ -2150,7 +2150,7 @@ void GcellDetailRouter::UpdatePlistNets(std::vector<std::vector<RouterDB::Metal>
 
 };
 
-void GcellDetailRouter::GetPhsical_Via_contacts(std::vector<std::vector<RouterDB::Metal> >physical_path, std::vector<RouterDB::contact> &temp_via_contact){
+void GcellDetailRouter::GetPhsical_Via_contacts(std::vector<std::vector<RouterDB::Metal> >&physical_path, std::vector<RouterDB::contact> &temp_via_contact){
 
 
   RouterDB::Via temp_via;

--- a/PlaceRouteHierFlow/router/GcellDetailRouter.h
+++ b/PlaceRouteHierFlow/router/GcellDetailRouter.h
@@ -65,7 +65,7 @@ class GcellDetailRouter : public GcellGlobalRouter{
     //bool CheckConnection_Dest(RouterDB::Segment& temp_seg);
     void CreatePlistBlocks(std::vector<std::vector<RouterDB::point> >& plist, std::vector<RouterDB::Block>& Blocks);
     //void CreatePlistNets(std::vector<std::vector<RouterDB::point> >& plist, std::vector<RouterDB::Net>& Nets);
-    void CreatePlistTerminals(std::vector<std::vector<RouterDB::point> >& plist, std::vector<RouterDB::terminal> Terminals);
+    void CreatePlistTerminals(std::vector<std::vector<RouterDB::point> >& plist, std::vector<RouterDB::terminal> &Terminals);
     //void CreatePlistNets_DetailRouter(std::vector<std::vector<RouterDB::point> >& plist, std::vector<RouterDB::Net>& Nets);
     void UpdatePlistNets(std::vector<std::vector<RouterDB::Metal> > &physical_path, std::vector<std::vector<RouterDB::point> > & plist);
     void GetPhsical_Metal(std::vector<std::vector<RouterDB::Metal> > &physical_path);
@@ -80,19 +80,19 @@ class GcellDetailRouter : public GcellGlobalRouter{
 
     void create_detailrouter();
     //std::vector<std::vector<RouterDB::SinkData> > findPins(RouterDB::Net temp_net);
-    std::vector<RouterDB::Metal> findGlobalPath(RouterDB::Net temp_net);
-    void splitPath(std::vector<std::vector<RouterDB::Metal> > temp_path, RouterDB::Net& temp_net);
-    void lastmile_source(std::vector<std::vector<RouterDB::Metal> > &temp_path, std::vector<RouterDB::SinkData> temp_source);
-    void lastmile_dest(std::vector<std::vector<RouterDB::Metal> > &temp_path, std::vector<RouterDB::SinkData> temp_source);
-    void lastmile_source_new(std::vector<std::vector<RouterDB::Metal> > &temp_path, std::vector<RouterDB::SinkData> temp_source);
-    void lastmile_dest_new(std::vector<std::vector<RouterDB::Metal> > &temp_path, std::vector<RouterDB::SinkData> temp_source);
-    void updateSource(std::vector<std::vector<RouterDB::Metal> > temp_path, std::vector<RouterDB::SinkData>& temp_source);
+    std::vector<RouterDB::Metal> findGlobalPath(RouterDB::Net &temp_net);
+    void splitPath(std::vector<std::vector<RouterDB::Metal> > &temp_path, RouterDB::Net& temp_net);
+    void lastmile_source(std::vector<std::vector<RouterDB::Metal> > &temp_path, std::vector<RouterDB::SinkData> &temp_source);
+    void lastmile_dest(std::vector<std::vector<RouterDB::Metal> > &temp_path, std::vector<RouterDB::SinkData> &temp_source);
+    void lastmile_source_new(std::vector<std::vector<RouterDB::Metal> > &temp_path, std::vector<RouterDB::SinkData> &temp_source);
+    void lastmile_dest_new(std::vector<std::vector<RouterDB::Metal> > &temp_path, std::vector<RouterDB::SinkData> &temp_source);
+    void updateSource(std::vector<std::vector<RouterDB::Metal> > &temp_path, std::vector<RouterDB::SinkData>& temp_source);
 
     void NetToNodeNet(PnRDB::hierNode& HierNode, RouterDB::Net& net, int net_index);
     void NetToNodeInterMetal(PnRDB::hierNode& HierNode, RouterDB::Net& net);
     void NetToNodeBlockPins(PnRDB::hierNode& HierNode, RouterDB::Net& net);
-    void returnPath(std::vector<std::vector<RouterDB::Metal> > temp_path, RouterDB::Net& temp_net);
-    std::vector<RouterDB::Metal> CpSymPath(std::vector<RouterDB::Metal> temp_path, int H, int center);
+    void returnPath(std::vector<std::vector<RouterDB::Metal> > &temp_path, RouterDB::Net& temp_net);
+    std::vector<RouterDB::Metal> CpSymPath(std::vector<RouterDB::Metal> &temp_path, int H, int center);
     RouterDB::contact SymContact(RouterDB::contact &temp_contact, bool H, int center);
     RouterDB::SinkData Sym_contact(RouterDB::SinkData &temp_contact, bool H, int center);
     int Cover_Contact(RouterDB::SinkData &temp_contact, RouterDB::SinkData &sym_temp_contact, RouterDB::SinkData &cover_contact);
@@ -124,7 +124,7 @@ class GcellDetailRouter : public GcellGlobalRouter{
     void JudgeTileCoverage(std::vector<std::pair<int,int> > &tile_index, std::vector<std::vector<RouterDB::SinkData> > &temp_pins, GlobalGrid &Gcell);
     int Tile_Cover_Contact(RouterDB::SinkData &temp_contact, RouterDB::SinkData &sym_temp_contact);
     void CheckTile(RouterDB::Net &temp_net, GlobalGrid &Gcell);
-    void GetPhsical_Via_contacts(std::vector<std::vector<RouterDB::Metal> >physical_path, std::vector<RouterDB::contact> &temp_via_contact);
+    void GetPhsical_Via_contacts(std::vector<std::vector<RouterDB::Metal> >&physical_path, std::vector<RouterDB::contact> &temp_via_contact);
     std::vector<std::pair<int,int> > MappingToConnected(RouterDB::R_const &temp_R, RouterDB::Net &temp_net);
     void GatherSourceDest(std::vector<std::pair<int,int> > & global_path, std::vector<int> &temp_src, std::vector<int> &temp_dest, std::vector<int> & Tile_Source, std::vector<int> & Tile_Dest);
     std::vector<int> EstimateDist(RouterDB::R_const &temp_R, RouterDB::Net &temp_net);

--- a/PlaceRouteHierFlow/router/GcellGlobalRouter.cpp
+++ b/PlaceRouteHierFlow/router/GcellGlobalRouter.cpp
@@ -1239,7 +1239,7 @@ int GcellGlobalRouter::ILPSolveRouting(GlobalGrid &grid, GlobalGraph &graph, std
   std::cout<<"LP test flag 7"<<std::endl;
   // 6. Solve with lp
   set_minim(lp);
-  //set_timeout(lp,60);
+  set_timeout(lp,60);
   std::cout<<"LP test flag 8"<<std::endl;
   //set_solutionlimit(lp, 10);
   std::cout<<"LP test flag 9"<<std::endl; 

--- a/PlaceRouteHierFlow/router/GlobalGraph.cpp
+++ b/PlaceRouteHierFlow/router/GlobalGraph.cpp
@@ -27,7 +27,7 @@ void GlobalGraph::FindSTs(GlobalGrid& grid, int pathNo, std::vector<int> &stiner
 
      std::vector<std::pair<int,int> > temp_path;
      //std::cout<<"Start iterate steiner"<<std::endl;
-     //Iterated_Steiner(grid,stiner_node); 
+     Iterated_Steiner(grid,stiner_node); 
      //std::cout<<"End iterate steiner"<<std::endl;
      int weight;    
 

--- a/PlaceRouteHierFlow/router/GlobalGraph.cpp
+++ b/PlaceRouteHierFlow/router/GlobalGraph.cpp
@@ -27,7 +27,7 @@ void GlobalGraph::FindSTs(GlobalGrid& grid, int pathNo, std::vector<int> &stiner
 
      std::vector<std::pair<int,int> > temp_path;
      //std::cout<<"Start iterate steiner"<<std::endl;
-     Iterated_Steiner(grid,stiner_node); 
+     //Iterated_Steiner(grid,stiner_node); 
      //std::cout<<"End iterate steiner"<<std::endl;
      int weight;    
 


### PR DESCRIPTION
@kkunal1408 

I found that in different machine, lp solver might get stuck when the available memory is diffferent. Maybe that's the reason why there is a difference between the cases when you run it and when I run it.

One more command in the code to exit LP in 60s. Now you can try this code with GF design (1h22min for me).

That's a temporary solution.  I am running TI_SAR and get stuck in top level too (3h to go to top level). You can try other designs. Let me know the results about other designs. Thanks.

Yaguang