### PR TITLE
[schema] Formalize Ordering & Alignment constraints

### DIFF
--- a/align/schema/checker.py
+++ b/align/schema/checker.py
@@ -1,0 +1,71 @@
+import collections
+from . import types
+import abc
+import random
+import string
+
+import logging
+logger = logging.getLogger(__name__)
+
+try:
+    import z3
+except:
+    z3 = None
+    logger.warning("Could not import z3. ConstraintDB will not look for spec inconsistency.")
+
+class AbstractChecker(abc.ABC):
+    @abc.abstractmethod
+    def append(self, constraint):
+        pass
+
+    @abc.abstractmethod
+    def __init__(self, constraint):
+        pass
+
+class Z3Checker(AbstractChecker):
+
+    def append(self, constraint):
+        if self._validation:
+            self._solver.append(*constraint.check())
+            assert self._solver.check() == z3.sat
+
+    def __init__(self):
+        self._commits = collections.OrderedDict()
+        self._validation = z3 is not None
+        if self._validation:
+            self._solver = z3.Solver()
+
+    def _gen_commit_id(self, nchar=8):
+        id_ = ''.join(random.choices(string.ascii_uppercase + string.digits, k=nchar))
+        return self._gen_commit_id(nchar) if id_ in self._commits else id_
+
+    def checkpoint(self):
+        self._commits[self._gen_commit_id()] = len(self)
+        if self._validation:
+            self._solver.push()
+        return next(reversed(self._commits))
+
+    def _revert(self):
+        if self._validation:
+            self._solver.pop()
+        _, length = self._commits.popitem()
+        del self[length:]
+
+    def revert(self, name=None):
+        assert len(self._commits) > 0, 'Top of scope. Nothing to revert'
+        if name is None or name == next(reversed(self._commits)):
+            self._revert()
+        else:
+            assert name in self._commits
+            self._revert()
+            self.revert(name)
+
+    @classmethod
+    def GenerateVar(cls, name, **fields):
+        if fields:
+            return collections.namedtuple(
+                name,
+                fields.keys(),
+            )(*z3.Ints(' '.join(fields.values())))
+        else:
+            return z3.Int(name)

--- a/align/schema/constraint.py
+++ b/align/schema/constraint.py
@@ -233,18 +233,18 @@ class ConstraintDB(types.List[ConstraintType]):
     #
     # Private attribute affecting class behavior
     #
-    _checker = types.PrivateAttr()
+    _checker = types.PrivateAttr(None)
 
     @types.validate_arguments
     def append(self, constraint: ConstraintType):
-        constraint.check(self._checker)
+        if self._checker:
+            constraint.check(self._checker)
         super().append(constraint)
 
     def __init__(self):
         super().__init__(__root__=[])
-        self._checker = Z3Checker()
-        if not self._checker.enabled:
-            self._checker = None
+        if Z3Checker.enabled:
+            self._checker = Z3Checker()
 
     def checkpoint(self):
         if self._checker:

--- a/align/schema/constraint.py
+++ b/align/schema/constraint.py
@@ -39,10 +39,6 @@ class PlacementConstraint(ConstraintBase):
         each bbox at least
         '''
         assert len(self.instances) >= 1
-        bvars = checker.bbox(self.instances)
-        for b in bvars:
-            checker.append(b.llx < b.urx)
-            checker.append(b.lly < b.ury)
 
 class Order(PlacementConstraint):
     '''
@@ -79,7 +75,7 @@ class Order(PlacementConstraint):
             else:
                 return getattr(b1, f'ur{c}') <= getattr(b2, f'll{c}')
         super().check(checker)
-        bvars = checker.bbox(self.instances)
+        bvars = checker.iter_bbox_vars(self.instances)
         for b1, b2 in itertools.pairwise(bvars):
             if self.direction == 'left_to_right':
                 checker.append(cc(b1, b2, 'x'))
@@ -135,7 +131,7 @@ class Align(PlacementConstraint):
     def check(self, checker):
         super().check(checker)
         assert len(self.instances) >= 2
-        bvars = checker.bbox(self.instances)
+        bvars = checker.iter_bbox_vars(self.instances)
         for b1, b2 in itertools.pairwise(bvars):
             if self.line == 'h_top':
                 checker.append(b1.ury == b2.ury)

--- a/align/schema/constraint.py
+++ b/align/schema/constraint.py
@@ -125,14 +125,16 @@ class Align(ConstraintBase):
 # NOTE: This may even happen automatically if we
 #       use List from .types as baseclass for
 #       ConstraintDB
-class AlignHorizontal(ConstraintBase):
-    blocks : List[str]
+
+class AlignHorizontal(Order, Align):
+    instances : List[str]
     alignment : Optional[Literal['top', 'bottom']]
+    direction: Literal['left->right'] = 'left->right'
 
     def check(self):
-        constraints = Order(instances=self.blocks, direction='left->right').check()
+        constraints = Order.check(self)
         if self.alignment:
-            constraints.extend(Align(instances=self.blocks, alignment=self.alignment).check())
+            constraints.extend(Align.check(self))
         return constraints
 
 ConstraintType=Union[Order, Align, AlignHorizontal]

--- a/align/schema/constraint.py
+++ b/align/schema/constraint.py
@@ -127,15 +127,21 @@ class Align(ConstraintBase):
 #       ConstraintDB
 
 class AlignHorizontal(Order, Align):
