### PR TITLE
five failing tests

### DIFF
--- a/align/compiler/preprocess.py
+++ b/align/compiler/preprocess.py
@@ -84,7 +84,10 @@ def modify_pg_conn_subckt(hier_graph_dict:dict,circuit_name, pg_conn):
     for k,v in pg_conn.items():
         logger.debug(f"fixing port {k} to {v} for all inst in {circuit_name}")
         new["ports"].remove(k)
-        del new["ports_weight"][k]
+        # TODO: Remove this hack. Create a new hierdictnode instead of deepcopy
+        ports_weight = {k:v for k,v in new["ports_weight"].items()}
+        del ports_weight[k]
+        new["ports_weight"] = ports_weight
         if v in new["graph"].nodes():
             old_edge_wt=list(copy.deepcopy(new["graph"].edges(v,data=True)))
             new["graph"] = nx.relabel_nodes(new["graph"],{k:v},copy=False)
@@ -154,6 +157,10 @@ def preprocess_stack_parallel(hier_graph_dict:dict,circuit_name,G):
         initial_size = len(G)
     #remove single instance subcircuits 
     attributes = [attr for node, attr in G.nodes(data=True) if 'net' not in attr["inst_type"]]
+
+    # TODO: Below needs to be fixed
+    return None 
+
     if len(attributes)==1:
         #Check any existing hier
         if 'sub_graph' in attributes[0].keys() and attributes[0]['sub_graph'] is not None:

--- a/align/pdk/finfet/transistor_array.py
+++ b/align/pdk/finfet/transistor_array.py
@@ -33,14 +33,14 @@ class MOSGenerator(CanvasPDK):
         # TODO: All of below goes away when TransistorArray is passed to mos_array as shown below
         for key in ['m', 'real_inst_type']:
             assert key in parameters, f'Missing transistor parameter {key}'
-        assert 'nf' or 'stack' in parameters, f'Missing transistor parameter nf or stack'
+        assert 'nf' or 'stack' in parameters, 'Missing transistor parameter nf or stack'
 
-        if 'nf' in parameters:
-            nf = 'nf'
-            device_type = 'parallel'
-        elif 'stack' in parameters:
+        if 'stack' in parameters:
             nf = 'stack'
             device_type = 'stack'
+        elif 'nf' in parameters:
+            nf = 'nf'
+            device_type = 'parallel'
         else:
             nf = device_type = None
             assert False, f'Either nf or stack parameter should be defined {parameters}'

