### PR TITLE
[schema] ring_oscillator constraint generation fix

### DIFF
--- a/align/compiler/match_graph.py
+++ b/align/compiler/match_graph.py
@@ -290,12 +290,18 @@ class Annotate:
                 if hasattr(const, 'instances'):
                     logger.debug(f"checking instances in the constraint:{const.instances} {set(remove_nodes)}")
                     if set(const.instances) & set(remove_nodes):
+                        replace = True
                         for block in remove_nodes:
-                            _list_replace(const.instances, block, new_inst)
+                            if replace:
+                                _list_replace(const.instances, block, new_inst)
+                                replace = False
+                            else:
+                                const.instances.remove(block)
+
                         logger.debug(f"updated instances in the constraint:{const}")
             #Removing single instances of instances
             self.hier_graph_dict[name]["constraints"] = constraint.ConstraintDB([const for const in const_list \
-                if ('instances' in const and len(const.instances)>1) or ('instances' not in const)])
+                if (hasattr(const,'instances') and len(const.instances)>1) or not hasattr(const,'instances')])
     def _if_const(self,name):
         """
         check if constraint exists for a subckt

--- a/align/schema/checker.py
+++ b/align/schema/checker.py
@@ -135,11 +135,11 @@ class Z3Checker(AbstractChecker):
     def __init__(self):
         self._bbox_cache = {}
         self._solver = z3.Solver()
-        self._solver.set(unsat_core=True)
 
     def append(self, formula, identifier=None):
         self._solver.add(formula)
-        if self._solver.check() == z3.unsat:
+        r = self._solver.check()
+        if r == z3.unsat:
             raise CheckerError(f'No solution exists for {formula} in conjunction with {self._solver}')
 
     def checkpoint(self):

--- a/examples/ring_oscillator/ring_oscillator.const.json
+++ b/examples/ring_oscillator/ring_oscillator.const.json
@@ -3,6 +3,6 @@
     {"constraint":"VerticalDistance",   "abs_distance":0},
     {"constraint": "order",
         "instances": ["xi0", "xi1", "xi2", "xi3", "xi4"],
-        "direction": "top_to_bottom"
+        "direction": "left_to_right"
     }
 ]

--- a/tests/compiler/test_user_constraint.py
+++ b/tests/compiler/test_user_constraint.py
@@ -3,6 +3,7 @@ import pytest
 import json
 
 from align.compiler.compiler import compiler, compiler_output
+from align.schema.checker import Z3Checker
 
 @pytest.fixture
 def test_compiler_hsc(dir_name):
@@ -43,7 +44,7 @@ def test_group_block_hsc(test_compiler_hsc):
         gold_const.sort(key=lambda item: item.get("const_name"))
     assert gold_const == gen_const
 
-
+@pytest.mark.skipif(not Z3Checker.enabled, reason="Couldn't import Z3")
 @pytest.mark.parametrize('dir_name', ['high_speed_comparator_broken'])
 def test_constraint_checking(dir_name):
     circuit_name = 'high_speed_comparator'

--- a/tests/schema/test_checker.py
+++ b/tests/schema/test_checker.py
@@ -1,5 +1,5 @@
 import pytest
-from align.schema.checker import Z3Checker
+from align.schema.checker import Z3Checker, CheckerError
 
 @pytest.fixture
 def checker():
@@ -9,7 +9,7 @@ def checker():
 def test_single_bbox_checking(checker):
     b1 = checker.bbox_vars('M1')
     checker.append(b1.llx < b1.urx)
-    with pytest.raises(AssertionError):
+    with pytest.raises(CheckerError):
         checker.append(b1.urx < b1.llx)
 
 @pytest.mark.skipif(not Z3Checker.enabled, reason="Couldn't import Z3")
@@ -18,5 +18,5 @@ def test_multi_bbox_checking(checker):
     checker.append(b1.llx < b1.urx)
     checker.append(b2.llx < b2.urx)
     checker.append(b2.urx <= b1.llx)
-    with pytest.raises(AssertionError):
+    with pytest.raises(CheckerError):
         checker.append(b1.urx <= b1.llx)

--- a/tests/schema/test_constraint.py
+++ b/tests/schema/test_constraint.py
@@ -1,7 +1,7 @@
 import pytest
 import pathlib
 from align.schema import constraint
-from align.schema.checker import Z3Checker
+from align.schema.checker import Z3Checker, CheckerError
 
 @pytest.fixture
 def db():
@@ -44,14 +44,14 @@ def test_Order_smt_checking(checker):
     x = constraint.Order(direction='left_to_right', instances=['M4', 'M5'])
     x.check(checker)
     x = constraint.Order(direction='left_to_right', instances=['M3', 'M2'])
-    with pytest.raises(AssertionError):
+    with pytest.raises(CheckerError):
         x.check(checker)
 
 @pytest.mark.skipif(not Z3Checker.enabled, reason="Couldn't import Z3")
 def test_Order_db_append(db):
     db.append(constraint.Order(direction='left_to_right', instances=['M1', 'M2', 'M3']))
     db.append(constraint.Order(direction='left_to_right', instances=['M4', 'M5']))
-    with pytest.raises(AssertionError):
+    with pytest.raises(CheckerError):
         db.append(constraint.Order(direction='left_to_right', instances=['M3', 'M2']))
 
 def test_AlignInOrder_input_sanitation():
@@ -64,7 +64,7 @@ def test_AlignInOrder_input_sanitation():
 def test_AlignInOrder_smt_checking(db):
     db.append(constraint.AlignInOrder(instances=['M1', 'M2', 'M3'], direction='horizontal'))
     db.append(constraint.AlignInOrder(instances=['M4', 'M5'], line='bottom'))
-    with pytest.raises(AssertionError):
+    with pytest.raises(CheckerError):
         db.append(constraint.AlignInOrder(instances=['M3', 'M2'], line='bottom'))
 
 @pytest.mark.skipif(not Z3Checker.enabled, reason="Couldn't import Z3")
@@ -78,14 +78,14 @@ def test_ConstraintDB_incremental_checking(db):
     db.append(constraint.Order(direction='left_to_right', instances=['M1', 'M2', 'M3']))
     db.checkpoint()
     # Experiment 2 : Failure
-    with pytest.raises(AssertionError):
+    with pytest.raises(CheckerError):
         db.append(constraint.Order(direction='left_to_right', instances=['M3', 'M2']))
     db.revert()
     # Experiment 3 : Success
     db.append(constraint.Order(direction='left_to_right', instances=['M4', 'M5']))
     db.checkpoint()
     # Experiment 4: Failure
-    with pytest.raises(AssertionError):
+    with pytest.raises(CheckerError):
         db.append(constraint.Order(direction='left_to_right', instances=['M3', 'M2']))
     db.revert()
     # Experiment 5: Success


### PR DESCRIPTION
CI is failing on master because of some weird constraints being generated for ring_oscillator. Could you please take a look @kkunal1408. The issue seems to be that we are trying to create an ordering constraint that orders an instance against itself.

```console
align.schema.constraint ERROR : Failed to add constraint constraint='order' instances=List[str](__root__=['mn0_mp0', 'mn0_mp0']) direction='top_to_bottom' abut=False due to conflict with one or more of:
align.schema.constraint ERROR : constraint='horizontal_distance' abs_distance=0
align.schema.constraint ERROR : constraint='vertical_distance' abs_distance=0
align.schema.constraint ERROR : constraint='order' instances=List[str](__root__=['mn0_mp0', 'mn0_mp0']) direction='top_to_bottom' abut=False
align.cmdline ERROR : Fatal Error. Cannot proceed
Traceback (most recent call last):
  File "/home/parijatm/ALIGN/ALIGN-public/align/cmdline.py", line 123, in parse_args
    return schematic2layout(**vars(arguments))
  File "/home/parijatm/ALIGN/ALIGN-public/align/main.py", line 71, in schematic2layout
    primitives = generate_hierarchy(netlist, subckt, topology_dir, flatten, pdk_dir, uniform_height)
  File "/home/parijatm/ALIGN/ALIGN-public/align/compiler/compiler.py", line 23, in generate_hierarchy
    hier_graph_dict = compiler(netlist, subckt, pdk_dir, flatten_heirarchy)
  File "/home/parijatm/ALIGN/ALIGN-public/align/compiler/compiler.py", line 120, in compiler
    annotate.annotate()
  File "/home/parijatm/ALIGN/ALIGN-public/align/compiler/match_graph.py", line 70, in annotate
    circuit["graph"] = self._reduce_graph(G1, circuit_name, mapped_graph_list)
  File "/home/parijatm/ALIGN/ALIGN-public/align/compiler/match_graph.py", line 349, in _reduce_graph
    self._update_block_const(name, G1, remove_nodes, new_node)
  File "/home/parijatm/ALIGN/ALIGN-public/align/compiler/match_graph.py", line 298, in _update_block_const
    self.hier_graph_dict[name]["constraints"] = constraint.ConstraintDB([const for const in const_list \
  File "/home/parijatm/ALIGN/ALIGN-public/align/schema/constraint.py", line 606, in __init__
    self._check_recursive(self.__root__)
  File "/home/parijatm/ALIGN/ALIGN-public/align/schema/constraint.py", line 590, in _check_recursive
    self._check(constraint)
  File "/home/parijatm/ALIGN/ALIGN-public/align/schema/constraint.py", line 585, in _check
    raise e
  File "/home/parijatm/ALIGN/ALIGN-public/align/schema/constraint.py", line 579, in _check
    constraint.check(self._checker)
  File "/home/parijatm/ALIGN/ALIGN-public/align/schema/constraint.py", line 117, in check
    checker.append(cc(b2, b1, 'y'))
  File "/home/parijatm/ALIGN/ALIGN-public/align/schema/checker.py", line 143, in append
    raise CheckerError(f'No solution exists for {formula} in conjunction with {self._solver}')
align.schema.checker.CheckerError: No solution exists for mn0_mp0_ury <= mn0_mp0_lly in conjunction with [mn0_mp0_llx < mn0_mp0_urx,
 mn0_mp0_lly < mn0_mp0_ury,
 mn0_mp0_ury <= mn0_mp0_lly]
```