### PR TITLE
Nightly INTERNALERROR fix

### DIFF
--- a/build/Dockerfile.base
+++ b/build/Dockerfile.base
@@ -43,7 +43,7 @@ RUN python3 -m venv $venv
 # Note: Package dependencies are in setup.py
 RUN $pip install --upgrade pip -q
 RUN $pip install -q \
-    pytest \
+    pytest==5.4.3 \
     pytest-cov \
     pytest-timeout \
     coverage-badge

--- a/build/Dockerfile.build.python
+++ b/build/Dockerfile.build.python
@@ -4,7 +4,7 @@ RUN apt-get update && apt-get install -yq vim git pkg-config python3 python3-pip
 
 RUN \
     python3 -m venv sympy && \
-    bash -c "source sympy/bin/activate; pip install pytest sympy networkx pygraphviz coverage pytest-cov protobuf"
+    bash -c "source sympy/bin/activate; pip install pytest==5.4.3 sympy networkx pygraphviz coverage pytest-cov protobuf"
 
 
 

--- a/build/Dockerfile.native
+++ b/build/Dockerfile.native
@@ -11,7 +11,7 @@ RUN \
 
 RUN \
     python3 -m venv general && \
-    bash -c "source general/bin/activate; pip install --upgrade pip && pip install wheel pytest general networkx pygraphviz coverage pytest-cov protobuf matplotlib pyyaml python-gdsii"
+    bash -c "source general/bin/activate; pip install --upgrade pip && pip install wheel pytest==5.4.3 general networkx pygraphviz coverage pytest-cov protobuf matplotlib pyyaml python-gdsii"
 
 COPY . /ALIGN-public
 

--- a/build/Dockerfile.native16
+++ b/build/Dockerfile.native16
@@ -19,7 +19,7 @@ RUN \
 
 RUN \
     python3 -m venv general && \
-    bash -c "source general/bin/activate; pip install --upgrade pip && pip install wheel pytest general networkx pygraphviz coverage pytest-cov protobuf matplotlib pyyaml python-gdsii"
+    bash -c "source general/bin/activate; pip install --upgrade pip && pip install wheel pytest==5.4.3 general networkx pygraphviz coverage pytest-cov protobuf matplotlib pyyaml python-gdsii"
 
 COPY . /ALIGN-public
 


### PR DESCRIPTION
Upgrading to pytest version 6.0.0 breaks nightly regressions by causing INTERNALERROR upon encountering failed DRC checks. This error causes the overall regression to silently pass without running all circuits.

Reverting to pytest version 5.4.3 in Dockerfile.base.