+    '''
+    Chain simple constraints together for more complex constraints by
+        assigning default values to certain attributes
+    
+    Note: Compositional check() is automatically constructed if
+        every check() in mro starts with `constraints = super().check()`.
+        (mro is Order, Align, ConstraintBase in this example)
+    Note: If you need to specialize check(), you do have the option 
+        to create a custom `check()` in this class. It shouldn't be
+        needed unless you are adding new semantics
+    '''
     instances : List[str]
     alignment : Optional[Literal['top', 'bottom']]
     direction: Literal['left->right'] = 'left->right'
 
-    def check(self):
-        constraints = Order.check(self)
-        if self.alignment:
-            constraints.extend(Align.check(self))
-        return constraints
 
 ConstraintType=Union[Order, Align, AlignHorizontal]
 

--- a/align/schema/constraint_placement.py
+++ b/align/schema/constraint_placement.py
@@ -1,9 +1,9 @@
 from .types import Union, Optional, Literal, List
-from .constraint import ConstraintBase
+from .constraint import PlacementConstraint
 from pydantic import validator
 
 
-class Alignment(ConstraintBase):
+class Alignment(PlacementConstraint):
     constraint_name: Literal["alignment"]
     instances: List[str]
     direction: Optional[Literal['horizontal', 'vertical']] = 'horizontal'
@@ -22,7 +22,7 @@ class Alignment(ConstraintBase):
         pass
 
 
-class Generator(ConstraintBase):
+class Generator(PlacementConstraint):
     constraint_name: Literal["generator"]
     instances: List[str]
     style: Optional[Literal['cc', 'id']] = 'cc'
@@ -34,7 +34,7 @@ class Generator(ConstraintBase):
         pass
 
 
-class Orientation(ConstraintBase):
+class Orientation(PlacementConstraint):
     constraint_name: Literal["orientation"]
     instances: List[str]
     flip_x: Optional[bool] = False
@@ -44,7 +44,7 @@ class Orientation(ConstraintBase):
         pass
 
 
-class Boundary(ConstraintBase):
+class Boundary(PlacementConstraint):
     constraint_name: Literal["boundary"]
     subcircuits: List[str]
     height_min: Optional[float] = None
@@ -75,10 +75,10 @@ class Boundary(ConstraintBase):
         pass
 
 
-class ConstraintsPlacement(ConstraintBase):
+class ConstraintsPlacement(PlacementConstraint):
     constraints: List[Union[Alignment, Generator, Orientation, Boundary]]
 
     def check(self):
         pass
 
-# TODO: Enhance ConstraintBase to handle list of lists (e.g. symmetry)
+# TODO: Enhance PlacementConstraint to handle list of lists (e.g. symmetry)

--- a/align/schema/constraint_placement.py
+++ b/align/schema/constraint_placement.py
@@ -4,7 +4,7 @@ from pydantic import validator
 
 
 class Alignment(PlacementConstraint):
-    constraint_name: Literal["alignment"]
+    constraint: Literal["alignment"]
     instances: List[str]
     direction: Optional[Literal['horizontal', 'vertical']] = 'horizontal'
     edge: Optional[Literal['top', 'center', 'bottom', 'left', 'right']] = 'bottom'
@@ -23,7 +23,7 @@ class Alignment(PlacementConstraint):
 
 
 class Generator(PlacementConstraint):
-    constraint_name: Literal["generator"]
+    constraint: Literal["generator"]
     instances: List[str]
     style: Optional[Literal['cc', 'id']] = 'cc'
     alias: Optional[str]
@@ -35,7 +35,7 @@ class Generator(PlacementConstraint):
 
 
 class Orientation(PlacementConstraint):
-    constraint_name: Literal["orientation"]
+    constraint: Literal["orientation"]
     instances: List[str]
     flip_x: Optional[bool] = False
     flip_y: Optional[bool] = False
@@ -45,7 +45,7 @@ class Orientation(PlacementConstraint):
 
 
 class Boundary(PlacementConstraint):
-    constraint_name: Literal["boundary"]
+    constraint: Literal["boundary"]
     subcircuits: List[str]
     height_min: Optional[float] = None
     height_max: Optional[float] = None

--- a/align/schema/types.py
+++ b/align/schema/types.py
@@ -82,12 +82,13 @@ except:
 # Pass through directly from pydantic
 from pydantic import \
     validator, \
