### PR TITLE
READY: Generate Intel ADR collaterals from the new PDK schema

### DIFF
--- a/align/pdk/finfet/canvas.py
+++ b/align/pdk/finfet/canvas.py
@@ -4,7 +4,7 @@ import logging
 from align.cell_fabric.canvas import Canvas
 from align.cell_fabric import Wire, Via, Region
 from align.cell_fabric import CenterLineGrid, EnclosureGrid, SingleGrid
-from align.schema.pdk import LayerMetal, LayerVia, LayerViaSet, PDK
+from align.schema.pdk import LayerMetal, LayerVia, PDK
 from align.cell_fabric import Pdk
 
 logger = logging.getLogger(__name__)
@@ -29,10 +29,10 @@ class CanvasPDK(Canvas):
     def _add_generators(self):
         # This PDK only has metal stack
         for layer_name, layer in self.pdk_v2.layers.items():
-            if layer_name.startswith('M'):
+            if isinstance(layer, LayerMetal):
                 self._add_metal_generator(layer)
-            elif layer_name.startswith('V'):
-                self._add_via_generator(layer.default_via)
+            elif isinstance(layer, LayerVia):
+                self._add_via_generator(layer)
 
         v_grid_pitch = sum(self.pdk_v2.layers['M1'].width) + sum(self.pdk_v2.layers['M1'].space)
         h_grid_pitch = sum(self.pdk_v2.layers['M2'].width) + sum(self.pdk_v2.layers['M2'].space)
@@ -127,36 +127,11 @@ class CanvasPDK(Canvas):
             min_length=2160, min_end_to_end=1080,
             offset=0, width=[400], space=[500], stop_pitch=1080, stop_point=540, stop_offset=0,
         )
