### PR TITLE
Incorrect annotation

### DIFF
--- a/align/compiler/match_graph.py
+++ b/align/compiler/match_graph.py
@@ -503,7 +503,9 @@ class Annotate:
                         logger.debug(f"Matched Circuit: {' '.join(Gsub)}")
                     if len(map_list)>1:
                         fix_order_for_multimatch(G1,map_list,map_list[-1])
-                mapped_graph_list[block_name] = map_list
+
+                if map_list:
+                    mapped_graph_list[block_name] = map_list
 
         return mapped_graph_list
 

--- a/align/compiler/match_graph.py
+++ b/align/compiler/match_graph.py
@@ -471,7 +471,13 @@ class Annotate:
                         logger.debug(f"Discarding match due to user constraint {Gsub}")
                         continue
                     
-                    if block_name.startswith('DP')  or block_name.startswith('CMC'):
+                    block_prefix = block_name.split('_')[0]
+                    if block_prefix in ['SCM', 'DP', 'CMC', 'CCP', 'LS']:
+                        if G1.nodes[all_nd[0]]['values'] != G1.nodes[all_nd[1]]['values']:
+                            logger.debug(f"Discarding match {block_name} due to value mismatch")
+                            continue
+                    
+                    if block_name.startswith('DP') or block_name.startswith('CMC'):
                         if G1.nodes[all_nd[0]]['values'] == G1.nodes[all_nd[1]]['values'] and \
                             compare_balanced_tree(G1,get_key(Gsub,'DA'),get_key(Gsub,'DB'),[all_nd[0]],[all_nd[1]]) :
                             if 'SA' in Gsub.values() and \

--- a/align/compiler/write_verilog_lef.py
+++ b/align/compiler/write_verilog_lef.py
@@ -262,7 +262,7 @@ def generate_lef(name:str, attr:dict, available_block_lef:list, design_config:di
             }
 
             if 'stack' in values:
-                # assert nf == 1, f'Stacked transistor cannot have multiple fingers {nf}'
+                assert nf == 1, f'Stacked transistor cannot have multiple fingers {nf}'
                 block_args['stack']=int(values['stack'])
                 block_name += f'_st'+str(int(values['stack']))
             else:

--- a/align/compiler/write_verilog_lef.py
+++ b/align/compiler/write_verilog_lef.py
@@ -262,7 +262,7 @@ def generate_lef(name:str, attr:dict, available_block_lef:list, design_config:di
             }
 
             if 'stack' in values:
-                assert nf == 1, f'Stacked transistor cannot have multiple fingers {nf}'
+                # assert nf == 1, f'Stacked transistor cannot have multiple fingers {nf}'
                 block_args['stack']=int(values['stack'])
                 block_name += f'_st'+str(int(values['stack']))
             else:

--- a/align/config/basic_template.sp
+++ b/align/config/basic_template.sp
@@ -42,30 +42,6 @@ M0 (DA DA S S) PMOS w=w l=90n
 M1 (DB DA S S) PMOS w=w l=90n
 .ends SCM_PMOS
 
-**.subckt CMFB_NMOS DA DB GB S
-**M0 (DA DA S B) NMOS w=w l=90n
-**M1 (DB GB S B) NMOS w=w l=90n
-**.ends CMFB_NMOS
-**
-**.subckt CMFB_PMOS DA DB GB S
-**M0 (DA DA S B) PMOS w=w l=90n
-**M1 (DB GB S B) PMOS w=w l=90n
-**.ends CMFB_PMOS
-
-.subckt CASCODED_CMC_PMOS DA GA DB S
-M0 DA GA SA S PMOS w=27e-9 l=20e-9 nfin=120
-M1 DB GA SB S PMOS w=27e-9 l=20e-9 nfin=60
-M2 SA DB S S PMOS w=27e-9 l=20e-9 nfin=10
-M3 SB DB S S PMOS w=27e-9 l=20e-9 nfin=5
-.ends CASCODED_CMC_PMOS
-
-.subckt CASCODED_CMC_NMOS DA GA DB S
-M0 DA GA SA S NMOS w=27e-9 l=20e-9 nfin=24
-M1 DB GA SB S NMOS w=27e-9 l=20e-9 nfin=24
-M2 SA DA S S NMOS w=27e-9 l=20e-9 nfin=30
-M3 SB DA S S NMOS w=27e-9 l=20e-9 nfin=30
-.ends CASCODED_CMC_NMOS
-
 .subckt CMC_S_NMOS_B DA DB SA SB G B
 M0 (DA G SA B) NMOS w=w l=90n
 M1 (DB G SB B) NMOS w=w l=90n
