### PR TITLE
WIP: bug in topology detection

### DIFF
--- a/examples/buffer/buffer.sp
+++ b/examples/buffer/buffer.sp
@@ -1,6 +1,6 @@
 .subckt buffer vin vout vdd vss
-mp1 vdd  vin vxx vdd p w=270e-9 l=20e-9 nfin=12
+mp1 vxx  vin vdd vdd p w=270e-9 l=20e-9 nfin=12
 mn1 vxx  vin vss vss n w=270e-9 l=20e-9 nfin=12
-mp2 vout vxx vdd vdd p w=270e-9 l=20e-9 nfin=12
-mn2 vout vxx vss vss n w=270e-9 l=20e-9 nfin=12
+mp2 vout vxx vdd vdd p w=270e-9 l=20e-9 nfin=24
+mn2 vout vxx vss vss n w=270e-9 l=20e-9 nfin=48
 .ends buffer


### PR DESCRIPTION
Subcircuit identification does not take into account the differences in transistor sizes.
In the example below, inverter sizes are different yet the generated Verilog shows same size. 

**Example:** 
buffer

**Netlist:**
.subckt buffer vin vout vdd vss
mp1 vxx  vin vdd vdd p w=270e-9 l=20e-9 nfin=12
mn1 vxx  vin vss vss n w=270e-9 l=20e-9 nfin=12
mp2 vout vxx vdd vdd p w=270e-9 l=20e-9 nfin=24
mn2 vout vxx vss vss n w=270e-9 l=20e-9 nfin=48
.ends buffer

**Verilog:**
module INV_LVT ( SN, SP, i, zn ); 
input SN, SP, i, zn;
Switch_NMOS_n12_X2_Y2 xm0 ( .B(SN), .D(zn), .G(i), .S(SN) ); 
Switch_PMOS_n12_X2_Y1 xm1 ( .B(SP), .D(zn), .G(i), .S(SP) ); 
endmodule
module stage2_inv ( G1, G2, SN, SP ); 
input G1, G2, SN, SP;
INV_LVT MM0_MM2 ( .zn(G1), .i(D), .SN(SN), .SP(SP) ); 
INV_LVT MM1_MM3 ( .zn(D), .i(G2), .SN(SN), .SP(SP) ); 
endmodule
module buffer ( vin, vout ); 
input vin, vout;
stage2_inv mn2_mn1_mp2_mp1 ( .G1(vout), .SN(vss), .G2(vin), .SP(vdd) ); 
endmodule