-        v1 = LayerViaSet(name="V1", gds_layer_number=21, default_via=LayerVia(
-            name="V1",
-            gds_layer_number=21,
-            stack=('M1', 'M2'),
-            width_x=600, width_y=400, space_x=600, space_y=300,
-        ))
-        v2 = LayerViaSet(name="V2", gds_layer_number=22, default_via=LayerVia(
-            name="V2",
-            gds_layer_number=22,
-            stack=('M2', 'M3'),
-            width_x=600, width_y=400, space_x=300, space_y=600,
-        ))
-        v3 = LayerViaSet(name="V3", gds_layer_number=23, default_via=LayerVia(
-            name="V3",
-            gds_layer_number=23,
-            stack=('M3', 'M4'),
-            width_x=600, width_y=400, space_x=600, space_y=300,
-        ))
-        v4 = LayerViaSet(name="V4", gds_layer_number=24, default_via=LayerVia(
-            name="V4",
-            gds_layer_number=24,
-            stack=('M4', 'M5'),
-            width_x=600, width_y=400, space_x=300, space_y=600,
-        ))
-        v5 = LayerViaSet(name="V5", gds_layer_number=25, default_via=LayerVia(
-            name="V5",
-            gds_layer_number=24,
-            stack=('M5', 'M6'),
-            width_x=600, width_y=400, space_x=600, space_y=300,
-        ))
+        v1 = LayerVia(name="V1", gds_layer_number=21, stack=('M1', 'M2'), width_x=600, width_y=400, space_x=600, space_y=300)
+        v2 = LayerVia(name="V2", gds_layer_number=22, stack=('M2', 'M3'), width_x=600, width_y=400, space_x=300, space_y=600)
+        v3 = LayerVia(name="V3", gds_layer_number=23, stack=('M3', 'M4'), width_x=600, width_y=400, space_x=600, space_y=300)
+        v4 = LayerVia(name="V4", gds_layer_number=24, stack=('M4', 'M5'), width_x=600, width_y=400, space_x=300, space_y=600)
+        v5 = LayerVia(name="V5", gds_layer_number=24, stack=('M5', 'M6'), width_x=600, width_y=400, space_x=600, space_y=300)
 
         self.pdk_v2 = PDK(name=
                        """Mock FinFET technology with non-uniform metal grids. \

--- a/align/schema/pdk.py
+++ b/align/schema/pdk.py
@@ -1,15 +1,15 @@
-from typing import List, Union, Dict, Optional, Tuple
 from pydantic import validator, ValidationError, Field
-from . import types
+from .types import BaseModel, Union, Optional, Literal, List
+from typing import Dict
 
 
-class ParasiticValues(types.BaseModel):
+class ParasiticValues(BaseModel):
     mean: int = 0
     min: int = 0
     max: int = 0
 
 
-class Layer(types.BaseModel):
+class Layer(BaseModel):
     name: str
     gds_layer_number: int
     gds_data_type: Optional[Dict[str, int]] = Field(default_factory=lambda: {"draw": 0})
@@ -17,7 +17,7 @@ class Layer(types.BaseModel):
 
 class LayerMetal(Layer):
 
-    direction: str
+    direction: Literal['h', 'v']
 
     min_length: int
     max_length: Optional[int]
@@ -36,50 +36,40 @@ class LayerMetal(Layer):
     unit_r: Optional[Dict[int, ParasiticValues]]
     unit_cc: Optional[Dict[int, ParasiticValues]]
 
-    @validator('direction')
-    def _validate_direction(cls, v):
-        if v not in ['h', 'v']:
-            raise ValueError('Direction value should be h or v')
-        return v
-
     @validator('name')
     def _validate_name(cls, v):
-        if not v.startswith('M'):
-            raise ValueError('Metal layer name should start with M')
+        assert v.startswith('M'), f'Metal layer name {v} should start with M'
         return v
 
-    @validator('min_length', 'min_end_to_end', 'width', 'space',
-               'stop_pitch', 'stop_point')
+    @validator('min_length', 'min_end_to_end', 'width', 'space', 'stop_pitch', 'stop_point')
     def _validate_positive(cls, v):
-        if type(v) is list:
-            if min(v) <= 0:
-                raise ValueError('Values should be positive')
+        if isinstance(v, List):
+            assert min(v) > 0, f'Values {v} should be positive'
         else:
-            if v <= 0:
-                raise ValueError('Value should be positive')
+            assert v > 0, f'Value {v} should be positive'
         return v
 
     @validator('stop_offset')
     def _validate_non_negative(cls, v):
-        if type(v) is list:
-            if min(v) < 0:
-                raise ValueError('Values should be non-negative')
+        if isinstance(v, List):
+            assert min(v) >= 0, f'Values {v} should be non-negative'
         else:
-            if v < 0:
-                raise ValueError('Value should be non-negative')
+            assert v >= 0, f'Value {v} should be positive'
         return v
 
     @validator('space')
     def _validate_width(cls, v, values):
-        if type(v) is list:
-            if len(v) != len(values['width']):
-                raise ValueError('Width and space length should match')
+        if isinstance(v, List):
+            assert len(v) == len(values['width']), f'width and space length should match'
         return v
 
 
 class LayerVia(Layer):
 
-    stack: Tuple[str, str]
+    class Config:
+        allow_mutation = True
+
+    stack: List[str]
 
     width_x: int
     width_y: int
@@ -87,37 +77,44 @@ class LayerVia(Layer):
     space_x: int
     space_y: int
 
-    layer1_width: Optional[int]
-    enc_layer1_x: Optional[int] = 0
-    enc_layer1_y: Optional[int] = 0
+    layer_l_width: Optional[List[int]] = None
+    layer_l_enc_x: Optional[int] = 0
+    layer_l_enc_y: Optional[int] = 0
 
-    layer2_width: Optional[int]
-    enc_layer2_x: Optional[int] = 0
-    enc_layer2_y: Optional[int] = 0
+    layer_h_width: Optional[List[int]] = None
+    layer_h_enc_x: Optional[int] = 0
+    layer_h_enc_x: Optional[int] = 0
 
     unit_r: Optional[Dict[int, ParasiticValues]]
 
+    @validator('stack')
+    def _validate_stack(cls, v):
+        assert len(v) == 2
+        return v
 
-class LayerViaSet(Layer):
 
-    default_via: LayerVia
-    via_list: Optional[List[LayerVia]]
+class PDK(BaseModel):
 
+    class Config:
+        allow_mutation = True
 
-class PDK(types.BaseModel):
     name: str
-    layers: Dict[str, Union[LayerMetal, LayerViaSet]] = Field(default_factory=lambda: {})
+    layers: Dict[str, Union[LayerMetal, LayerVia]] = Field(default_factory=lambda: {})
     scale_factor: int = 1
 
     @validator('layers')
-    def _validate_metal_stack(cls, layers):
-        for key, value in layers.items():
-            if key.startswith('V'):
-                ml, mh = value.default_via.stack
-                assert ml is None or ml in layers, f'Lower metal layer {ml} not found for {key}'
-                assert mh in layers, f'Upper metal layer {mh} not found for {key}'
-                if ml is not None and mh is not None:
-                    assert layers[ml].direction != layers[mh].direction, f'Metal layer directions are not orthogonal'
+    def _validate_via(cls, layers):
+        for key, via in layers.items():
+            if isinstance(via, LayerVia):
+                ml, mh = via.stack
+                assert ml in layers, f'Lower layer {ml} not found for {key} {layers.keys()}'
+                assert mh in layers, f'Higher layer {mh} not found for {key}'
+                assert layers[ml].direction != layers[mh].direction, f'Lower and higher layer directions are not orthogonal'
+
+                if via.layer_l_width is None:
+                    via.layer_l_width = layers[ml].width.copy()
+                if via.layer_h_width is None:
+                    via.layer_h_width = layers[mh].width.copy()
         return layers
 
     def add_layer(self, layer):

--- a/align/schema/pdk.py
+++ b/align/schema/pdk.py
@@ -122,7 +122,7 @@ class PDK(BaseModel):
         assert layer.name not in self.layers
         self.layers[layer.name] = layer
 
-    def generate_adr_collaterals(self, write_path: pathlib.Path, x_pitch: int, x_grid: int, y_pitch: int, y_grid: int):
+    def generate_adr_collaterals(self, write_path: pathlib.Path, x_pitch: int, x_grid: int, y_pitch: int, y_grid: int, region: List[int]):
 
         with open(write_path/"adr_forbidden_patterns.txt", "wt") as fp:
             # TODO: Write rules for horizontal and vertical via spacing
@@ -147,6 +147,17 @@ class PDK(BaseModel):
                     if layer.color is not None and len(layer.color) > 0:
                         line += f' colors={",".join(str(i) for i in layer.color)}'
                     line += " stops=%s" % (",".join( str(i) for i in [layer.stop_pitch - 2*layer.stop_point, 2*layer.stop_point]))
+                    line += '\n'
+                    fp.write(line)
+
+        # Single metal template instance. Generalize to multiple as needed in the future.
+        with open(write_path/"adr_metal_templates_instances.txt", "wt") as fp:
+            for name, layer in self.layers.items():
+                if isinstance(layer, LayerMetal):
+                    line  = f'MetalTemplateInstance template={name}_template_0'
+                    line += f' pgdoffset_abs={layer.offset}'
+                    line += f' ogdoffset_abs={layer.stop_point}'
+                    line += f' region={":".join(str(i) for i in region)}'
                     line += '\n'
                     fp.write(line)
 

--- a/pdks/Nonuniform_mock_pdk/canvas.py
+++ b/pdks/Nonuniform_mock_pdk/canvas.py
@@ -4,7 +4,7 @@ import logging
 from align.cell_fabric.canvas import Canvas
 from align.cell_fabric import Wire, Via, Region
 from align.cell_fabric import CenterLineGrid, EnclosureGrid, SingleGrid
-from align.schema.pdk import LayerMetal, LayerVia, LayerViaSet, PDK
+from align.schema.pdk import LayerMetal, LayerVia, PDK
 
 logger = logging.getLogger(__name__)
 
@@ -24,10 +24,10 @@ class CanvasPDK(Canvas):
 
     def _add_generators(self):
         for layer_name, layer in self.pdk.layers.items():
-            if layer_name.startswith('M'):
+            if isinstance(layer, LayerMetal):
                 self._add_metal_generator(layer)
-            elif layer_name.startswith('V'):
-                self._add_via_generator(layer.default_via)
+            elif isinstance(layer, LayerVia):
+                self._add_via_generator(layer)
 
         v_grid_pitch = sum(self.pdk.layers['M1'].width) + sum(self.pdk.layers['M1'].space)
         h_grid_pitch = sum(self.pdk.layers['M2'].width) + sum(self.pdk.layers['M2'].space)
@@ -112,7 +112,7 @@ class CanvasPDK(Canvas):
             space=[300, 300, 400, 400, 400, 300, 300],
             stop_pitch=1000,
             stop_point=350,
-            stop_offset=0,
+            stop_offset=0
         )
         m3 = LayerMetal(
             name="M3",
@@ -139,7 +139,7 @@ class CanvasPDK(Canvas):
             space=[300, 300, 400, 400, 400, 300, 300],
             stop_pitch=1000,
             stop_point=350,
-            stop_offset=0,
+            stop_offset=0
         )
         m5 = LayerMetal(
             name="M5",
@@ -155,38 +155,34 @@ class CanvasPDK(Canvas):
             stop_point=500,
             stop_offset=0
         )
-
-        v1 = LayerViaSet(name="V1", gds_layer_number=21, default_via=LayerVia(
+        v1 = LayerVia(
             name="V1",
             gds_layer_number=21,
             stack=('M1', 'M2'),
             width_x=600,
             width_y=500,
             space_x=100,
-            space_y=100,
-        ))
-
-        v2 = LayerViaSet(name="V2", gds_layer_number=22, default_via=LayerVia(
+            space_y=100
+        )
+        v2 = LayerVia(
             name="V2",
             gds_layer_number=22,
             stack=('M2', 'M3'),
             width_x=600,
             width_y=500,
             space_x=100,
-            space_y=100,
-        ))
-
-        v3 = LayerViaSet(name="V3", gds_layer_number=23, default_via=LayerVia(
+            space_y=100
+        )
+        v3 = LayerVia(
             name="V3",
             gds_layer_number=23,
             stack=('M3', 'M4'),
             width_x=600,
             width_y=500,
             space_x=100,
-            space_y=100,
-        ))
-
-        v4 = LayerViaSet(name="V4", gds_layer_number=24, default_via=LayerVia(
+            space_y=100
+        )
+        v4 = LayerVia(
             name="V4",
             gds_layer_number=24,
             stack=('M3', 'M4'),
@@ -194,12 +190,12 @@ class CanvasPDK(Canvas):
             width_y=500,
             space_x=100,
             space_y=100,
-        ))
+        )
 
         self.pdk = PDK(name=
                        """Mock FinFET technology with non-uniform metal grids.\
-This PDK is for development and not functional yet.\
-This file is auto-generated using tests/schema/test_pdk.py""",
+                       This PDK is for development and not functional yet.\
+                       This file is auto-generated using tests/schema/test_pdk.py""",
                        layers={'M1': m1, 'M2': m2, 'M3': m3, 'M4': m4, 'M5': m5,
                                'V1': v1, 'V2': v2, 'V3': v3, 'V4': v4,})
 

