### PR TITLE
WIP: Move cc capacitor generation to primitive stage

### DIFF
--- a/align/pnr/toplevel.py
+++ b/align/pnr/toplevel.py
@@ -182,6 +182,9 @@ def place( *, DB, opath, fpath, numLayout, effort, idx):
 
     DB.AddingPowerPins(current_node)
 
+    #
+    # We want to run this step earlier in the flow; Can we run it in its own DB and move the resulting LEF files to the corrent place?
+    #
     PRC = PnR.Placer_Router_Cap_Ifc(opath,fpath,current_node,DB.getDrc_info(),DB.checkoutSingleLEF(),1,6)
 
     hyper = PnR.PlacerHyperparameters()


### PR DESCRIPTION
- [ ] Duplicate generation of DB (verilog_json, map, lef parsing). Use LEF instead of internal calls to inject capacitor sizes into the flow.
- [ ] Remove need for DB create during capacitor generation [using only information from primitives.json or the like