### PR TITLE
Separate nroutings from nvariants

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -207,7 +207,7 @@ workflows:
               pdk:
                 - "Finfet"
               design:
-                - "adder or switched_capacitor_filter or high_speed_comparator or telescopic_ota_guard_ring"
+                - "adder or switched_capacitor_filter or high_speed_comparator"
       - test-integration:
           name: "test-integration-cp38-<<matrix.pdk>>"
           requires:

--- a/align/cmdline.py
+++ b/align/cmdline.py
@@ -135,6 +135,11 @@ class CmdlineParser():
                             default=None,
                             help='JSON file for adding a reference placement to GUI.')
 
+        parser.add_argument('--nroutings',
+                            type=int,
+                            default=1,
+                            help='Maximum number of routings to generate.')
+
         self.parser = parser
 
     def parse_args(self, *args, **kwargs):

--- a/align/main.py
+++ b/align/main.py
@@ -197,7 +197,7 @@ def extract_netlist_files(netlist_dir,netlist_file):
 
     return netlist_files[0]
 
-def schematic2layout(netlist_dir, pdk_dir, netlist_file=None, subckt=None, working_dir=None, flatten=False, unit_size_mos=10, unit_size_cap=10, nvariants=1, effort=0, extract=False, log_level=None, verbosity=None, generate=False, regression=False, uniform_height=False, PDN_mode=False, flow_start=None, flow_stop=None, router_mode='top_down', gui=False, skipGDS=False, lambda_coeff=1.0, reference_placement_verilog_json=None):
+def schematic2layout(netlist_dir, pdk_dir, netlist_file=None, subckt=None, working_dir=None, flatten=False, unit_size_mos=10, unit_size_cap=10, nvariants=1, effort=0, extract=False, log_level=None, verbosity=None, generate=False, regression=False, uniform_height=False, PDN_mode=False, flow_start=None, flow_stop=None, router_mode='top_down', gui=False, skipGDS=False, lambda_coeff=1.0, reference_placement_verilog_json=None, nroutings=1):
 
     steps_to_run = build_steps( flow_start, flow_stop)
 