--- a/tests/schema/test_pdk.py
+++ b/tests/schema/test_pdk.py
@@ -165,4 +165,4 @@ def test_three():
         space_y=100
         )
     pdk = PDK(name= "Mock", layers={'M1': m1, 'M2': m2, 'V1': v1})
-    pdk.generate_adr_collaterals(my_dir, 4, 8)
+    pdk.generate_adr_collaterals(my_dir, 1080, 4, 900, 7)

--- a/tests/schema/test_pdk.py
+++ b/tests/schema/test_pdk.py
@@ -1,5 +1,6 @@
 import pathlib
 import json
+import pytest
 from align.schema.pdk import LayerMetal, LayerVia, LayerViaSet, PDK
 
 my_dir = pathlib.Path(__file__).resolve().parent
@@ -32,48 +33,6 @@ def test_one():
         stop_point=350,
         stop_offset=0,
     )
-    m3 = LayerMetal(
-        name="M3",
-        gds_layer_number=3,
-        direction="v",
-        min_length=1000,
-        min_end_to_end=400,
-        offset=0,
-        width=[800, 1000],
-        space=[600, 600],
-        color=["a", "b"],
-        stop_pitch=1000,
-        stop_point=500,
-        stop_offset=0
-    )
-    m4 = LayerMetal(
-        name="M4",
-        gds_layer_number=4,
-        direction="h",
-        min_length=500,
-        min_end_to_end=300,
-        offset=0,
-        width=[400, 500, 500, 600, 600, 500, 500],
-        space=[300, 300, 400, 400, 400, 300, 300],
-        stop_pitch=1000,
-        stop_point=350,
-        stop_offset=0,
-    )
-    m5 = LayerMetal(
-        name="M5",
-        gds_layer_number=5,
-        direction="v",
-        min_length=1000,
-        min_end_to_end=400,
-        offset=0,
-        width=[800, 1000],
-        space=[600, 600],
-        color=["a", "b"],
-        stop_pitch=1000,
-        stop_point=500,
-        stop_offset=0
-    )
-
     v1 = LayerVia(
         name="V1",
         gds_layer_number=21,
@@ -85,13 +44,106 @@ def test_one():
     )
     v1_set = LayerViaSet(name="V1", gds_layer_number=21, default_via=v1)
 