@@ -151,13 +127,6 @@ M0 (DA DB S B) PMOS w=w l=90n
 M1 (DB DA S B) PMOS w=w l=90n
 .ends CCP_PMOS_B
 
-**.subckt CASCODED_CCP_NMOS DA DB SA SB S BN BP
-**M0 (DA DB SA BN) NMOS w=w l=90n
-**M1 (DB DA SB BN) NMOS w=w l=90n
-**M2 (DA DB S BP) PMOS w=w l=90n
-**M3 (DB DA S BP) PMOS w=w l=90n
-**.ends CASCODED_CCP_NMOS
-
 .subckt LS_S_NMOS_B DA DB SA SB
 M0 (DA DA SA B) NMOS w=w l=90n
 M1 (DB DA SB B) NMOS w=w l=90n
@@ -168,23 +137,6 @@ M0 (DA DA SA B) PMOS w=w l=90n
 M1 (DB DA SB B) PMOS w=w l=90n
 .ends LS_S_PMOS_B
 
-**.subckt LS_S_NMOS DA DB S
-***UT austin VCM5
-**M0 (DA DA S B) NMOS w=w l=90n
-**M1 (DB DA S B) NMOS w=w l=90n
-**.ends LS_S_NMOS
-**
-**.subckt LS_S_PMOS DA DB S
-***UT austin VCM5
-**M0 (DA DA S B) PMOS w=w l=90n
-**M1 (DB DA S B) PMOS w=w l=90n
-**.ends LS_S_PMOS
-
-***gate connected 
-**
-**transmission gate
-**ccp `
-
 .subckt DCL_NMOS_B D S B
 M0 (D D S B) NMOS w=w l=90n
 .ends DCL_NMOS_B
@@ -192,7 +144,6 @@ M0 (D D S B) NMOS w=w l=90n
 .subckt DCL_PMOS_B D S B
 M0 (D D S B) PMOS w=w l=90n
 .ends DCL_PMOS_B
-
 
 .subckt DCL_NMOS D S
 M0 (D D S S) NMOS w=w l=90n
@@ -261,7 +212,3 @@ CC1 PLUS MINUS BULK cap cap=60f
 .subckt Cap PLUS MINUS
 CC1 PLUS MINUS cap cap=60f
 .ends Cap
-
-
-
-

--- a/align/config/user_template.sp
+++ b/align/config/user_template.sp
@@ -1,3 +1,17 @@
+.subckt CASCODED_CMC_PMOS DA GA DB S
+M0 DA GA SA S PMOS w=27e-9 l=20e-9 nfin=120
+M1 DB GA SB S PMOS w=27e-9 l=20e-9 nfin=60
+M2 SA DB S S PMOS w=27e-9 l=20e-9 nfin=10
+M3 SB DB S S PMOS w=27e-9 l=20e-9 nfin=5
+.ends CASCODED_CMC_PMOS
+
+.subckt CASCODED_CMC_NMOS DA GA DB S
+M0 DA GA SA S NMOS w=27e-9 l=20e-9 nfin=24
+M1 DB GA SB S NMOS w=27e-9 l=20e-9 nfin=24
+M2 SA DA S S NMOS w=27e-9 l=20e-9 nfin=30
+M3 SB DA S S NMOS w=27e-9 l=20e-9 nfin=30
+.ends CASCODED_CMC_NMOS
+
 .subckt CASCODED_SCM_NMOS DA DC GA S
 M0 (DA GA DB B) NMOS w=w l=90n
 M1 (DB DA S B) NMOS w=w l=90n
@@ -141,17 +155,6 @@ c1 net63 net67 30e-15
 c0 net72 net63 60e-15
 .ends switched_capacitor_combination
 
-**.subckt res_array_8 MINUS0 PLUS0 PLUS1 PLUS2 PLUS3 PLUS4 PLUS5 PLUS6 PLUS7
-**r0 PLUS0 MINUS0 500
-**r1 PLUS1 PLUS0 1e3
-**r2 PLUS2 PLUS1 1e3
-**r3 PLUS3 PLUS2 1e3
-**r4 PLUS4 PLUS3 1e3
-**r5 PLUS5 PLUS4 1e3
-**r6 PLUS6 PLUS5 1e3
-**r7 PLUS7 PLUS6 500
-**.ends res_array_8
-
 .subckt tgate GA GB D S BN BP
 M0 (D GA S BN) NMOS w=w l=90n
 M1 (D GB S BP) PMOS w=w l=90n
@@ -184,12 +187,3 @@ R0 (GB DA) res res=1k
 C1 (DA net1) cap cap=1f
 R1 (net1 GA) res res=1k
 .ends SCM_NMOS_RC
-
-**.subckt SCM_PMOS_RC DA DB GA S
-**M0 (DA GA S B) NMOS w=w l=90n
-**M1 (DB GB S B) NMOS w=w l=90n
-**C0 (GB S) cap
-**R0 (GB DA) res
-**C1 (DA net1) cap
-**R1 (net1 GA) res
-**.ends SCM_NMOS_RC

--- a/align/pdk/finfet/transistor_array.py
+++ b/align/pdk/finfet/transistor_array.py
@@ -35,12 +35,12 @@ class MOSGenerator(CanvasPDK):
             assert key in parameters, f'Missing transistor parameter {key}'
         assert 'nf' or 'stack' in parameters, f'Missing transistor parameter nf or stack'
 
-        if 'nf' in parameters:
-            nf = 'nf'
-            device_type = 'parallel'
-        elif 'stack' in parameters:
+        if 'stack' in parameters:
             nf = 'stack'
             device_type = 'stack'
+        elif 'nf' in parameters:
+            nf = 'nf'
+            device_type = 'parallel'
         else:
             nf = device_type = None
             assert False, f'Either nf or stack parameter should be defined {parameters}'

--- a/tests/pdk/finfet/circuits.py
+++ b/tests/pdk/finfet/circuits.py
@@ -61,3 +61,85 @@ def tia(name):
         .ends {name}
     """)
     return netlist
+
+
+def ldo_amp(name):
+    netlist = textwrap.dedent(f"""\
+        .subckt nlplvt_s_pcell_0 d g s b
+        mi1 d g inet1 b nlplvt w=180e-9 m=1 nf=1
+        mi2 inet1 g inet2 b nlplvt w=180e-9 m=1 nf=1
+        mi3 inet2 g inet3 b nlplvt w=180e-9 m=1 nf=1
+        mi4 inet3 g s b nlplvt w=180e-9 m=1 nf=1
+        .ends nlplvt_s_pcell_0
+
+        .subckt nlplvt_s_pcell_1 d g s b
+        mi1 d g inet1 b nlplvt w=180e-9 m=1 nf=1
+        mi2 inet1 g s b nlplvt w=180e-9 m=1 nf=1
+        .ends nlplvt_s_pcell_1
+
+        .subckt nlplvt_s_pcell_2 d g s b
+        mi1 d g inet1 b nlplvt w=180e-9 m=1 nf=1
+        mi2 inet1 g s b nlplvt w=180e-9 m=1 nf=1
+        .ends nlplvt_s_pcell_2
+
+        .subckt nlplvt_s_pcell_3 d g s b
+        mi1 d g inet1 b nlplvt w=180e-9 m=1 nf=1
+        mi2 inet1 g s b nlplvt w=180e-9 m=1 nf=1
+        .ends nlplvt_s_pcell_3
+
+        .subckt nlplvt_s_pcell_4 d g s b
+        mi1 d g inet1 b nlplvt w=180e-9 m=1 nf=1
+        mi2 inet1 g inet2 b nlplvt w=180e-9 m=1 nf=1
+        mi3 inet2 g inet3 b nlplvt w=180e-9 m=1 nf=1
+        mi4 inet3 g s b nlplvt w=180e-9 m=1 nf=1
+        .ends nlplvt_s_pcell_4
+
+        .subckt plplvt_s_pcell_5 d g s b
+        mi2 inet1 g s b plplvt w=180e-9 m=1 nf=1
+        mi1 d g inet1 b plplvt w=180e-9 m=1 nf=1
+        .ends plplvt_s_pcell_5
+
+        .subckt plplvt_s_pcell_6 d g s b
+        mi2 inet1 g s b plplvt w=180e-9 m=1 nf=1
+        mi1 d g inet1 b plplvt w=180e-9 m=1 nf=1
+        .ends plplvt_s_pcell_6
+
+        .subckt plplvt_s_pcell_7 d g s b
+        mi2 inet1 g s b plplvt w=180e-9 m=1 nf=1
+        mi1 d g inet1 b plplvt w=180e-9 m=1 nf=1
+        .ends plplvt_s_pcell_7
+
+        .subckt {name} vbias_an vccx vfb vg v1 vref vssx vbias_bf en
+        xmn56 vbias6 vbias_bf vssx vssx nlplvt_s_pcell_0 m=4
+        xmn20 v5 v4 vssx vssx nlplvt_s_pcell_1 m=8
+        xmn40 vssx vbias_bf vssx vssx nlplvt_s_pcell_0 m=4
+        xmn41 vbias4 vbias_an vssx vssx nlplvt_s_pcell_0 m=4
+        xmn21 vbias2 vbias1 vbias3 vssx nlplvt_s_pcell_2 m=4
+        xmn37 v6 v4 vssx vssx nlplvt_s_pcell_1 m=8
+        xmn22 v1 vref vcom1 vssx nlplvt_s_pcell_3 m=20
+        xmn23 v2 vfb vcom1 vssx nlplvt_s_pcell_3 m=20
+        xmn38 v4 vbias3 v6 vssx nlplvt_s_pcell_1 m=8
+        xmn39 v3 vbias3 v5 vssx nlplvt_s_pcell_1 m=8
+        xmn55 v3_d vbias_bf vssx vssx nlplvt_s_pcell_4 m=8
+        xmn3 vssx vbias_an vssx vssx nlplvt_s_pcell_0 m=4
+        xmn2 vcom1 vbias_an vssx vssx nlplvt_s_pcell_4 m=8
+        mp23 vg en vccx vccx plplvt w=360e-9 m=1 nf=2
+        mp221 v3 en vccx vccx plplvt w=360e-9 m=1 nf=2
+        mp24 enb en vccx vccx plplvt w=360e-9 m=1 nf=2
+        mp5 vg vg vccx vccx plplvt w=720e-9 m=1 nf=4
+        mp29 v4 vbias2 v2 vccx plplvt w=2.16e-6 m=1 nf=12
+        mp30 v3 vbias2 v1 vccx plplvt w=2.16e-6 m=1 nf=12
+        mp33 vbias2 vbias2 vbias1 vccx plplvt w=1.44e-6 m=1 nf=8
+        mp1 v3_d v3 vg vccx plplvt w=1.44e-6 m=1 nf=8
+        xmp41 vbias6 vbias6 vccx vccx plplvt_s_pcell_5 m=4
+        xmp4 vg vbias6 vccx vccx plplvt_s_pcell_6 m=8
+        xmp22 v1 vbias1 vccx vccx plplvt_s_pcell_7 m=12
+        xmp34 vbias1 vbias1 vccx vccx plplvt_s_pcell_5 m=4
+        xmp28 v2 vbias1 vccx vccx plplvt_s_pcell_7 m=12
+        mn11 v3_d enb vssx vssx nlplvt w=360e-9 m=1 nf=2
+        mn12 enb en vssx vssx nlplvt w=360e-9 m=1 nf=2
+        mn322 vg v3_d vssx vssx nlplvt w=720e-9 m=1 nf=4
+        mn42 vbias3 vbias3 vbias4 vssx nlplvt w=1.44e-6 m=2 nf=8
+        .ends {name}
+    """)
+    return netlist

--- a/tests/pdk/finfet/test_annotation.py
+++ b/tests/pdk/finfet/test_annotation.py
@@ -10,7 +10,6 @@ except BaseException:
     import circuits
 
 
-@pytest.mark.skip
 def test_1():
     name = f'ckt_{get_test_id()}'
     netlist = circuits.ldo_amp(name)
@@ -21,7 +20,14 @@ def test_1():
         """)
     constraints = []
     example = build_example(name, netlist, setup, constraints)
-    run_example(example)
+    ckt_dir, run_dir = run_example(example, cleanup=False)
+
+    with (run_dir / '1_topology' / '__primitives__.json').open('rt') as fp:
+        primitives = json.load(fp)
+        print(primitives)
+
+    shutil.rmtree(run_dir)
+    shutil.rmtree(ckt_dir)
 
 
 def test_2():

--- a/tests/pdk/finfet/test_annotation.py
+++ b/tests/pdk/finfet/test_annotation.py
@@ -1,0 +1,48 @@
+import json
+import shutil
+import pytest
+import textwrap
+try:
+    from .utils import get_test_id, build_example, run_example
+    from . import circuits
+except BaseException:
+    from utils import get_test_id, build_example, run_example
+    import circuits
+
+
+@pytest.mark.skip
+def test_1():
+    name = f'ckt_{get_test_id()}'
+    netlist = circuits.ldo_amp(name)
+    setup = textwrap.dedent("""\
+        POWER = vccx
+        GND = vssx
+        DONT_USE_CELLS = CASCODED_CMC_NMOS CMB_PMOS_2 LSB_PMOS_2 LSB_NMOS_2
+        """)
+    constraints = []
+    example = build_example(name, netlist, setup, constraints)
+    run_example(example)
+
+
+def test_2():
+    name = f'ckt_{get_test_id()}'
+    netlist = textwrap.dedent("""\
+        mp29 v4 vbias2 v2 vccx p w=2.16e-6 m=1 nf=12
+        mp33 vbias2 vbias2 vbias1 vccx p w=1.44e-6 m=1 nf=8
+        """)
+    setup = textwrap.dedent("""\
+        POWER = vccx
+        GND = vssx
+        DONT_USE_CELLS = CASCODED_CMC_NMOS CMB_PMOS_2 LSB_PMOS_2 LSB_NMOS_2
+        """)
+    constraints = []
+    example = build_example(name, netlist, setup, constraints)
+    ckt_dir, run_dir = run_example(example, cleanup=False)
+
+    with (run_dir / '1_topology' / '__primitives__.json').open('rt') as fp:
+        primitives = json.load(fp)
+        for key, _ in primitives.items():
+            assert key.startswith('Switch'), 'Incorrect subcircuit identification'
+
+    shutil.rmtree(run_dir)
+    shutil.rmtree(ckt_dir)

--- a/tests/pdk/finfet/test_annotation.py
+++ b/tests/pdk/finfet/test_annotation.py
@@ -12,26 +12,6 @@ except BaseException:
 
 def test_1():
     name = f'ckt_{get_test_id()}'
-    netlist = circuits.ldo_amp(name)
-    setup = textwrap.dedent("""\
-        POWER = vccx
-        GND = vssx
-        DONT_USE_CELLS = CASCODED_CMC_NMOS CMB_PMOS_2 LSB_PMOS_2 LSB_NMOS_2
-        """)
-    constraints = []
-    example = build_example(name, netlist, setup, constraints)
-    ckt_dir, run_dir = run_example(example, cleanup=False)
-
-    with (run_dir / '1_topology' / '__primitives__.json').open('rt') as fp:
-        primitives = json.load(fp)
-        print(primitives)
-
-    shutil.rmtree(run_dir)
-    shutil.rmtree(ckt_dir)
-
-
-def test_2():
-    name = f'ckt_{get_test_id()}'
     netlist = textwrap.dedent("""\
         mp29 v4 vbias2 v2 vccx p w=2.16e-6 m=1 nf=12
         mp33 vbias2 vbias2 vbias1 vccx p w=1.44e-6 m=1 nf=8

--- a/tests/pdk/finfet/test_annotation.py
+++ b/tests/pdk/finfet/test_annotation.py
@@ -33,7 +33,6 @@ def test_2():
     setup = textwrap.dedent("""\
         POWER = vccx
         GND = vssx
-        DONT_USE_CELLS = CASCODED_CMC_NMOS CMB_PMOS_2 LSB_PMOS_2 LSB_NMOS_2
         """)
     constraints = []
     example = build_example(name, netlist, setup, constraints)
@@ -42,7 +41,7 @@ def test_2():
     with (run_dir / '1_topology' / '__primitives__.json').open('rt') as fp:
         primitives = json.load(fp)
         for key, _ in primitives.items():
-            assert key.startswith('Switch'), 'Incorrect subcircuit identification'
+            assert key.startswith('Switch') or key.startswith('DCL'), 'Incorrect subcircuit identification'
 
     shutil.rmtree(run_dir)
     shutil.rmtree(ckt_dir)

--- a/tests/pdk/finfet/test_circuits.py
+++ b/tests/pdk/finfet/test_circuits.py
@@ -132,3 +132,16 @@ def test_tia():
     constraints = []
     example = build_example(name, netlist, setup, constraints)
     run_example(example)
+
+
+def test_ldo_amp():
+    name = f'ckt_{get_test_id()}'
+    netlist = circuits.ldo_amp(name)
+    setup = textwrap.dedent("""\
+        POWER = vccx
+        GND = vssx
+        DONT_USE_CELLS = CASCODED_CMC_NMOS CMB_PMOS_2 LSB_PMOS_2 LSB_NMOS_2
+        """)
+    constraints = []
+    example = build_example(name, netlist, setup, constraints)
+    run_example(example)


### PR DESCRIPTION
Please see the failing test: `tests/pdk/finfet/test_annotation.py`

The netlist below is mapped to a level shifter:
```
        mp29 v4 vbias2 v2 vccx p w=2.16e-6 m=1 nf=12
        mp33 vbias2 vbias2 vbias1 vccx p w=1.44e-6 m=1 nf=8
```
This is wrong as the transistor widths are not the same. 