@@ -265,7 +265,7 @@ def schematic2layout(netlist_dir, pdk_dir, netlist_file=None, subckt=None, worki
     sub_steps = [step for step in steps_to_run if '3_pnr:' in step]
     if sub_steps:
         pnr_dir.mkdir(exist_ok=True)
-        variants = generate_pnr(topology_dir, primitive_dir, pdk_dir, pnr_dir, subckt, primitives=primitives, nvariants=nvariants, effort=effort, extract=extract, gds_json=not skipGDS, PDN_mode=PDN_mode, router_mode=router_mode, gui=gui, skipGDS=skipGDS, steps_to_run=sub_steps, lambda_coeff=lambda_coeff, reference_placement_verilog_json=reference_placement_verilog_json)
+        variants = generate_pnr(topology_dir, primitive_dir, pdk_dir, pnr_dir, subckt, primitives=primitives, nvariants=nvariants, effort=effort, extract=extract, gds_json=not skipGDS, PDN_mode=PDN_mode, router_mode=router_mode, gui=gui, skipGDS=skipGDS, steps_to_run=sub_steps, lambda_coeff=lambda_coeff, reference_placement_verilog_json=reference_placement_verilog_json, nroutings=nroutings)
         results.append( (subckt, variants))
 
         assert gui or router_mode == 'no_op' or '3_pnr:check' not in sub_steps or len(variants) > 0, f"No layouts were generated for {subckt}. Cannot proceed further. See LOG/align.log for last error."

--- a/align/pnr/main.py
+++ b/align/pnr/main.py
@@ -172,7 +172,7 @@ def gen_leaf_collateral( leaves, primitives, primitive_dir):
 
     return leaf_collateral
 
-def generate_pnr(topology_dir, primitive_dir, pdk_dir, output_dir, subckt, *, primitives, nvariants=1, effort=0, extract=False, gds_json=False, PDN_mode=False, router_mode='top_down', gui=False, skipGDS=False, steps_to_run,lambda_coeff, reference_placement_verilog_json):
+def generate_pnr(topology_dir, primitive_dir, pdk_dir, output_dir, subckt, *, primitives, nvariants=1, effort=0, extract=False, gds_json=False, PDN_mode=False, router_mode='top_down', gui=False, skipGDS=False, steps_to_run,lambda_coeff, reference_placement_verilog_json, nroutings=1):
 
     logger.info(f"Running Place & Route for {subckt} {router_mode} {steps_to_run}")
 
@@ -254,7 +254,7 @@ def generate_pnr(topology_dir, primitive_dir, pdk_dir, output_dir, subckt, *, pr
 
         current_working_dir = os.getcwd()
         os.chdir(working_dir)
-        DB, results_name_map = toplevel(cmd, PDN_mode=PDN_mode, results_dir=None, router_mode=router_mode, gui=gui, skipGDS=skipGDS, lambda_coeff=lambda_coeff, scale_factor=scale_factor, reference_placement_verilog_json=reference_placement_verilog_json)
+        DB, results_name_map = toplevel(cmd, PDN_mode=PDN_mode, results_dir=None, router_mode=router_mode, gui=gui, skipGDS=skipGDS, lambda_coeff=lambda_coeff, scale_factor=scale_factor, reference_placement_verilog_json=reference_placement_verilog_json, nroutings=nroutings)
         os.chdir(current_working_dir)
 
         # Copy generated cap jsons from results_dir to working_dir

--- a/align/pnr/toplevel.py
+++ b/align/pnr/toplevel.py
@@ -134,10 +134,10 @@ def route_single_variant( DB, drcInfo, current_node, lidx, opath, adr_mode, *, P
 
     return return_name
 
-def route_bottom_up( *, DB, idx, opath, adr_mode, PDN_mode, skipGDS, placements_to_run):
+def route_bottom_up( *, DB, idx, opath, adr_mode, PDN_mode, skipGDS, placements_to_run, nroutings):
 
     if placements_to_run is None:
-        placements_to_run = list(range(DB.hierTree[idx].numPlacement))
+        placements_to_run = list(range(min(nroutings, DB.hierTree[idx].numPlacement)))
 
     # Compute all the needed subblocks
     subblocks_d = defaultdict(set)
@@ -207,7 +207,7 @@ def route_bottom_up( *, DB, idx, opath, adr_mode, PDN_mode, skipGDS, placements_
 
     return results_name_map
 
-def route_no_op( *, DB, idx, opath, adr_mode, PDN_mode, skipGDS, placements_to_run):
+def route_no_op( *, DB, idx, opath, adr_mode, PDN_mode, skipGDS, placements_to_run, nroutings):
     results_name_map = {}
     return results_name_map
 
@@ -269,11 +269,11 @@ def route_top_down_aux( DB, drcInfo,
 
     return new_currentnode_idx
 
-def route_top_down( *, DB, idx, opath, adr_mode, PDN_mode, skipGDS, placements_to_run):
+def route_top_down( *, DB, idx, opath, adr_mode, PDN_mode, skipGDS, placements_to_run, nroutings):
     assert len(DB.hierTree[idx].PnRAS) == DB.hierTree[idx].numPlacement
 
     if placements_to_run is None:
-        placements_to_run = list(range(DB.hierTree[idx].numPlacement))
+        placements_to_run = list(range(min(nroutings,DB.hierTree[idx].numPlacement)))
 
     results_name_map = {}
     new_topnode_indices = []
@@ -326,7 +326,7 @@ def place( *, DB, opath, fpath, numLayout, effort, idx, lambda_coeff):
 
     DB.hierTree[idx].numPlacement = actualNumLayout
 
-def route( *, DB, idx, opath, adr_mode, PDN_mode, router_mode, skipGDS, placements_to_run):
+def route( *, DB, idx, opath, adr_mode, PDN_mode, router_mode, skipGDS, placements_to_run, nroutings):
     logger.info(f'Starting {router_mode} routing on {DB.hierTree[idx].name} {idx} restricted to {placements_to_run}')
 
     router_engines = { 'top_down': route_top_down,
@@ -334,7 +334,7 @@ def route( *, DB, idx, opath, adr_mode, PDN_mode, router_mode, skipGDS, placemen
                        'no_op': route_no_op
                        }
 
-    return router_engines[router_mode]( DB=DB, idx=idx, opath=opath, adr_mode=adr_mode, PDN_mode=PDN_mode, skipGDS=skipGDS, placements_to_run=placements_to_run)
+    return router_engines[router_mode]( DB=DB, idx=idx, opath=opath, adr_mode=adr_mode, PDN_mode=PDN_mode, skipGDS=skipGDS, placements_to_run=placements_to_run, nroutings=nroutings)
 
 def subset_verilog_d( verilog_d, nm):
     # Should be an abstract verilog_d; no concrete_instance_names
@@ -367,7 +367,7 @@ def subset_verilog_d( verilog_d, nm):
 
     return new_verilog_d
 
-def place_and_route( *, DB, opath, fpath, numLayout, effort, adr_mode, PDN_mode, verilog_d, router_mode, gui, skipGDS, lambda_coeff, scale_factor, reference_placement_verilog_json):
+def place_and_route( *, DB, opath, fpath, numLayout, effort, adr_mode, PDN_mode, verilog_d, router_mode, gui, skipGDS, lambda_coeff, scale_factor, reference_placement_verilog_json, nroutings):
     TraverseOrder = DB.TraverseHierTree()
 
     for idx in TraverseOrder:
@@ -531,9 +531,9 @@ def place_and_route( *, DB, opath, fpath, numLayout, effort, adr_mode, PDN_mode,
                 if m.groups()[0] == top_level:
                     placements_to_run = [int(m.groups()[1])]
 
-    return route( DB=DB, idx=idx, opath=opath, adr_mode=adr_mode, PDN_mode=PDN_mode, router_mode=router_mode, skipGDS=skipGDS, placements_to_run=placements_to_run)
+    return route( DB=DB, idx=idx, opath=opath, adr_mode=adr_mode, PDN_mode=PDN_mode, router_mode=router_mode, skipGDS=skipGDS, placements_to_run=placements_to_run, nroutings=nroutings)
 
-def toplevel(args, *, PDN_mode=False, adr_mode=False, results_dir=None, router_mode='top_down', gui=False, skipGDS=False, lambda_coeff=1.0, scale_factor=2, reference_placement_verilog_json=None):
+def toplevel(args, *, PDN_mode=False, adr_mode=False, results_dir=None, router_mode='top_down', gui=False, skipGDS=False, lambda_coeff=1.0, scale_factor=2, reference_placement_verilog_json=None, nroutings=1):
 
     assert len(args) == 9
 
@@ -553,6 +553,6 @@ def toplevel(args, *, PDN_mode=False, adr_mode=False, results_dir=None, router_m
 
     pathlib.Path(opath).mkdir(parents=True,exist_ok=True)
 
-    results_name_map = place_and_route( DB=DB, opath=opath, fpath=fpath, numLayout=numLayout, effort=effort, adr_mode=adr_mode, PDN_mode=PDN_mode, verilog_d=verilog_d, router_mode=router_mode, gui=gui, skipGDS=skipGDS, lambda_coeff=lambda_coeff, scale_factor=scale_factor, reference_placement_verilog_json=reference_placement_verilog_json)
+    results_name_map = place_and_route( DB=DB, opath=opath, fpath=fpath, numLayout=numLayout, effort=effort, adr_mode=adr_mode, PDN_mode=PDN_mode, verilog_d=verilog_d, router_mode=router_mode, gui=gui, skipGDS=skipGDS, lambda_coeff=lambda_coeff, scale_factor=scale_factor, reference_placement_verilog_json=reference_placement_verilog_json, nroutings=nroutings)
 
     return DB, results_name_map

--- a/tests/pnr/test_hpwl.py
+++ b/tests/pnr/test_hpwl.py
@@ -526,11 +526,3 @@ def test_gen_netlist_matrix():
     assert hpwl5 > hpwl6
 
     print( hpwl6 / 27584 - 1)
-
-    placement_verilog_d['modules'][0]['concrete_name'] = 'matrix_ref'
-    placement_verilog_d['modules'][0]['bbox'][2] -= 80
-    placement_verilog_d['modules'][0]['bbox'][3] -= 2*84
-    placement_verilog_d['modules'][1]['bbox'][2] -= 80
-
-    with pathlib.Path( '__reference_placement_verilog_d__').open('wt') as fp:
-        json.dump( placement_verilog_d, fp=fp, indent=2)


### PR DESCRIPTION
Add new command line parameter to specify the maximum number of routings to generate. This is independent of nvariants. It should improve the runtime for cases where nvariants needs to be set > 1 for quality reasons in the placer. The default is now 1.