+    root_validator, \
     validate_arguments, \
     PrivateAttr
 
 __all__ = [
     'BaseModel', 'List', 'Dict',
-    'validator', 'validate_arguments',
+    'validator', 'root_validator', 'validate_arguments',
     'Optional', 'Union',
     'NamedTuple', 'Literal',
     'ClassVar', 'PrivateAttr'

--- a/align/schema/types.py
+++ b/align/schema/types.py
@@ -16,13 +16,14 @@ class List(pydantic.generics.GenericModel, typing.Generic[DataT]):
     __root__: typing.Sequence[DataT]
 
     class Config:
+        validate_assignment = True
+        extra = 'forbid'
         copy_on_model_validation = False
-
-    @pydantic.validate_arguments
+        allow_mutation = False
+        
     def append(self, data: DataT):
         return self.__root__.append(data)
 
-    @pydantic.validate_arguments
     def remove(self, data: DataT):
         return self.__root__.remove(data)
 
@@ -45,7 +46,10 @@ class Dict(pydantic.generics.GenericModel, typing.Generic[KeyT,DataT]):
     __root__: typing.Mapping[KeyT, DataT]
 
     class Config:
+        validate_assignment = True
+        extra = 'forbid'
         copy_on_model_validation = False
+        allow_mutation = False
 
     def items(self):
         return self.__root__.items()

--- a/tests/schema/test_checker.py
+++ b/tests/schema/test_checker.py
@@ -12,7 +12,7 @@ def test_single_bbox_checking(checker):
     with pytest.raises(AssertionError):
         checker.append(b1.urx < b1.llx)
 
-@pytest.mark.skipif(not Z3Checker.enabled, reason="requires z3")
+@pytest.mark.skipif(not Z3Checker.enabled, reason="Couldn't import Z3")
 def test_multi_bbox_checking(checker):
     b1, b2 = checker.iter_bbox_vars(['M1', 'M2'])
     checker.append(b1.llx < b1.urx)

--- a/tests/schema/test_checker.py
+++ b/tests/schema/test_checker.py
@@ -7,14 +7,14 @@ def checker():
 
 @pytest.mark.skipif(not Z3Checker.enabled, reason="requires z3")
 def test_single_bbox_checking(checker):
-    b1 = checker.bbox('M1')[0]
+    b1 = checker.bbox_vars('M1')
     checker.append(b1.llx < b1.urx)
     with pytest.raises(AssertionError):
         checker.append(b1.urx < b1.llx)
 
 @pytest.mark.skipif(not Z3Checker.enabled, reason="requires z3")
 def test_multi_bbox_checking(checker):
-    b1, b2 = checker.bbox('M1', 'M2')
+    b1, b2 = checker.iter_bbox_vars(['M1', 'M2'])
     checker.append(b1.llx < b1.urx)
     checker.append(b2.llx < b2.urx)
     checker.append(b2.urx <= b1.llx)

--- a/tests/schema/test_checker.py
+++ b/tests/schema/test_checker.py
@@ -1,0 +1,22 @@
+import pytest
+from align.schema.checker import Z3Checker
+
+@pytest.fixture
+def checker():
+    return Z3Checker()
+
+@pytest.mark.skipif(not Z3Checker.enabled, reason="requires z3")
+def test_single_bbox_checking(checker):
+    b1 = checker.bbox('M1')[0]
+    checker.append(b1.llx < b1.urx)
+    with pytest.raises(AssertionError):
+        checker.append(b1.urx < b1.llx)
+
+@pytest.mark.skipif(not Z3Checker.enabled, reason="requires z3")
+def test_multi_bbox_checking(checker):
+    b1, b2 = checker.bbox('M1', 'M2')
+    checker.append(b1.llx < b1.urx)
+    checker.append(b2.llx < b2.urx)
+    checker.append(b2.urx <= b1.llx)
+    with pytest.raises(AssertionError):
+        checker.append(b1.urx <= b1.llx)

--- a/tests/schema/test_constraint.py
+++ b/tests/schema/test_constraint.py
@@ -74,22 +74,23 @@ def test_AlignInOrder_order_checking(solver):
     (See test_ConstraintDB_checking() for example)
     '''
     x = constraint.AlignInOrder(instances=['M1', 'M2', 'M3'], direction='horizontal')
-    print(x)
     solver.append(*x.check())
     assert solver.check() == z3.sat
     x = constraint.AlignInOrder(instances=['M4', 'M5'], line='bottom')
-    print(x)
     solver.append(*x.check())
     assert solver.check() == z3.sat
     x = constraint.AlignInOrder(instances=['M3', 'M2'], line='bottom')
-    print(x)
     solver.append(*x.check())
     with pytest.raises(AssertionError):
         assert solver.check() == z3.sat
 
 def test_ConstraintDB_inputapi(db):
+    class Garbage(constraint.PlacementConstraint):
+        test: str = 'hello'
+        def check(self):
+            pass
     with pytest.raises(Exception):
-        db.append('garbage')
+        db.append(Garbage())
 
 @pytest.mark.skipif(z3 is None, reason="requires z3")
 def test_ConstraintDB_checking(db):

--- a/tests/schema/test_constraint.py
+++ b/tests/schema/test_constraint.py
@@ -16,17 +16,17 @@ def db():
 
 @pytest.mark.skipif(z3 is None, reason="requires z3")
 def test_Order_input_sanitation(solver):
-    x = constraint.Order(direction='left->right', instances=['M1', 'M2'])
-    x = constraint.Order(direction='left->right', instances=['M1', 'M2', 'M3'])
+    x = constraint.Order(direction='left_to_right', instances=['M1', 'M2'])
+    x = constraint.Order(direction='left_to_right', instances=['M1', 'M2', 'M3'])
     with pytest.raises(Exception):
         x = constraint.Order(direction='lefta->rightb', instances=['M1', 'M2', 'M3'])
 
 @pytest.mark.skipif(z3 is None, reason="requires z3")
 def test_Order_nblock_checking(solver):
-    x = constraint.Order(direction='left->right', instances=[])
+    x = constraint.Order(direction='left_to_right', instances=[])
     with pytest.raises(AssertionError):
         x.check()
-    x = constraint.Order(direction='left->right', instances=['M1'])
+    x = constraint.Order(direction='left_to_right', instances=['M1'])
     with pytest.raises(AssertionError):
         x.check()
 
@@ -38,48 +38,51 @@ def test_Order_z3_checking(solver):
     Please use ConstraintDB to manage constraints
     (See test_ConstraintDB_checking() for example)
     '''
-    x = constraint.Order(direction='left->right', instances=['M1', 'M2', 'M3'])
+    x = constraint.Order(direction='left_to_right', instances=['M1', 'M2', 'M3'])
     solver.append(*x.check())
     assert solver.check() == z3.sat
-    x = constraint.Order(direction='left->right', instances=['M4', 'M5'])
+    x = constraint.Order(direction='left_to_right', instances=['M4', 'M5'])
     solver.append(*x.check())
     assert solver.check() == z3.sat
-    x = constraint.Order(direction='left->right', instances=['M3', 'M2'])
+    x = constraint.Order(direction='left_to_right', instances=['M3', 'M2'])
     solver.append(*x.check())
     with pytest.raises(AssertionError):
         assert solver.check() == z3.sat
 
 @pytest.mark.skipif(z3 is None, reason="requires z3")
-def test_AlignHorizontal_input_sanitation(solver):
-    x = constraint.AlignHorizontal(instances=['M1', 'M2'], line='top')
-    x = constraint.AlignHorizontal(instances=['M1', 'M2', 'M3'], line='top')
+def test_AlignInOrder_input_sanitation(solver):
+    x = constraint.AlignInOrder(instances=['M1', 'M2'], line='top')
+    x = constraint.AlignInOrder(instances=['M1', 'M2', 'M3'], line='top')
     with pytest.raises(Exception):
-        x = constraint.AlignHorizontal(instances=['M1', 'M2', 'M3'], line='garbage')
+        x = constraint.AlignInOrder(instances=['M1', 'M2', 'M3'], line='garbage')
 
 @pytest.mark.skipif(z3 is None, reason="requires z3")
-def test_AlignHorizontal_nblock_checking(solver):
-    x = constraint.AlignHorizontal(instances=[], line='top')
+def test_AlignInOrder_nblock_checking(solver):
+    x = constraint.AlignInOrder(instances=[], line='top')
     with pytest.raises(AssertionError):
         x.check()
-    x = constraint.AlignHorizontal(instances=['M1'], line='top')
+    x = constraint.AlignInOrder(instances=['M1'], line='top')
     with pytest.raises(AssertionError):
         x.check()
 
 @pytest.mark.skipif(z3 is None, reason="requires z3")
-def test_AlignHorizontal_order_checking(solver):
+def test_AlignInOrder_order_checking(solver):
     '''
     This is just a unittest of generated constraints
 
     Please use ConstraintDB to manage constraints
     (See test_ConstraintDB_checking() for example)
     '''
-    x = constraint.AlignHorizontal(instances=['M1', 'M2', 'M3'])
+    x = constraint.AlignInOrder(instances=['M1', 'M2', 'M3'], direction='horizontal')
+    print(x)
     solver.append(*x.check())
     assert solver.check() == z3.sat
-    x = constraint.AlignHorizontal(instances=['M4', 'M5'], line='bottom')
+    x = constraint.AlignInOrder(instances=['M4', 'M5'], line='bottom')
+    print(x)
     solver.append(*x.check())
     assert solver.check() == z3.sat
-    x = constraint.AlignHorizontal(instances=['M3', 'M2'], line='bottom')
+    x = constraint.AlignInOrder(instances=['M3', 'M2'], line='bottom')
+    print(x)
     solver.append(*x.check())
     with pytest.raises(AssertionError):
         assert solver.check() == z3.sat
@@ -90,10 +93,10 @@ def test_ConstraintDB_inputapi(db):
 
 @pytest.mark.skipif(z3 is None, reason="requires z3")
 def test_ConstraintDB_checking(db):
-    db.append(constraint.Order(direction='left->right', instances=['M1', 'M2', 'M3']))
-    db.append(constraint.Order(direction='left->right', instances=['M4', 'M5']))
+    db.append(constraint.Order(direction='left_to_right', instances=['M1', 'M2', 'M3']))
+    db.append(constraint.Order(direction='left_to_right', instances=['M4', 'M5']))
     with pytest.raises(AssertionError):
-        db.append(constraint.Order(direction='left->right', instances=['M3', 'M2']))
+        db.append(constraint.Order(direction='left_to_right', instances=['M3', 'M2']))
 
 @pytest.mark.skipif(z3 is None, reason="requires z3")
 def test_ConstraintDB_incremental_checking(db):
@@ -103,25 +106,25 @@ def test_ConstraintDB_incremental_checking(db):
     is an overhead so use sparingly
     '''
     # Experiment 1 : Success
-    db.append(constraint.Order(direction='left->right', instances=['M1', 'M2', 'M3']))
+    db.append(constraint.Order(direction='left_to_right', instances=['M1', 'M2', 'M3']))
     db.checkpoint()
     # Experiment 2 : Failure
     with pytest.raises(AssertionError):
-        db.append(constraint.Order(direction='left->right', instances=['M3', 'M2']))
+        db.append(constraint.Order(direction='left_to_right', instances=['M3', 'M2']))
     db.revert()
     # Experiment 3 : Success
-    db.append(constraint.Order(direction='left->right', instances=['M4', 'M5']))
+    db.append(constraint.Order(direction='left_to_right', instances=['M4', 'M5']))
     db.checkpoint()
     # Experiment 4: Failure
     with pytest.raises(AssertionError):
-        db.append(constraint.Order(direction='left->right', instances=['M3', 'M2']))
+        db.append(constraint.Order(direction='left_to_right', instances=['M3', 'M2']))
     db.revert()
     # Experiment 5: Success
-    db.append(constraint.Order(direction='left->right', instances=['M2', 'M5']))
+    db.append(constraint.Order(direction='left_to_right', instances=['M2', 'M5']))
     # Experiments Completed ! Final Constraints:
-    # constraint.Order(direction='left->right', instances=['M1', 'M2', 'M3'])
-    # constraint.Order(direction='left->right', instances=['M4', 'M5'])
-    # constraint.Order(direction='left->right', instances=['M2', 'M5'])
+    # constraint.Order(direction='left_to_right', instances=['M1', 'M2', 'M3'])
+    # constraint.Order(direction='left_to_right', instances=['M4', 'M5'])
+    # constraint.Order(direction='left_to_right', instances=['M2', 'M5'])
 
 def test_ConstraintDB_nonincremental_revert(db):
     '''
@@ -129,11 +132,11 @@ def test_ConstraintDB_nonincremental_revert(db):
     checkpoint() by name, needing to unroll multiple
     checkpoints can indicate suboptimal compiler design
     '''
-    db.append(constraint.Order(direction='left->right', instances=['M1', 'M2']))
+    db.append(constraint.Order(direction='left_to_right', instances=['M1', 'M2']))
     idx = db.checkpoint()
-    db.append(constraint.Order(direction='left->right', instances=['M1', 'M3']))
+    db.append(constraint.Order(direction='left_to_right', instances=['M1', 'M3']))
     db.checkpoint()
-    db.append(constraint.Order(direction='left->right', instances=['M2', 'M3']))
+    db.append(constraint.Order(direction='left_to_right', instances=['M2', 'M3']))
     db.checkpoint()
     db.revert(idx)
     assert len(db) == 1
@@ -147,5 +150,5 @@ def test_ConstraintDB_permissive():
     NOT RECOMMENDED !! DO NOT DO THIS !!!
     '''
     db = constraint.ConstraintDB(validation=False)
-    db.append(constraint.Order(direction='left->right', instances=['M1', 'M2']))
-    db.append(constraint.Order(direction='left->right', instances=['M2', 'M1']))
+    db.append(constraint.Order(direction='left_to_right', instances=['M1', 'M2']))
+    db.append(constraint.Order(direction='left_to_right', instances=['M2', 'M1']))

--- a/tests/schema/test_constraint.py
+++ b/tests/schema/test_constraint.py
@@ -36,7 +36,7 @@ def test_ConstraintDB_inputapi(db):
     with pytest.raises(Exception):
         db.append(Garbage())
 
-@pytest.mark.skipif(not Z3Checker.enabled, reason="requires z3")
+@pytest.mark.skipif(not Z3Checker.enabled, reason="Couldn't import Z3")
 def test_Order_smt_checking(checker):
     x = constraint.Order(direction='left_to_right', instances=['M1', 'M2', 'M3'])
     x.check(checker)
@@ -46,7 +46,7 @@ def test_Order_smt_checking(checker):
     with pytest.raises(AssertionError):
         x.check(checker)
 
-@pytest.mark.skipif(not Z3Checker.enabled, reason="test requires z3")
+@pytest.mark.skipif(not Z3Checker.enabled, reason="Couldn't import Z3")
 def test_Order_db_append(db):
     db.append(constraint.Order(direction='left_to_right', instances=['M1', 'M2', 'M3']))
     db.append(constraint.Order(direction='left_to_right', instances=['M4', 'M5']))
@@ -59,14 +59,14 @@ def test_AlignInOrder_input_sanitation():
     with pytest.raises(Exception):
         x = constraint.AlignInOrder(instances=['M1', 'M2', 'M3'], line='garbage')
 
-@pytest.mark.skipif(not Z3Checker.enabled, reason="test requires z3")
+@pytest.mark.skipif(not Z3Checker.enabled, reason="Couldn't import Z3")
 def test_AlignInOrder_smt_checking(db):
     db.append(constraint.AlignInOrder(instances=['M1', 'M2', 'M3'], direction='horizontal'))
     db.append(constraint.AlignInOrder(instances=['M4', 'M5'], line='bottom'))
     with pytest.raises(AssertionError):
         db.append(constraint.AlignInOrder(instances=['M3', 'M2'], line='bottom'))
 
-@pytest.mark.skipif(not Z3Checker.enabled, reason="test requires z3")
+@pytest.mark.skipif(not Z3Checker.enabled, reason="Couldn't import Z3")
 def test_ConstraintDB_incremental_checking(db):
     '''
     ConstraintDB can be used to run experiments

--- a/tests/schema/test_constraint.py
+++ b/tests/schema/test_constraint.py
@@ -51,17 +51,17 @@ def test_Order_z3_checking(solver):
 
 @pytest.mark.skipif(z3 is None, reason="requires z3")
 def test_AlignHorizontal_input_sanitation(solver):
-    x = constraint.AlignHorizontal(instances=['M1', 'M2'], alignment='top')
-    x = constraint.AlignHorizontal(instances=['M1', 'M2', 'M3'], alignment='top')
+    x = constraint.AlignHorizontal(instances=['M1', 'M2'], line='top')
+    x = constraint.AlignHorizontal(instances=['M1', 'M2', 'M3'], line='top')
     with pytest.raises(Exception):
-        x = constraint.AlignHorizontal(instances=['M1', 'M2', 'M3'], alignment='garbage')
+        x = constraint.AlignHorizontal(instances=['M1', 'M2', 'M3'], line='garbage')
 
 @pytest.mark.skipif(z3 is None, reason="requires z3")
 def test_AlignHorizontal_nblock_checking(solver):
-    x = constraint.AlignHorizontal(instances=[], alignment='top')
+    x = constraint.AlignHorizontal(instances=[], line='top')
     with pytest.raises(AssertionError):
         x.check()
-    x = constraint.AlignHorizontal(instances=['M1'], alignment='top')
+    x = constraint.AlignHorizontal(instances=['M1'], line='top')
     with pytest.raises(AssertionError):
         x.check()
 
@@ -76,10 +76,10 @@ def test_AlignHorizontal_order_checking(solver):
     x = constraint.AlignHorizontal(instances=['M1', 'M2', 'M3'])
     solver.append(*x.check())
     assert solver.check() == z3.sat
-    x = constraint.AlignHorizontal(instances=['M4', 'M5'], alignment='bottom')
+    x = constraint.AlignHorizontal(instances=['M4', 'M5'], line='bottom')
     solver.append(*x.check())
     assert solver.check() == z3.sat
-    x = constraint.AlignHorizontal(instances=['M3', 'M2'], alignment='bottom')
+    x = constraint.AlignHorizontal(instances=['M3', 'M2'], line='bottom')
     solver.append(*x.check())
     with pytest.raises(AssertionError):
         assert solver.check() == z3.sat

--- a/tests/schema/test_constraint.py
+++ b/tests/schema/test_constraint.py
@@ -51,17 +51,17 @@ def test_Order_z3_checking(solver):
 
 @pytest.mark.skipif(z3 is None, reason="requires z3")
 def test_AlignHorizontal_input_sanitation(solver):
-    x = constraint.AlignHorizontal(blocks=['M1', 'M2'], alignment='top')
-    x = constraint.AlignHorizontal(blocks=['M1', 'M2', 'M3'], alignment='top')
+    x = constraint.AlignHorizontal(instances=['M1', 'M2'], alignment='top')
+    x = constraint.AlignHorizontal(instances=['M1', 'M2', 'M3'], alignment='top')
     with pytest.raises(Exception):
-        x = constraint.AlignHorizontal(blocks=['M1', 'M2', 'M3'], alignment='garbage')
+        x = constraint.AlignHorizontal(instances=['M1', 'M2', 'M3'], alignment='garbage')
 
 @pytest.mark.skipif(z3 is None, reason="requires z3")
 def test_AlignHorizontal_nblock_checking(solver):
-    x = constraint.AlignHorizontal(blocks=[], alignment='top')
+    x = constraint.AlignHorizontal(instances=[], alignment='top')
     with pytest.raises(AssertionError):
         x.check()
-    x = constraint.AlignHorizontal(blocks=['M1'], alignment='top')
+    x = constraint.AlignHorizontal(instances=['M1'], alignment='top')
     with pytest.raises(AssertionError):
         x.check()
 
@@ -73,13 +73,13 @@ def test_AlignHorizontal_order_checking(solver):
     Please use ConstraintDB to manage constraints
     (See test_ConstraintDB_checking() for example)
     '''
-    x = constraint.AlignHorizontal(blocks=['M1', 'M2', 'M3'])
+    x = constraint.AlignHorizontal(instances=['M1', 'M2', 'M3'])
     solver.append(*x.check())
     assert solver.check() == z3.sat
-    x = constraint.AlignHorizontal(blocks=['M4', 'M5'], alignment='bottom')
+    x = constraint.AlignHorizontal(instances=['M4', 'M5'], alignment='bottom')
     solver.append(*x.check())
     assert solver.check() == z3.sat
-    x = constraint.AlignHorizontal(blocks=['M3', 'M2'], alignment='bottom')
+    x = constraint.AlignHorizontal(instances=['M3', 'M2'], alignment='bottom')
     solver.append(*x.check())
     with pytest.raises(AssertionError):
         assert solver.check() == z3.sat

--- a/tests/schema/test_constraint.py
+++ b/tests/schema/test_constraint.py
@@ -14,15 +14,17 @@ def solver():
 def db():
     return constraint.ConstraintDB()
 
-@pytest.mark.skipif(z3 is None, reason="requires z3")
-def test_Order_input_sanitation(solver):
+def test_Order_input_sanitation():
     x = constraint.Order(direction='left_to_right', instances=['M1', 'M2'])
     x = constraint.Order(direction='left_to_right', instances=['M1', 'M2', 'M3'])
     with pytest.raises(Exception):
-        x = constraint.Order(direction='lefta->rightb', instances=['M1', 'M2', 'M3'])
+        x = constraint.Order(direction='lefta_to_rightb', instances=['M1', 'M2', 'M3'])
 
-@pytest.mark.skipif(z3 is None, reason="requires z3")
-def test_Order_nblock_checking(solver):
+def test_Order_constraint():
+    x = constraint.Order(direction='left_to_right', instances=['M1', 'M2'])
+    assert x.constraint == 'order'
+
+def test_Order_nblock_checking():
     x = constraint.Order(direction='left_to_right', instances=[])
     with pytest.raises(AssertionError):
         x.check()

--- a/tests/schema/test_constraint.py
+++ b/tests/schema/test_constraint.py
@@ -146,12 +146,3 @@ def test_ConstraintDB_nonincremental_revert(db):
     assert len(db._commits) == 0
     if db._validation:
         assert 'M3' not in str(db._solver)
-
-def test_ConstraintDB_permissive():
-    '''
-    Check that it is possible to turn validation OFF
-    NOT RECOMMENDED !! DO NOT DO THIS !!!
-    '''
-    db = constraint.ConstraintDB(validation=False)
-    db.append(constraint.Order(direction='left_to_right', instances=['M1', 'M2']))
-    db.append(constraint.Order(direction='left_to_right', instances=['M2', 'M1']))

--- a/tests/schema/test_constraint.py
+++ b/tests/schema/test_constraint.py
@@ -1,18 +1,14 @@
 import pytest
 from align.schema import constraint
-
-try:
-    import z3
-except:
-    z3 = None
-
-@pytest.fixture
-def solver():
-    return z3.Solver()
+from align.schema.checker import Z3Checker
 
 @pytest.fixture
 def db():
     return constraint.ConstraintDB()
+
+@pytest.fixture
+def checker():
+    return Z3Checker()
 
 def test_Order_input_sanitation():
     x = constraint.Order(direction='left_to_right', instances=['M1', 'M2'])
@@ -20,71 +16,17 @@ def test_Order_input_sanitation():
     with pytest.raises(Exception):
         x = constraint.Order(direction='lefta_to_rightb', instances=['M1', 'M2', 'M3'])
 
-def test_Order_constraint():
+def test_Order_constraintname():
     x = constraint.Order(direction='left_to_right', instances=['M1', 'M2'])
     assert x.constraint == 'order'
 
 def test_Order_nblock_checking():
     x = constraint.Order(direction='left_to_right', instances=[])
     with pytest.raises(AssertionError):
-        x.check()
+        x.check(None)
     x = constraint.Order(direction='left_to_right', instances=['M1'])
     with pytest.raises(AssertionError):
-        x.check()
-
-@pytest.mark.skipif(z3 is None, reason="requires z3")
-def test_Order_z3_checking(solver):
-    '''
-    This is just a unittest of generated constraints
-
-    Please use ConstraintDB to manage constraints
-    (See test_ConstraintDB_checking() for example)
-    '''
-    x = constraint.Order(direction='left_to_right', instances=['M1', 'M2', 'M3'])
-    solver.append(*x.check())
-    assert solver.check() == z3.sat
-    x = constraint.Order(direction='left_to_right', instances=['M4', 'M5'])
-    solver.append(*x.check())
-    assert solver.check() == z3.sat
-    x = constraint.Order(direction='left_to_right', instances=['M3', 'M2'])
-    solver.append(*x.check())
-    with pytest.raises(AssertionError):
-        assert solver.check() == z3.sat
-
-@pytest.mark.skipif(z3 is None, reason="requires z3")
-def test_AlignInOrder_input_sanitation(solver):
-    x = constraint.AlignInOrder(instances=['M1', 'M2'], line='top')
-    x = constraint.AlignInOrder(instances=['M1', 'M2', 'M3'], line='top')
-    with pytest.raises(Exception):
-        x = constraint.AlignInOrder(instances=['M1', 'M2', 'M3'], line='garbage')
-
-@pytest.mark.skipif(z3 is None, reason="requires z3")
-def test_AlignInOrder_nblock_checking(solver):
-    x = constraint.AlignInOrder(instances=[], line='top')
-    with pytest.raises(AssertionError):
-        x.check()
-    x = constraint.AlignInOrder(instances=['M1'], line='top')
-    with pytest.raises(AssertionError):
-        x.check()
-
-@pytest.mark.skipif(z3 is None, reason="requires z3")
-def test_AlignInOrder_order_checking(solver):
-    '''
-    This is just a unittest of generated constraints
-
-    Please use ConstraintDB to manage constraints
-    (See test_ConstraintDB_checking() for example)
-    '''
-    x = constraint.AlignInOrder(instances=['M1', 'M2', 'M3'], direction='horizontal')
-    solver.append(*x.check())
-    assert solver.check() == z3.sat
-    x = constraint.AlignInOrder(instances=['M4', 'M5'], line='bottom')
-    solver.append(*x.check())
-    assert solver.check() == z3.sat
-    x = constraint.AlignInOrder(instances=['M3', 'M2'], line='bottom')
-    solver.append(*x.check())
-    with pytest.raises(AssertionError):
-        assert solver.check() == z3.sat
+        x.check(None)
 
 def test_ConstraintDB_inputapi(db):
     class Garbage(constraint.PlacementConstraint):
@@ -94,14 +36,37 @@ def test_ConstraintDB_inputapi(db):
     with pytest.raises(Exception):
         db.append(Garbage())
 
-@pytest.mark.skipif(z3 is None, reason="requires z3")
-def test_ConstraintDB_checking(db):
+@pytest.mark.skipif(not Z3Checker.enabled, reason="requires z3")
+def test_Order_smt_checking(checker):
+    x = constraint.Order(direction='left_to_right', instances=['M1', 'M2', 'M3'])
+    x.check(checker)
+    x = constraint.Order(direction='left_to_right', instances=['M4', 'M5'])
+    x.check(checker)
+    x = constraint.Order(direction='left_to_right', instances=['M3', 'M2'])
+    with pytest.raises(AssertionError):
+        x.check(checker)
+
+@pytest.mark.skipif(not Z3Checker.enabled, reason="test requires z3")
+def test_Order_db_append(db):
     db.append(constraint.Order(direction='left_to_right', instances=['M1', 'M2', 'M3']))
     db.append(constraint.Order(direction='left_to_right', instances=['M4', 'M5']))
     with pytest.raises(AssertionError):
         db.append(constraint.Order(direction='left_to_right', instances=['M3', 'M2']))
 
-@pytest.mark.skipif(z3 is None, reason="requires z3")
+def test_AlignInOrder_input_sanitation():
+    x = constraint.AlignInOrder(instances=['M1', 'M2'], line='top')
+    x = constraint.AlignInOrder(instances=['M1', 'M2', 'M3'], line='top')
+    with pytest.raises(Exception):
+        x = constraint.AlignInOrder(instances=['M1', 'M2', 'M3'], line='garbage')
+
+@pytest.mark.skipif(not Z3Checker.enabled, reason="test requires z3")
+def test_AlignInOrder_smt_checking(db):
+    db.append(constraint.AlignInOrder(instances=['M1', 'M2', 'M3'], direction='horizontal'))
+    db.append(constraint.AlignInOrder(instances=['M4', 'M5'], line='bottom'))
+    with pytest.raises(AssertionError):
+        db.append(constraint.AlignInOrder(instances=['M3', 'M2'], line='bottom'))
+
+@pytest.mark.skipif(not Z3Checker.enabled, reason="test requires z3")
 def test_ConstraintDB_incremental_checking(db):
     '''
     ConstraintDB can be used to run experiments
@@ -144,5 +109,5 @@ def test_ConstraintDB_nonincremental_revert(db):
     db.revert(idx)
     assert len(db) == 1
     assert len(db._commits) == 0
-    if db._validation:
-        assert 'M3' not in str(db._solver)
+    if db._checker:
+        assert 'M3' not in str(db._checker._solver)

--- a/tests/schema/test_constraint_placement.py
+++ b/tests/schema/test_constraint_placement.py
@@ -10,23 +10,23 @@ def test_one():
 {
     "constraints": [
       {
-        "constraint_name": "alignment",
+        "constraint": "alignment",
         "instances": ["i0"],
         "direction": "horizontal",
         "edge": "bottom"
       },
       {
-        "constraint_name": "generator",
+        "constraint": "generator",
         "instances": ["i1", "i2"],
         "style": "cc"
       },
       {
-        "constraint_name": "orientation",
+        "constraint": "orientation",
         "instances": ["i2"],
         "flip_y": true
       },
       {
-        "constraint_name": "boundary",
+        "constraint": "boundary",
         "subcircuits": ["subcircuit_a"],
         "aspect_ratio_min": 0.3,
         "aspect_ratio_max": 0.6
@@ -44,13 +44,13 @@ def test_two():
 {
     "constraints": [
       {
-        "constraint_name": "alignment",
+        "constraint": "alignment",
         "instances": ["i0, i1"],
         "direction": "horizontal",
         "edge": "nowhere"
       },
       {
-        "constraint_name": "orientation",
+        "constraint": "orientation",
         "instances": ["i1"],
         "flip_y": true
       }

--- a/tests/schema/test_parser.py
+++ b/tests/schema/test_parser.py
@@ -38,11 +38,11 @@ def setup_annotation():
 * This is one awesome diffamp
 
 * Subcircuit constraints can be directly specified here
-* @: AlignHorizontal(blocks=['R2', 'M1'], alignment='top')
-* @: AlignHorizontal(blocks=['M1', 'M2'], alignment='bottom')
+* @: Order(instances=['R2', 'M1'], direction='left->right')
+* @: Order(instances=['M1', 'M2'], direction='left->right')
 
 R1 vcc outplus 1e4;  Or even here! Amazing !
-R2 vcc outminus 1e4; @: AlignHorizontal(blocks=['R1', 'R2'], alignment='center')
+R2 vcc outminus 1e4; @: Order(instances=['R1', 'R2'], direction='left->right')
 M1 outplus inplus src 0 NMOS   l=0.014u nfin=2
 M2 outminus inminus src 0 NMOS l=0.014u nfin=2
 
@@ -139,7 +139,7 @@ def test_parser_annotation(setup_annotation, parser):
     assert [x.name for x in parser.library['DIFFAMP'].elements] == ['R1', 'R2', 'M1', 'M2'], parser.library['DIFFAMP'].elements
     assert len(parser.library['DIFFAMP'].nets) == 7, parser.library['DIFFAMP'].nets
     assert parser.library['DIFFAMP'].nets == ['VCC', 'OUTPLUS', 'OUTMINUS', 'INPLUS', 'SRC', '0', 'INMINUS'], parser.circuit.nets
-    assert len(parser.library['DIFFAMP'].constraints) == 2
+    assert len(parser.library['DIFFAMP'].constraints) == 3
 
 def test_subckt_decl(setup_realistic, parser):
     parser.parse(f'''

--- a/tests/schema/test_parser.py
+++ b/tests/schema/test_parser.py
@@ -38,11 +38,11 @@ def setup_annotation():
 * This is one awesome diffamp
 
 * Subcircuit constraints can be directly specified here
-* @: Order(instances=['R2', 'M1'], direction='left->right')
-* @: Order(instances=['M1', 'M2'], direction='left->right')
+* @: Order(instances=['R2', 'M1'], direction='left_to_right')
+* @: Order(instances=['M1', 'M2'], direction='left_to_right')
 
 R1 vcc outplus 1e4;  Or even here! Amazing !
-R2 vcc outminus 1e4; @: Order(instances=['R1', 'R2'], direction='left->right')
+R2 vcc outminus 1e4; @: Order(instances=['R1', 'R2'], direction='left_to_right')
 M1 outplus inplus src 0 NMOS   l=0.014u nfin=2
 M2 outminus inminus src 0 NMOS l=0.014u nfin=2
 


### PR DESCRIPTION
This PR aims to:
- [x] Formalize internal (tool-facing) DSL for `Order` and `Align`. 
   - [x] Add `abut` flag to `Order` to handle abutment as well
   - [x] Review how this overlaps with #594 
- [x] Demonstrate compositional constraints by creating a more user-friendly AlignInOrder constraint
- [x] Add internal constraints to ensure Bboxes do not overlap
   - [x] Cache bbox variables to avoid generating redundant internal constraints
- [ ] Create `Engine` framework to stitch together workflow
   - [ ] Do we need to annotate predicates to figure out if an engine is callable?
   - [ ] Do we need to annotate consequents to figure out what properties we can verify?
