### PR TITLE
Example testcases

### DIFF
--- a/align/pnr/main.py
+++ b/align/pnr/main.py
@@ -75,9 +75,6 @@ def generate_pnr(topology_dir, primitive_dir, pdk_dir, output_dir, subckt, nvari
     compiler_path = pathlib.Path(os.environ['ALIGN_HOME']).resolve() / 'PlaceRouteHierFlow' / 'pnr_compiler'
     assert compiler_path.is_file(), f"{compiler_path} not found. Has it been built?"
 
-    shared_object_path = pathlib.Path(os.environ['ALIGN_HOME']).resolve() / 'PlaceRouteHierFlow' / 'PnR.cpython-36m-x86_64-linux-gnu.so'
-    assert shared_object_path.is_file(), f"{shared_object_path} not found. Has it been built?"
-
     sys.setdlopenflags(os.RTLD_GLOBAL|os.RTLD_LAZY)
 
     import PnR

--- a/examples/five_transistor_ota_high_frequency/five_transistor_ota_high_frequency.const
+++ b/examples/five_transistor_ota_high_frequency/five_transistor_ota_high_frequency.const
@@ -1,0 +1,5 @@
+Multi_Connection ( {vout_ota} , {3} )
+Multi_Connection ( {net19} , {3} )
+Multi_Connection ( {net017} , {5} )
+Multi_Connection ( {vss_ota} , {5} )
+Multi_Connection ( {vdd_ota} , {5} )

--- a/examples/five_transistor_ota_high_frequency/five_transistor_ota_high_frequency.setup
+++ b/examples/five_transistor_ota_high_frequency/five_transistor_ota_high_frequency.setup
@@ -1,0 +1,4 @@
+POWER = vdd_ota
+GND = vss_ota
+CLOCK = 
+DIGITAL = 

--- a/examples/five_transistor_ota_high_frequency/five_transistor_ota_high_frequency.sp
+++ b/examples/five_transistor_ota_high_frequency/five_transistor_ota_high_frequency.sp
@@ -1,0 +1,8 @@
+.subckt five_transistor_ota_high_frequency vinn_ota vinp_ota vout_ota id_ota vdd_ota vss_ota
+m5 vout_ota net19 vdd_ota vdd_ota pfet m=1 l=14e-9 nfin=12 nf=2
+m4 net19 net19 vdd_ota vdd_ota pfet m=1 l=14e-9 nfin=12 nf=2
+m3 id_ota id_ota vss_ota vss_ota nfet m=1 l=14e-9 nfin=12 nf=2
+m2 net017 id_ota vss_ota vss_ota nfet m=1 l=14e-9 nfin=12 nf=16
+m1 vout_ota vinn_ota net017 vss_ota nfet m=1 l=14e-9 nfin=12 nf=40
+m0 net19 vinp_ota net017 vss_ota nfet m=1 l=14e-9 nfin=12 nf=40
+.ends

--- a/examples/telescopic_ota_multi_connection/telescopic_ota_multi_connection.const
+++ b/examples/telescopic_ota_multi_connection/telescopic_ota_multi_connection.const
@@ -1,0 +1,5 @@
+Multi_Connection ( {voutp} , {3} )
+Multi_Connection ( {voutn} , {3} )
+Multi_Connection ( {net10} , {3} )
+Multi_Connection ( {vss} , {3} )
+Multi_Connection ( {vdd} , {3} )

--- a/examples/telescopic_ota_multi_connection/telescopic_ota_multi_connection.setup
+++ b/examples/telescopic_ota_multi_connection/telescopic_ota_multi_connection.setup
@@ -1,0 +1,4 @@
+POWER = vdd
+GND = vss
+CLOCK =
+DIGITAL =

--- a/examples/telescopic_ota_multi_connection/telescopic_ota_multi_connection.sp
+++ b/examples/telescopic_ota_multi_connection/telescopic_ota_multi_connection.sp
@@ -1,0 +1,12 @@
+.subckt telescopic_ota_multi_connection d1 vdd vinn vinp vss vbiasn vbiasp1 vbiasp2 voutn voutp
+m9 voutn vbiasn net8 vss nmos_rvt w=270e-9 l=20e-9 nfin=36
+m8 voutp vbiasn net014 vss nmos_rvt w=270e-9 l=20e-9 nfin=36
+m5 d1 d1 vss vss nmos_rvt w=270e-9 l=20e-9 nfin=24
+m4 net10 d1 vss vss nmos_rvt w=270e-9 l=20e-9 nfin=36
+m3 net014 vinn net10 vss nmos_rvt w=270e-9 l=20e-9 nfin=108
+m0 net8 vinp net10 vss nmos_rvt w=270e-9 l=20e-9 nfin=108
+m7 voutp vbiasp2 net012 vdd pmos_rvt w=270e-9 l=20e-9 nfin=24
+m6 voutn vbiasp2 net06 vdd pmos_rvt w=270e-9 l=20e-9 nfin=24
+m2 net012 vbiasp1 vdd vdd pmos_rvt w=270e-9 l=20e-9 nfin=12
+m1 net06 vbiasp1 vdd vdd pmos_rvt w=270e-9 l=20e-9 nfin=12
+.ends telescopic_ota_multi_connection


### PR DESCRIPTION
@parijatm @stevenmburns @854768750 @meghna09 

When I use the commend below:
pytest -vv --runnightly -k multi -- tests/integration

Error happens like:
ERROR    align.cmdline:cmdline.py:109 Fatal Error. Cannot proceed
Traceback (most recent call last):
  File "/home/liyg/Desktop/Research/ALIGN-public/align/cmdline.py", line 107, in parse_args
    return schematic2layout(**vars(arguments))
  File "/home/liyg/Desktop/Research/ALIGN-public/align/main.py", line 75, in schematic2layout
    variants = generate_pnr(topology_dir, primitive_dir, pdk_dir, pnr_dir, subckt, nvariants, effort, check, extract, gds_json=python_gds_json)
  File "/home/liyg/Desktop/Research/ALIGN-public/align/pnr/main.py", line 79, in generate_pnr
    assert shared_object_path.is_file(), f"{shared_object_path} not found. Has it been built?"
AssertionError: /home/liyg/Desktop/Research/ALIGN-public/PlaceRouteHierFlow/PnR.cpython-36m-x86_64-linux-gnu.so not found. Has it been built?

Seems in the new flow, we need PnR.cpython-36m-x86_64-linux-gnu.so. How to build this?