--- a/tests/pdk/finfet/test_generic.py
+++ b/tests/pdk/finfet/test_generic.py
@@ -1,0 +1,125 @@
+import textwrap
+try:
+    from .utils import get_test_id, build_example, run_example
+    from . import circuits
+except BaseException:
+    from utils import get_test_id, build_example, run_example
+    import circuits
+import shutil
+
+
+def test_1():
+    name = f'ckt_{get_test_id()}'
+    netlist = textwrap.dedent(f"""\
+        .subckt pcell_tfr_0 n1 n2
+            xi0 n1 n2 tfr_prim w=1e-6 l=1e-6
+        .ends pcell_tfr_0
+        .subckt {name} vin vop vccx vssx
+            mp0 vop vin vccx vccx p w=720e-9 nf=4 m=4
+            mn0 vop vin vssx vssx n w=720e-9 nf=4 m=4
+            xi0 vin vop pcell_tfr_0
+            xi1 vop vssx pcell_tfr_0
+        .ends {name}
+    """)
+    setup = textwrap.dedent("""\
+        POWER = vccx
+        GND = vssx
+        """)
+    constraints = []
+    example = build_example(name, netlist, setup, constraints)
+    run_example(example, cleanup=False)
+
+
+def test_2():
+    name = f'ckt_{get_test_id()}'
+    netlist = textwrap.dedent(f"""\
+        .subckt pcell_tfr_0 n1 n2
+            xi0 n1 n3 tfr_prim w=1e-6 l=1e-6
+            xi1 n3 n2 tfr_prim w=1e-6 l=1e-6
+        .ends pcell_tfr_0
+        .subckt {name} vin vop vccx vssx
+            mp0 vop vin vccx vccx p w=720e-9 nf=4 m=4
+            mn0 vop vin vssx vssx n w=720e-9 nf=4 m=4
+            xi0 vin vop pcell_tfr_0
+        .ends {name}
+    """)
+    setup = textwrap.dedent("""\
+        POWER = vccx
+        GND = vssx
+        """)
+    constraints = []
+    example = build_example(name, netlist, setup, constraints)
+    run_example(example, cleanup=False)
+
+
+def test_3():
+    name = f'ckt_{get_test_id()}'
+    netlist = textwrap.dedent(f"""\
+        .subckt pcell_tfr_0 n1 n2
+            xi0 n1 n3 tfr_prim w=1e-6 l=1e-6
+            xi1 n3 n2 tfr_prim w=1e-6 l=1e-6
+        .ends pcell_tfr_0
+        .subckt {name} vin vop vccx vssx
+            mp0 vop vin vccx vccx p w=720e-9 nf=4 m=4
+            mn0 vop vin vssx vssx n w=720e-9 nf=4 m=4
+            xi0 vin vop pcell_tfr_0
+            xi1 vop vssx pcell_tfr_0
+        .ends {name}
+    """)
+    setup = textwrap.dedent("""\
+        POWER = vccx
+        GND = vssx
+        """)
+    constraints = []
+    example = build_example(name, netlist, setup, constraints)
+    run_example(example, cleanup=False)
+
+
+def test_4():
+    name = f'ckt_{get_test_id()}'
+    netlist = textwrap.dedent(f"""\
+        .subckt pcell_tfr_0 n1 n2
+            xi0 n1 n3 tfr_prim w=1e-6 l=1e-6
+            xi1 n3 n2 tfr_prim w=2e-6 l=1e-6
+        .ends pcell_tfr_0
+        .subckt {name} vin vop vccx vssx
+            mp0 vop vin vccx vccx p w=720e-9 nf=4 m=4
+            mn0 vop vin vssx vssx n w=720e-9 nf=4 m=4
+            xi0 vin vop pcell_tfr_0
+            xi1 vop vssx pcell_tfr_0
+        .ends {name}
+    """)
+    setup = textwrap.dedent("""\
+        POWER = vccx
+        GND = vssx
+        """)
+    constraints = []
+    example = build_example(name, netlist, setup, constraints)
+    run_example(example, cleanup=False)
+
+
+def test_stacked_device():
+    name = f'ckt_{get_test_id()}'
+    netlist = textwrap.dedent(f"""\
+        .subckt p_pcell_0 d g s b
+            mn0 d g s1 b p w=180e-9 nf=1 m=1
+            mn1 s1 g s b p w=180e-9 nf=1 m=1
+        .ends p_pcell_0
+        .subckt {name} vin vop vccx vss
+            xi1 vop vin vccx vccx p_pcell_0 m=4
+            mn0 vop vin vssx vssx n w=720e-9 nf=4 m=4
+        .ends {name}
+    """)
+    setup = textwrap.dedent("""\
+        POWER = vccx
+        GND = vssx
+        """)
+    constraints = []
+    example = build_example(name, netlist, setup, constraints)
+    ckt_dir, run_dir = run_example(example, cleanup=False)
+
+    p = run_dir / '2_primitives' / 'Switch_PMOS_p_w180_m4_st2_x2_y2.json'
+    assert p.is_file(), f'Stacked transistor primitive not generated: {p}'
+
+    shutil.rmtree(run_dir)
+    shutil.rmtree(ckt_dir)


### PR DESCRIPTION
Several failing tests due to compiler hacks (hierarchy flattening, power pin munging): `tests/pdk/finfet/test_generic.py`
- [ ] Fix hierarchy flattening for single instance subcircuits
- [ ] Do not copy but create new types.py::Dict in hierarchy manipulations