### PR TITLE
Add the 'adder' testcase that is supposed to fail in CI

### DIFF
--- a/tests/test_cmdline.py
+++ b/tests/test_cmdline.py
@@ -5,7 +5,8 @@ import pathlib
 
 examples = ['inverter_v1',
             'buffer',
-            'five_transistor_ota']
+            'five_transistor_ota',
+            'adder']
 
 ALIGN_HOME = pathlib.Path(__file__).resolve().parent.parent
 


### PR DESCRIPTION
CI should  fail according to Kunal with the 'adder' testcase added.