### PR TITLE
Fix installation scripts for Ubuntu 18.04

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -62,8 +62,8 @@ export VENV=$ALIGN_HOME/general
 cd $ALIGN_HOME
 python3 -m venv $VENV
 source $VENV/bin/activate
-pip install --upgrade pip
-pip install -e .
+python3 -m pip install --upgrade pip
+python3 -m pip install -e .
 deactivate
 
 ## Install ALIGN_PnR

--- a/install_tcsh.sh
+++ b/install_tcsh.sh
@@ -62,8 +62,8 @@ setenv VENV $ALIGN_HOME/general
 cd $ALIGN_HOME
 python3 -m venv $VENV
 source $VENV/bin/activate
-pip install --upgrade pip
-pip install -e .
+python3 -m pip install --upgrade pip
+python3 -m pip install -e .
 deactivate
 
 ## install align_PnR


### PR DESCRIPTION
On systems that have python 2 and 3 installed, the installation script
fails silently because apparently the wrong pip is called. Calling pip
using python3 -m pip solves the issue