-    pdk = PDK(name=
-                   """Mock FinFET technology with non-uniform metal grids.\
-This PDK is for development and not functional yet.\
-This file is auto-generated using tests/schema/test_pdk.py""",
-                   layers={'M1': m1, 'M2': m2, 'M3': m3, 'M4': m4, 'M5': m5,
-                           'V1': v1_set})
+    pdk = PDK(
+        name= "Mock FinFET technology with non-uniform metal grids", 
+        layers={'M1': m1, 'M2': m2, 'V1': v1_set}
+        )
 
-    # pprint.pprint(pdk.dict())
-    with open(my_dir/"layers.json", "wt") as fp:
+    with open(my_dir/"test_pdk_one-cand.json", "wt") as fp:
         fp.write(json.dumps(pdk.dict(), indent=2) + '\n')
+
+
+def test_two():
+    # upper metal not found 
+    m1 = LayerMetal(
+        name="M1",
+        gds_layer_number=1,
+        direction="v",
+        min_length=1000,
+        min_end_to_end=400,
+        offset=0,
+        width=[600],
+        space=[400],
+        stop_pitch=1000,
+        stop_point=200,
+        stop_offset=0
+    )
+    v1 = LayerVia(
+        name="V1",
+        gds_layer_number=21,
+        stack=('M1', 'M3'),
+        width_x=600,
+        width_y=500,
+        space_x=100,
+        space_y=100,
+    )
+    v1_set = LayerViaSet(name="V1", gds_layer_number=21, default_via=v1)
+    with pytest.raises(Exception):
+        pdk = PDK(name= "Mock", layers={'M1': m1, 'V1': v1_set})
+
+    # lower metal not found 
+    m1 = LayerMetal(
+        name="M1",
+        gds_layer_number=1,
+        direction="v",
+        min_length=1000,
+        min_end_to_end=400,
+        offset=0,
+        width=[600],
+        space=[400],
+        stop_pitch=1000,
+        stop_point=200,
+        stop_offset=0
+    )
+    v1 = LayerVia(
+        name="V1",
+        gds_layer_number=21,
+        stack=('M0', 'M1'),
+        width_x=600,
+        width_y=500,
+        space_x=100,
+        space_y=100,
+    )
+    v1_set = LayerViaSet(name="V1", gds_layer_number=21, default_via=v1)
+    with pytest.raises(Exception):
+        pdk = PDK(name= "Mock", layers={'M1': m1, 'V1': v1_set})
+
+    # metals not orthogonal 
+    m1 = LayerMetal(
+        name="M1",
+        gds_layer_number=1,
+        direction="v",
+        min_length=1000,
+        min_end_to_end=400,
+        offset=0,
+        width=[600],
+        space=[400],
+        stop_pitch=1000,
+        stop_point=200,
+        stop_offset=0
+    )
+    m2 = LayerMetal(
+        name="M2",
+        gds_layer_number=2,
+        direction="v",
+        min_length=500,
+        min_end_to_end=300,
+        offset=0,
+        width=[400, 500, 500, 600, 600, 500, 500],
+        space=[300, 300, 400, 400, 400, 300, 300],
+        stop_pitch=1000,
+        stop_point=350,
+        stop_offset=0,
+    )
+    v1 = LayerVia(
+        name="V1",
+        gds_layer_number=21,
+        stack=('M1', 'M2'),
+        width_x=600,
+        width_y=500,
+        space_x=100,
+        space_y=100,
+    )
+    v1_set = LayerViaSet(name="V1", gds_layer_number=21, default_via=v1)
+    with pytest.raises(Exception):
+        pdk = PDK(name= "Mock", layers={'M1': m1, 'M2': m2, 'V1': v1_set})

