### PR TITLE
Remove multiple netlist support and add flow stage control

### DIFF
--- a/align/cmdline.py
+++ b/align/cmdline.py
@@ -115,6 +115,13 @@ class CmdlineParser():
 #                            action='store_true',
 #                            help="Write out GDS after python postprocessing")
 
+        parser.add_argument('--flow_start',
+                            type=str,
+                            help='Stage to start the flow. Previous stages are skipped.')
+        parser.add_argument('--flow_stop',
+                            type=str,
+                            help='Stage after which to stop the flow. Subsequent stages are skipped.')
+
         self.parser = parser
 
     def parse_args(self, *args, **kwargs):

--- a/align/main.py
+++ b/align/main.py
@@ -81,9 +81,9 @@ def schematic2layout(netlist_dir, pdk_dir, netlist_file=None, subckt=None, worki
         regression_dir.mkdir(exist_ok=True)
 
     assert len(netlist_files) == 1, "Only one .sp file allowed"
+    netlist = netlist_files[0]
 
     results = []
-    netlist = netlist_files[0]
 
     logger.info(f"READ file: {netlist} subckt={subckt}, flat={flatten}")
 

--- a/align/main.py
+++ b/align/main.py
@@ -1,6 +1,7 @@
 import pathlib
 import shutil
 import os
+import json
 
 from .compiler import generate_hierarchy
 from .primitive import generate_primitive
@@ -12,7 +13,29 @@ from .utils.logging import reconfigure_loglevels
 import logging
 logger = logging.getLogger(__name__)
 
-def schematic2layout(netlist_dir, pdk_dir, netlist_file=None, subckt=None, working_dir=None, flatten=False, unit_size_mos=10, unit_size_cap=10, nvariants=1, effort=0, check=False, extract=False, log_level=None, verbosity=None, generate=False, python_gds_json=True, regression=False, uniform_height=False, render_placements=False, PDN_mode=False):
+def build_steps( flow_start, flow_stop):
+    steps = [ '1_topology', '2_primitives', '3_pnr']
+
+    start_idx = 0
+    if flow_start is not None:
+        assert flow_start in steps
+        start_idx = steps.index( flow_start)
+    stop_idx = len(steps)
+    if flow_stop is not None:
+        assert flow_stop in steps
+        stop_idx = steps.index( flow_stop)+1
+
+    assert start_idx < stop_idx, f'No steps to run in the flow: {steps}[{start_idx}:{stop_idx}]'
+
+    steps_to_run = steps[start_idx:stop_idx]
+    logger.info( f'Steps to run in the flow: {steps}[{start_idx}:{stop_idx}] => {steps_to_run}')
+
+    return steps_to_run
+
+
+def schematic2layout(netlist_dir, pdk_dir, netlist_file=None, subckt=None, working_dir=None, flatten=False, unit_size_mos=10, unit_size_cap=10, nvariants=1, effort=0, check=False, extract=False, log_level=None, verbosity=None, generate=False, python_gds_json=True, regression=False, uniform_height=False, render_placements=False, PDN_mode=False, flow_start=None, flow_stop=None):
+
+    steps_to_run = build_steps( flow_start, flow_stop)
 
     reconfigure_loglevels(file_level=log_level, console_level=verbosity)
 
@@ -52,28 +75,42 @@ def schematic2layout(netlist_dir, pdk_dir, netlist_file=None, subckt=None, worki
         assert len(netlist_files) == 1, "Encountered multiple spice files. Cannot infer top-level circuit"
         subckt = netlist_files[0].stem
 
-    # Create directories for each stage
-    topology_dir = working_dir / '1_topology'
-    topology_dir.mkdir(exist_ok=True)
-    primitive_dir = (working_dir / '2_primitives')
-    primitive_dir.mkdir(exist_ok=True)
-    pnr_dir = working_dir / '3_pnr'
-    pnr_dir.mkdir(exist_ok=True)
     if regression:
         # Copy regression results in one dir
         regression_dir = working_dir / 'regression'
         regression_dir.mkdir(exist_ok=True)
 
+    assert len(netlist_files) == 1, "Only one .sp file allowed"
+
     results = []
-    for netlist in netlist_files:
-        logger.info(f"READ file: {netlist} subckt={subckt}, flat={flatten}")
-        # Generate hierarchy
+    netlist = netlist_files[0]
+
+    logger.info(f"READ file: {netlist} subckt={subckt}, flat={flatten}")
+
+    # Generate hierarchy
+    topology_dir = working_dir / '1_topology'
+    if '1_topology' in steps_to_run:
+        topology_dir.mkdir(exist_ok=True)
         primitives = generate_hierarchy(netlist, subckt, topology_dir, flatten, pdk_dir, uniform_height)
-        # Generate primitives
+        with (topology_dir / 'primitives.json').open( 'wt') as fp:
+            json.dump( primitives, fp=fp, indent=2)
+    else:
+        with (topology_dir / 'primitives.json').open( 'rt') as fp:
+            primitives = json.load(fp)
+        
+
+    # Generate primitives
+    primitive_dir = (working_dir / '2_primitives')
+    if '2_primitives' in steps_to_run:
+        primitive_dir.mkdir(exist_ok=True)
         for block_name, block_args in primitives.items():
             logger.debug(f"Generating primitive: {block_name}")
             generate_primitive(block_name, **block_args, pdkdir=pdk_dir, outputdir=primitive_dir)
-        # Copy over necessary collateral & run PNR tool
+
+    # run PNR tool
+    pnr_dir = working_dir / '3_pnr'
+    if '3_pnr' in steps_to_run:
+        pnr_dir.mkdir(exist_ok=True)
         variants = generate_pnr(topology_dir, primitive_dir, pdk_dir, pnr_dir, subckt, nvariants=nvariants, effort=effort, check=check, extract=extract, gds_json=python_gds_json, render_placements=render_placements, PDN_mode=PDN_mode)
         results.append( (netlist, variants))
         assert len(variants) >= 1, f"No layouts were generated for {netlist}. Cannot proceed further. See LOG/align.log for last error."

--- a/regression_summaries/render_table.py
+++ b/regression_summaries/render_table.py
@@ -55,6 +55,11 @@ for nm in df.columns.tolist():
 for k,v in names.items():
     assert set([f'{k}_x', f'{k}_y']) == set(v)
 
+for k,v in names.items():
+    for kk in v:
+        if kk.startswith('failed'):
+            df[kk] = df[kk].replace({True:1, False:0})
+
 for k,_ in names.items():
     df[f'{k}_d'] = df[f'{k}_y'] - df[f'{k}_x']
 


### PR DESCRIPTION
@parijatm @854768750 @soneryaldiz @Lastdayends @arvuce22 @kkunal1408 
I want to add flow stage control (so you run any consecutive subsequence of  ['1_topology', '2_primitive', '3_pnr'])

To do this it made sense to remove support for multiple .sp files in the same input directory. This doesn't seem to be used or tested for.

I did have to create one more file, a JSON file of the primitive information generated by stage 1 and feed to stage 2.

The new command line parameters are '--flow_start' and '--flow_stop'.

I think we should eventually extend this to include a 4th stage of gds generation (I almost never want to run that).
We might even be able to defer the .gds.json generation to that stage.
