### PR TITLE
add assert when no space for power grid construction

### DIFF
--- a/PlaceRouteHierFlow/router/PowerRouter.cpp
+++ b/PlaceRouteHierFlow/router/PowerRouter.cpp
@@ -74,6 +74,13 @@ void PowerRouter::PowerNetRouter(PnRDB::hierNode& node, PnRDB::Drc_info& drc_inf
            RouterDB::Pin temp_pin = PowerNets[i].pins[j];
            std::vector<RouterDB::SinkData> temp_source, temp_dest;
 
+           if(Vdd_grid.metals.size()==0 or Gnd_grid.metals.size()==0){
+             std::cout<<"Placement Area is too small, no space to create power grid"<<std::endl;
+             assert(0);
+             //continue;
+           }
+
+
            if(PowerNets[i].power ==1){
                //Q1
                SetSrcDest(temp_pin, Vdd_grid, temp_source, temp_dest);

--- a/PlaceRouteHierFlow/router/PowerRouter.h
+++ b/PlaceRouteHierFlow/router/PowerRouter.h
@@ -5,6 +5,7 @@
 #include <fstream>
 #include <vector>
 #include <string>
+#include <assert.h>
 #include <sstream>
 #include <set>
 #include <cmath>


### PR DESCRIPTION
@kkunal1408 

Example inverter_v1.
Crash if INV_LVT has a constraint "SymmBlock ( {xm0} , {xm1} )".
The test case can be reproduced by removing "and name not in lib_names" from line 188 in align/compiler.py

This constraint make that there is no space to create power grid. Then P&R fails. 
A assert is added when power grid is empty.