### PR TITLE
updated m,nf,nfin

### DIFF
--- a/examples/powertrain/powertrain.sp
+++ b/examples/powertrain/powertrain.sp
@@ -1,3 +1,3 @@
 .subckt powertrain vcc vg vout
-mmp0 vout vg vcc vcc plplvt w=180n l=40n nfin=240
+mmp0 vout vg vcc vcc plplvt w=180n l=40n nfin=4 nf=8 m=20
 .ends

--- a/examples/powertrain_binary/powertrain_binary.sp
+++ b/examples/powertrain_binary/powertrain_binary.sp
@@ -1,5 +1,5 @@
 .subckt powertrain_cell ond vcc vout
-mmp0 vout ond vcc vcc p w=180n l=40n nfin=128
+mmp0 vout ond vcc vcc p w=180n l=40n nfin=4 nf=8 m=4
 .ends
 
 .subckt powertrain_binary on_d[5] on_d[4] on_d[3] on_d[2] on_d[1] on_d[0] vcc vout

--- a/examples/powertrain_thermo/powertrain_thermo.sp
+++ b/examples/powertrain_thermo/powertrain_thermo.sp
@@ -1,5 +1,5 @@
 .subckt powertrain_cell ond vcc vout
-mmp0 vout ond vcc vcc p w=180n l=40n nfin=128
+mmp0 vout ond vcc vcc p w=180n l=40n nfin=4 nf=8 m=4
 .ends
 
 .subckt powertrain_thermo on_d[63] on_d[62] on_d[61] on_d[60] on_d[59]


### PR DESCRIPTION
Updated m,nf,nfin in examples/powertrain* to follow the convention as agreed upon during the virtual F2F:
nfin : Number of fins in an atomic transistor (equivalent to W in bulk technologies) 
nf : Number of fingers that share diffusion
m : Number of instances of the transistor specified with nfin and nf  