--- a/tests/schema/test_pdk.py
+++ b/tests/schema/test_pdk.py
@@ -1,7 +1,7 @@
 import pathlib
 import json
 import pytest
-from align.schema.pdk import LayerMetal, LayerVia, LayerViaSet, PDK
+from align.schema.pdk import LayerMetal, LayerVia, PDK
 
 my_dir = pathlib.Path(__file__).resolve().parent
 
@@ -19,7 +19,7 @@ def test_one():
         stop_pitch=1000,
         stop_point=200,
         stop_offset=0
-    )
+        )
     m2 = LayerMetal(
         name="M2",
         gds_layer_number=2,
@@ -31,23 +31,18 @@ def test_one():
         space=[300, 300, 400, 400, 400, 300, 300],
         stop_pitch=1000,
         stop_point=350,
-        stop_offset=0,
-    )
+        stop_offset=0
+        )
     v1 = LayerVia(
         name="V1",
         gds_layer_number=21,
-        stack=('M1', 'M2'),
+        stack=['M1', 'M2'],
         width_x=600,
         width_y=500,
         space_x=100,
-        space_y=100,
-    )
-    v1_set = LayerViaSet(name="V1", gds_layer_number=21, default_via=v1)
-
-    pdk = PDK(
-        name= "Mock FinFET technology with non-uniform metal grids", 
-        layers={'M1': m1, 'M2': m2, 'V1': v1_set}
+        space_y=100
         )
