### PR TITLE
Fix/pins in python gds

### DIFF
--- a/align/cell_fabric/gen_gds_json.py
+++ b/align/cell_fabric/gen_gds_json.py
@@ -6,7 +6,7 @@ from . import pdk
 import logging
 logger = logging.getLogger(__name__)
 
-def translate_data( macro_name, exclude_pattern, pdkfile, pinSwitch, data, via_gen_tbl, timestamp=None):
+def translate_data( macro_name, exclude_pattern, pdkfile, pinSwitch, data, via_gen_tbl, timestamp=None, *, add_text_for_pins=False):
   j = pdk.Pdk().load(pdkfile)
   with open(pdkfile, "rt") as fp1:
     j1 = json.load(fp1)
@@ -104,5 +104,5 @@ def translate_data( macro_name, exclude_pattern, pdkfile, pinSwitch, data, via_g
 
   return top
 
-def translate( macro_name, exclude_pattern, pinSwitch, fp, ofile, timestamp=None, p=None):
-  json.dump(translate_data( macro_name, exclude_pattern, p.layerfile, pinSwitch, json.load(fp), {}, timestamp), ofile, indent=4)
+def translate( macro_name, exclude_pattern, pinSwitch, fp, ofile, timestamp=None, p=None, *, add_text_for_pins=False):
+  json.dump(translate_data( macro_name, exclude_pattern, p.layerfile, pinSwitch, json.load(fp), {}, timestamp, add_text_for_pins), ofile, indent=4)

--- a/align/cell_fabric/gen_gds_json.py
+++ b/align/cell_fabric/gen_gds_json.py
@@ -100,9 +100,9 @@ def translate_data( macro_name, exclude_pattern, pdkfile, pinSwitch, data, via_g
                         "datatype" : j[k]['GdsDatatype']['Pin'],
                         "xy" : flat_rect_to_boundary( list(map(scale,obj['rect'])))})
       if ('pin' in obj) and add_text_for_pins:
-          test_font, test_vp, test_hp, test_texttype, test_mag = 1, 1, 1, 251, 0.03
+          test_font, test_vp, test_hp, test_mag = 1, 1, 1, 0.03
           strct["elements"].append ({"type": "text", "layer" : j[k]['GdsLayerNo'],
-                        "texttype": test_texttype,
+                        "texttype": j[k]['GdsDatatype']['Pin'],
                         "presentation": JSON_Presentation( test_font, test_vp, test_hp),
                         "strans": 0,
                         "mag": test_mag,

--- a/align/cell_fabric/gen_gds_json.py
+++ b/align/cell_fabric/gen_gds_json.py
@@ -105,4 +105,4 @@ def translate_data( macro_name, exclude_pattern, pdkfile, pinSwitch, data, via_g
   return top
 
 def translate( macro_name, exclude_pattern, pinSwitch, fp, ofile, timestamp=None, p=None, *, add_text_for_pins=False):
-  json.dump(translate_data( macro_name, exclude_pattern, p.layerfile, pinSwitch, json.load(fp), {}, timestamp, add_text_for_pins), ofile, indent=4)
+  json.dump(translate_data( macro_name, exclude_pattern, p.layerfile, pinSwitch, json.load(fp), {}, timestamp, add_text_for_pins=add_text_for_pins), ofile, indent=4)

--- a/align/pnr/main.py
+++ b/align/pnr/main.py
@@ -70,7 +70,7 @@ def _generate_json( *, dbfile, variant, primitive_dir, pdk_dir, output_dir, chec
         ret['python_gds_json'] = output_dir / f'{variant}.python.gds.json'
         with open( ret['json'], 'rt') as ifp:
             with open( ret['python_gds_json'], 'wt') as ofp:
-                gen_gds_json.translate( hN.name, '', 0, ifp, ofp, timestamp=None, p=cnv.pdk)
+                gen_gds_json.translate( hN.name, '', 0, ifp, ofp, timestamp=None, p=cnv.pdk, add_text_for_pins=True)
         logger.info(f"OUTPUT gds.json {ret['python_gds_json']}")
 
     return ret
@@ -210,7 +210,7 @@ def generate_pnr(topology_dir, primitive_dir, pdk_dir, output_dir, subckt, nvari
         elif file_.suffixes == ['.lef']:
             variants[variant]['lef'] = file_
         elif file_.suffixes == ['.db', '.json'] and (check or extract or gds_json):
-            logger.debug( f".db.json: {file_.name}")
+            logger.warning( f".db.json: {file_.name}")
             variants[variant].update(
                 _generate_json( dbfile = file_,
                                 variant = variant,

--- a/align/primitive/default/via.py
+++ b/align/primitive/default/via.py
@@ -36,6 +36,9 @@ def ColorClosure( *, info):
             color = colors[q % len(colors)]
             colored_term = deepcopy(term)
             colored_term['color'] = color
+            # Don't want duplicate pins
+            if 'pin' in colored_term:
+                del colored_term['pin']
             logger.debug( f"Adding {color}...{term}...{colored_term}") 
             return [term,colored_term]
         else:

--- a/align/primitive/main.py
+++ b/align/primitive/main.py
@@ -263,6 +263,6 @@ def generate_primitive(block_name, primitive, height=28, x_cells=1, y_cells=1, p
     gen_lef.json_lef(outputdir / (block_name + '.json'), block_name, cell_pin, bodyswitch, blockM, uc.pdk)
     with open( outputdir / (block_name + ".json"), "rt") as fp0, \
          open( outputdir / (block_name + ".gds.json"), 'wt') as fp1:
-        gen_gds_json.translate(block_name, '', pinswitch, fp0, fp1, datetime.datetime( 2019, 1, 1, 0, 0, 0), uc.pdk)
+        gen_gds_json.translate(block_name, '', pinswitch, fp0, fp1, datetime.datetime( 2019, 1, 1, 0, 0, 0), uc.pdk, add_text_for_pins=True)
 
     return uc


### PR DESCRIPTION
Fix for issue #540 

- [x] Will enable optionally writing out text in the .gds.json if a rectangle is labeled as a pin in the .json format. Will use the center of that rectangle.

- [ ] Will also need make sure that pins are generated correctly in the .json that comes from importing a PnR design.

