### PR TITLE
Generalize Align Constraint

### DIFF
--- a/PlaceRouteHierFlow/PnR-pybind11.cpp
+++ b/PlaceRouteHierFlow/PnR-pybind11.cpp
@@ -297,7 +297,8 @@ PYBIND11_MODULE(PnR, m) {
   py::class_<AlignBlock>( m, "AlignBlock")
     .def( py::init<>())
     .def_readwrite("blocks", &AlignBlock::blocks)
-    .def_readwrite("horizon", &AlignBlock::horizon);
+    .def_readwrite("horizon", &AlignBlock::horizon)
+    .def_readwrite("line", &AlignBlock::line);
   py::class_<PortPos>( m, "PortPos")
     .def( py::init<>())
     .def_readwrite("tid", &PortPos::tid)

--- a/PlaceRouteHierFlow/PnRDB/ReadConstraint.cpp
+++ b/PlaceRouteHierFlow/PnRDB/ReadConstraint.cpp
@@ -317,10 +317,27 @@ void PnRdatabase::ReadConstraint_Json(PnRDB::hierNode& node, const string& jsonS
       node.CC_Caps.push_back(temp_cccap);
     } else if (constraint["const_name"] == "AlignBlock") {
       PnRDB::AlignBlock alignment_unit;
-      if (constraint["direction"] == "H") {
+      size_t found;
+      if(constraint["line"] == "h_bottom") {
         alignment_unit.horizon = 1;
-      } else {
+        alignment_unit.line = 0;
+      } else if (constraint["line"] == "h_center") {
+        alignment_unit.horizon = 1;
+        alignment_unit.line = 1;
+      } else if (constraint["line"] == "h_top") {
+        alignment_unit.horizon = 1;
+        alignment_unit.line = 2;
+      } else if (constraint["line"] == "v_left") {
         alignment_unit.horizon = 0;
+        alignment_unit.line = 0;
+      } else if (constraint["line"] == "v_center") {
+        alignment_unit.horizon = 0;
+        alignment_unit.line = 1;
+      } else if (constraint["line"] == "v_right") {
+        alignment_unit.horizon = 0;
+        alignment_unit.line = 2;
+      } else {
+        logger->error("PnRDB-Error: wrong AlignBlock constraint: line {0}", constraint["line"]);
       }
       for (auto block : constraint["blocks"]) {
         for (int i = 0; i < (int)node.Blocks.size(); i++) {

--- a/PlaceRouteHierFlow/PnRDB/datatype.h
+++ b/PlaceRouteHierFlow/PnRDB/datatype.h
@@ -483,6 +483,7 @@ struct MatchBlock {
 struct AlignBlock {
   std::vector<int> blocks;
   int horizon; // 1 is h, 0 is v.
+  int line; // 0 is left or bottom, 1 is center, 2 is right or top
 };
 
 struct PortPos {

--- a/PlaceRouteHierFlow/placer/ILP_solver.cpp
+++ b/PlaceRouteHierFlow/placer/ILP_solver.cpp
@@ -315,15 +315,43 @@ double ILP_solver::GenerateValidSolution(design& mydesign, SeqPair& curr_sp, PnR
     for (unsigned int j = 0; j < alignment_unit.blocks.size() - 1; j++) {
       int first_id = alignment_unit.blocks[j], second_id = alignment_unit.blocks[j + 1];
       if (alignment_unit.horizon == 1) {
-        // same y
-        double sparserow[2] = {1, -1};
-        int colno[2] = {first_id * 4 + 2, second_id * 4 + 2};
-        add_constraintex(lp, 2, sparserow, colno, EQ, 0);
+        if(alignment_unit.line == 0){
+          // align to bottom
+          double sparserow[2] = {1, -1};
+          int colno[2] = {first_id * 4 + 2, second_id * 4 + 2};
+          add_constraintex(lp, 2, sparserow, colno, EQ, 0);
+        } else if (alignment_unit.line == 1){
+          // align center y
+          double sparserow[2] = {1, -1};
+          int colno[2] = {first_id * 4 + 2, second_id * 4 + 2};
+          int bias = - mydesign.Blocks[first_id][curr_sp.selected[first_id]].height / 2 + mydesign.Blocks[second_id][curr_sp.selected[second_id]].height / 2;
+          add_constraintex(lp, 2, sparserow, colno, EQ, bias);
+        } else {
+          // align to top
+          double sparserow[2] = {1, -1};
+          int colno[2] = {first_id * 4 + 2, second_id * 4 + 2};
+          int bias = - mydesign.Blocks[first_id][curr_sp.selected[first_id]].height + mydesign.Blocks[second_id][curr_sp.selected[second_id]].height;
+          add_constraintex(lp, 2, sparserow, colno, EQ, bias);
+        }
       } else {
-        // same x
-        double sparserow[2] = {1, -1};
-        int colno[2] = {first_id * 4 + 1, second_id * 4 + 1};
-        add_constraintex(lp, 2, sparserow, colno, EQ, 0);
+        if(alignment_unit.line == 0){
+          // align to left
+          double sparserow[2] = {1, -1};
+          int colno[2] = {first_id * 4 + 1, second_id * 4 + 1};
+          add_constraintex(lp, 2, sparserow, colno, EQ, 0);
+        } else if (alignment_unit.line == 1){
+          // align center x
+          double sparserow[2] = {1, -1};
+          int colno[2] = {first_id * 4 + 1, second_id * 4 + 1};
+          int bias = - mydesign.Blocks[first_id][curr_sp.selected[first_id]].width / 2 + mydesign.Blocks[second_id][curr_sp.selected[second_id]].width / 2;
+          add_constraintex(lp, 2, sparserow, colno, EQ, bias);
+        } else {
+          // align to right
+          double sparserow[2] = {1, -1};
+          int colno[2] = {first_id * 4 + 1, second_id * 4 + 1};
+          int bias = - mydesign.Blocks[first_id][curr_sp.selected[first_id]].width + mydesign.Blocks[second_id][curr_sp.selected[second_id]].width;
+          add_constraintex(lp, 2, sparserow, colno, EQ, bias);
+        }
       }
     }
   }

--- a/PlaceRouteHierFlow/placer/design.cpp
+++ b/PlaceRouteHierFlow/placer/design.cpp
@@ -274,6 +274,7 @@ design::design(design& other, int mode) {
         this->Align_blocks.resize( this->Align_blocks.size() );
         this->Align_blocks.back().blocks=tmpB;
         this->Align_blocks.back().horizon=it->horizon;
+        this->Align_blocks.back().line = it->line;
       }
     }
     logger->debug("Test: add paramenter");
@@ -537,6 +538,7 @@ design::design(PnRDB::hierNode& node) {
   for(vector<PnRDB::AlignBlock>::iterator it=node.Align_blocks.begin();it!=node.Align_blocks.end();++it) {
     this->Align_blocks.resize(this->Align_blocks.size()+1);
     this->Align_blocks.back().horizon=it->horizon;
+    this->Align_blocks.back().line=it->line;
     for(std::vector<int>::iterator it2=it->blocks.begin();it2!=it->blocks.end();++it2) {
       this->Align_blocks.back().blocks.push_back(*it2);
     }

--- a/PlaceRouteHierFlow/placer/design.h
+++ b/PlaceRouteHierFlow/placer/design.h
@@ -142,6 +142,7 @@ class design
     struct AlignBlock {
       std::vector<int> blocks;
       int horizon; // 1 is h, 0 is v.
+      int line; // 0 is left or bottom, 1 is center, 2 is right or top
     };
     vector<AlignBlock> Align_blocks;
 

--- a/align/pnr/write_constraint.py
+++ b/align/pnr/write_constraint.py
@@ -104,7 +104,7 @@ class PnRConstraintWriter:
                 del const["blocks"]
             elif const["const_name"] == 'Align':
                 const["const_name"] = 'AlignBlock'
-                if const['line'] not in ['h_bottom', 'h_top', 'h_center', 'v_right', 'v_left', 'v_center']:
+                if const['line'] not in ['h_bottom', 'h_top', 'v_right', 'v_left', 'v_center']:
                     raise NotImplementedError(f'PnR does not support edge {const["line"]} yet')
             elif const["const_name"] == 'SymmetricNets':
                 const["const_name"] = 'SymmNet'

--- a/align/pnr/write_constraint.py
+++ b/align/pnr/write_constraint.py
@@ -104,13 +104,8 @@ class PnRConstraintWriter:
                 del const["blocks"]
             elif const["const_name"] == 'Align':
                 const["const_name"] = 'AlignBlock'
-                if const["line"] in ('h_bottom', 'h_any'):
-                    const["direction"] = 'H'
-                elif const["line"] in ('v_left', 'v_any'):
-                    const["direction"] = 'V'
-                else:
+                if const['line'] not in ['h_bottom', 'h_top', 'h_center', 'v_right', 'v_left', 'v_center']:
                     raise NotImplementedError(f'PnR does not support edge {const["line"]} yet')
-                del const["line"]
             elif const["const_name"] == 'SymmetricNets':
                 const["const_name"] = 'SymmNet'
                 const["axis_dir"] = const.pop("direction")

--- a/tests/constraints/test_constraint.py
+++ b/tests/constraints/test_constraint.py
@@ -75,3 +75,15 @@ def test_order_abut():
     ]
     example = build_example(name, netlist, setup, constraints)
     run_example(example)
+
+
+def test_align_top_right():
+    name = f'ckt_{get_test_id()}'
+    netlist = circuits.cascode_amplifier(name)
+    setup = ""
+    constraints = [
+        {"constraint": "AlignInOrder", "direction": "vertical", "line": "right", "instances": ["mn0", "mn1"]},
+        {"constraint": "AlignInOrder", "direction": "horizontal", "line": "top", "instances": ["mn1", "mp1"]}
+    ]
+    example = build_example(name, netlist, setup, constraints)
+    run_example(example)

--- a/tests/constraints/test_constraint.py
+++ b/tests/constraints/test_constraint.py
@@ -79,11 +79,34 @@ def test_order_abut():
 
 def test_align_top_right():
     name = f'ckt_{get_test_id()}'
-    netlist = circuits.cascode_amplifier(name)
+    netlist = textwrap.dedent(f"""\
+        .subckt {name} vin vop vcc vss nbs pbs
+        mp1 vop pbs vcc vcc p w=720e-9 nf=4 m=8
+        mn1 vop nbs vmd vss n w=720e-9 nf=4 m=6
+        mn0 vmd vin vss vss n w=720e-9 nf=4 m=4
+        .ends {name}
+        """)
     setup = ""
     constraints = [
         {"constraint": "AlignInOrder", "direction": "vertical", "line": "right", "instances": ["mn0", "mn1"]},
         {"constraint": "AlignInOrder", "direction": "horizontal", "line": "top", "instances": ["mn1", "mp1"]}
     ]
+    example = build_example(name, netlist, setup, constraints)
+    run_example(example)
+
+
+def test_align_center():
+    name = f'ckt_{get_test_id()}'
+    netlist = textwrap.dedent(f"""\
+        .subckt {name} vin vop vcc vss nbs pbs
+        mp1 vop pbs vcc vcc p w=720e-9 nf=4 m=8
+        mn1 vop nbs vmd vss n w=720e-9 nf=4 m=6
+        mn0 vmd vin vss vss n w=720e-9 nf=4 m=4
+        .ends {name}
+        """)
+    setup = ""
+    constraints = [
+        {"constraint": "AlignInOrder", "direction": "vertical", "line": "center", "instances": ["mn0", "mn1", "mn2"]}
+        ]
     example = build_example(name, netlist, setup, constraints)
     run_example(example)

--- a/tests/constraints/test_constraint.py
+++ b/tests/constraints/test_constraint.py
@@ -101,12 +101,12 @@ def test_align_center():
         .subckt {name} vin vop vcc vss nbs pbs
         mp1 vop pbs vcc vcc p w=720e-9 nf=4 m=8
         mn1 vop nbs vmd vss n w=720e-9 nf=4 m=6
-        mn0 vmd vin vss vss n w=720e-9 nf=4 m=4
+        mn0 vmd vin vss vss n w=720e-9 nf=4 m=16
         .ends {name}
         """)
     setup = ""
     constraints = [
-        {"constraint": "AlignInOrder", "direction": "vertical", "line": "center", "instances": ["mn0", "mn1", "mn2"]}
+        {"constraint": "AlignInOrder", "direction": "vertical", "line": "center", "instances": ["mn0", "mn1", "mp1"]}
         ]
     example = build_example(name, netlist, setup, constraints)
     run_example(example)

--- a/tests/files/test_results/high_speed_comparator_align.pnr.const.json
+++ b/tests/files/test_results/high_speed_comparator_align.pnr.const.json
@@ -57,6 +57,7 @@
             ]
         },
         {
+            "line": "h_bottom",
             "const_name": "AlignBlock",
             "blocks": [
                 "mp9",
@@ -64,17 +65,16 @@
                 "mn1_mn2",
                 "mp8",
                 "mp10"
-            ],
-            "direction": "H"
+            ]
         },
         {
+            "line": "h_bottom",
             "const_name": "AlignBlock",
             "blocks": [
                 "mp11_mn13",
                 "mp5_mp6",
                 "mp12_mn14"
-            ],
-            "direction": "H"
+            ]
         },
         {
             "const_name": "DoNotIdentify",

--- a/tests/files/test_results/high_speed_comparator_multiconnection.pnr.const.json
+++ b/tests/files/test_results/high_speed_comparator_multiconnection.pnr.const.json
@@ -47,8 +47,8 @@
         },
         {
             "direction": "V",
-            "const_name": "Ordering",
             "abut": false,
+            "const_name": "Ordering",
             "blocks": [
                 "mn0",
                 "mn1_mn2",
@@ -57,6 +57,7 @@
             ]
         },
         {
+            "line": "h_bottom",
             "const_name": "AlignBlock",
             "blocks": [
                 "mp9",
@@ -64,17 +65,16 @@
                 "mn1_mn2",
                 "mp8",
                 "mp10"
-            ],
-            "direction": "H"
+            ]
         },
         {
+            "line": "h_bottom",
             "const_name": "AlignBlock",
             "blocks": [
                 "mp11_mn13",
                 "mp5_mp6",
                 "mp12_mn14"
-            ],
-            "direction": "H"
+            ]
         },
         {
             "const_name": "Multi_Connection",

--- a/tests/files/test_results/high_speed_comparator_portlocation.pnr.const.json
+++ b/tests/files/test_results/high_speed_comparator_portlocation.pnr.const.json
@@ -47,8 +47,8 @@
         },
         {
             "direction": "V",
-            "const_name": "Ordering",
             "abut": false,
+            "const_name": "Ordering",
             "blocks": [
                 "mn0",
                 "mn1_mn2",
@@ -57,6 +57,7 @@
             ]
         },
         {
+            "line": "h_bottom",
             "const_name": "AlignBlock",
             "blocks": [
                 "mp9",
@@ -64,17 +65,16 @@
                 "mn1_mn2",
                 "mp8",
                 "mp10"
-            ],
-            "direction": "H"
+            ]
         },
         {
+            "line": "h_bottom",
             "const_name": "AlignBlock",
             "blocks": [
                 "mp11_mn13",
                 "mp5_mp6",
                 "mp12_mn14"
-            ],
-            "direction": "H"
+            ]
         },
         {
             "const_name": "PortLocation",

--- a/tests/files/test_results/high_speed_comparator_symmnet.pnr.const.json
+++ b/tests/files/test_results/high_speed_comparator_symmnet.pnr.const.json
@@ -47,8 +47,8 @@
         },
         {
             "direction": "V",
-            "const_name": "Ordering",
             "abut": false,
+            "const_name": "Ordering",
             "blocks": [
                 "mn0",
                 "mn1_mn2",
@@ -57,6 +57,7 @@
             ]
         },
         {
+            "line": "h_bottom",
             "const_name": "AlignBlock",
             "blocks": [
                 "mp9",
@@ -64,17 +65,16 @@
                 "mn1_mn2",
                 "mp8",
                 "mp10"
-            ],
-            "direction": "H"
+            ]
         },
         {
+            "line": "h_bottom",
             "const_name": "AlignBlock",
             "blocks": [
                 "mp11_mn13",
                 "mp5_mp6",
                 "mp12_mn14"
-            ],
-            "direction": "H"
+            ]
         },
         {
             "net1": {


### PR DESCRIPTION
Allow user to align blocks on top, bottom, left, right and center (horizontal or vertical) as defined per  `class Align` in `align/schema/constraint.py`. Please see `tests/constraints/test_constraint.py:test_align_top_right`

Example:
 ```
       {
            "line": < { h_bottom, h_top, v_left, v_right, v_center }> ,
            "const_name": "AlignBlock",
            "blocks": [
                "mn0",
                "mn1"
            ]
        }
```