+    pdk = PDK(name= "Mock", layers={'M1': m1, 'M2': m2, 'V1': v1})
 
     with open(my_dir/"test_pdk_one-cand.json", "wt") as fp:
         fp.write(json.dumps(pdk.dict(), indent=2) + '\n')
@@ -67,46 +62,31 @@ def test_two():
         stop_pitch=1000,
         stop_point=200,
         stop_offset=0
-    )
+        )
     v1 = LayerVia(
         name="V1",
         gds_layer_number=21,
-        stack=('M1', 'M3'),
+        stack=['M1', 'M3'],
         width_x=600,
         width_y=500,
         space_x=100,
-        space_y=100,
-    )
-    v1_set = LayerViaSet(name="V1", gds_layer_number=21, default_via=v1)
+        space_y=100
+        )
     with pytest.raises(Exception):
-        pdk = PDK(name= "Mock", layers={'M1': m1, 'V1': v1_set})
+        pdk = PDK(name= "Mock", layers={'M1': m1, 'V1': v1})
 
     # lower metal not found 
-    m1 = LayerMetal(
-        name="M1",
-        gds_layer_number=1,
-        direction="v",
-        min_length=1000,
-        min_end_to_end=400,
-        offset=0,
-        width=[600],
-        space=[400],
-        stop_pitch=1000,
-        stop_point=200,
-        stop_offset=0
-    )
     v1 = LayerVia(
         name="V1",
         gds_layer_number=21,
-        stack=('M0', 'M1'),
+        stack=['M0', 'M1'],
         width_x=600,
         width_y=500,
         space_x=100,
-        space_y=100,
+        space_y=100
     )
-    v1_set = LayerViaSet(name="V1", gds_layer_number=21, default_via=v1)
     with pytest.raises(Exception):
-        pdk = PDK(name= "Mock", layers={'M1': m1, 'V1': v1_set})
+        pdk = PDK(name= "Mock", layers={'M1': m1, 'V1': v1})
 
     # metals not orthogonal 
     m1 = LayerMetal(
@@ -133,17 +113,16 @@ def test_two():
         space=[300, 300, 400, 400, 400, 300, 300],
         stop_pitch=1000,
         stop_point=350,
-        stop_offset=0,
+        stop_offset=0
     )
     v1 = LayerVia(
         name="V1",
         gds_layer_number=21,
-        stack=('M1', 'M2'),
+        stack=['M1', 'M2'],
         width_x=600,
         width_y=500,
         space_x=100,
-        space_y=100,
+        space_y=100
     )
-    v1_set = LayerViaSet(name="V1", gds_layer_number=21, default_via=v1)
     with pytest.raises(Exception):
-        pdk = PDK(name= "Mock", layers={'M1': m1, 'M2': m2, 'V1': v1_set})
+        pdk = PDK(name= "Mock", layers={'M1': m1, 'M2': m2, 'V1': v1})

--- a/tests/schema/test_pdk.py
+++ b/tests/schema/test_pdk.py
@@ -165,4 +165,4 @@ def test_three():
         space_y=100
         )
     pdk = PDK(name= "Mock", layers={'M1': m1, 'M2': m2, 'V1': v1})
-    pdk.generate_adr_collaterals(my_dir, 1080, 4, 900, 7)
+    pdk.generate_adr_collaterals(my_dir, 1080, 4, 900, 7, [0, 0, 10*1080, 10*900])

--- a/tests/schema/test_pdk.py
+++ b/tests/schema/test_pdk.py
@@ -126,3 +126,43 @@ def test_two():
     )
     with pytest.raises(Exception):
         pdk = PDK(name= "Mock", layers={'M1': m1, 'M2': m2, 'V1': v1})
+
+
+def test_three():
+    m1 = LayerMetal(
+        name="M1",
+        gds_layer_number=1,
+        direction="v",
+        min_length=1000,
+        min_end_to_end=400,
+        offset=0,
+        width=[600],
+        space=[400],
+        stop_pitch=1000,
+        stop_point=200,
+        stop_offset=0
+        )
+    m2 = LayerMetal(
+        name="M2",
+        gds_layer_number=2,
+        direction="h",
+        min_length=500,
+        min_end_to_end=300,
+        offset=0,
+        width=[400, 500, 500, 600, 600, 500, 500],
+        space=[300, 300, 400, 400, 400, 300, 300],
+        stop_pitch=1000,
+        stop_point=350,
+        stop_offset=0
+        )
+    v1 = LayerVia(
+        name="V1",
+        gds_layer_number=21,
+        stack=['M1', 'M2'],
+        width_x=600,
+        width_y=500,
+        space_x=100,
+        space_y=100
+        )
+    pdk = PDK(name= "Mock", layers={'M1': m1, 'M2': m2, 'V1': v1})
+    pdk.generate_adr_collaterals(my_dir, 4, 8)


### PR DESCRIPTION
- Retire LayerViaSet due to replicated data to be re-introduce in a future PR as needed
- Generate ADR collaterals from the new PDK schema. Single metal template instance.

These collaterals to be tested with ADR in a future PR. 

@stevenmburns , this is ready for review. 