### PR TITLE
Flipping incorrect in synthetic testcase

### DIFF
--- a/PlaceRouteHierFlow/placer/ILP_solver.cpp
+++ b/PlaceRouteHierFlow/placer/ILP_solver.cpp
@@ -461,7 +461,7 @@ double ILP_solver::GenerateValidSolution(design& mydesign, SeqPair& curr_sp, PnR
       }
     }
     // add estimated area
-    row[curr_sp.negPair[URblock_neg_id] * 4 + 2] += estimated_width / 2;
+    for (unsigned int i = 0; i < mydesign.Blocks.size(); i++) row[curr_sp.negPair[i] * 4 + 2] += estimated_width / 2;
     // estimate height
     for (unsigned int i = URblock_pos_id; i < curr_sp.posPair.size(); i++) {
       if (curr_sp.posPair[i] < int(mydesign.Blocks.size())) {
@@ -469,7 +469,7 @@ double ILP_solver::GenerateValidSolution(design& mydesign, SeqPair& curr_sp, PnR
       }
     }
     // add estimated area
-    row[curr_sp.negPair[URblock_neg_id] * 4 + 1] += estimated_height / 2;
+    for (unsigned int i = 0; i < mydesign.Blocks.size(); i++) row[curr_sp.negPair[i] * 4 + 1] += estimated_height / 2;
 
     set_obj_fn(lp, row);
     set_minim(lp);

--- a/PlaceRouteHierFlow/placer/Placer.cpp
+++ b/PlaceRouteHierFlow/placer/Placer.cpp
@@ -635,14 +635,16 @@ std::map<double, std::pair<SeqPair, ILP_solver>> Placer::PlacementCoreAspectRati
       double trial_cost = trial_sol.GenerateValidSolution(designData, trial_sp, drcInfo);
       if (trial_cost >= 0) {
         oData[trial_cost] = std::make_pair(trial_sp, trial_sol);
-        bool Smark = false;
-        delta_cost = trial_cost - curr_cost;
-        if (delta_cost <= 0) {
-          Smark = true;
-        } else {
-          double r = (double)rand() / RAND_MAX;
-          if (r < exp((-1.0 * delta_cost) / T)) {
+        bool Smark = trial_sp.Enumerate();
+        if (!Smark) {
+          delta_cost = trial_cost - curr_cost;
+          if (delta_cost <= 0) {
             Smark = true;
+          } else {
+            double r = (double)rand() / RAND_MAX;
+            if (r < exp((-1.0 * delta_cost) / T)) {
+              Smark = true;
+            }
           }
         }
         if (Smark) {

--- a/PlaceRouteHierFlow/placer/SeqPair.cpp
+++ b/PlaceRouteHierFlow/placer/SeqPair.cpp
@@ -111,6 +111,8 @@ SeqPairEnumerator::SeqPairEnumerator(const vector<int>& pair, design& casenl, co
       _valid = 0;
     }
     logger->debug("enumeration check valid : {0}\n maxIter : {1} seq pair size : {2} total enumerations : {3}", (_valid ? 1 : 0), maxIter, _posPair.size(), totEnum);
+  } else {
+    _maxEnum = _posEnumerator.NumSequences() * _negEnumerator.NumSequences();
   }
   if (!_valid) return;
   std::sort(_posPair.begin(), _posPair.end());

--- a/PlaceRouteHierFlow/placer/SeqPair.cpp
+++ b/PlaceRouteHierFlow/placer/SeqPair.cpp
@@ -112,7 +112,7 @@ SeqPairEnumerator::SeqPairEnumerator(const vector<int>& pair, design& casenl, co
     }
     logger->debug("enumeration check valid : {0}\n maxIter : {1} seq pair size : {2} total enumerations : {3}", (_valid ? 1 : 0), maxIter, _posPair.size(), totEnum);
   } else {
-    _maxEnum = _posEnumerator.NumSequences() * _negEnumerator.NumSequences();
+    _maxEnum = _posEnumerator.NumSequences();
   }
   if (!_valid) return;
   std::sort(_posPair.begin(), _posPair.end());
@@ -134,7 +134,7 @@ SeqPairEnumerator::SeqPairEnumerator(const vector<int>& pair, design& casenl, co
 
 const bool SeqPairEnumerator::IncrementSelected()
 {
-  return false;
+  //auto logger = spdlog::default_logger()->clone("placer.SeqPairEnumerator.IncrementSelected");
   if (_maxSize <= 1) return false;
   int i = _selected.size() - 1;
   int rem = 1;
@@ -198,6 +198,7 @@ void SeqPairEnumerator::Permute()
     }
   }
   if (_enumIndex.first >= _maxEnum) _exhausted = true;
+  //logger->info("enum index : {0} {1}", _enumIndex.first, _enumIndex.second);
 }
 
 SeqPair::SeqPair() {

--- a/PlaceRouteHierFlow/placer/SeqPair.h
+++ b/PlaceRouteHierFlow/placer/SeqPair.h
@@ -42,6 +42,7 @@ class OrderedEnumerator {
     bool NextPermutation(vector<int>& seq);
     void print();
     bool valid() const { return _valid; }
+    size_t NumSequences() const { return _sequences.size(); }
 };
 
 class SeqPairEnumerator

--- a/align/gui/mockup.py
+++ b/align/gui/mockup.py
@@ -586,8 +586,8 @@ class AppWithCallbacksAndState:
             self.make_placement_graph(display_type=display_type,display_pins_type=display_pins_type,netname=netname)
 
 
+        options = []
         if self.nets_d is not None:
-            options = []
             for k, v in self.nets_d.items():
                 net = '/'.join(k)
                 options.append( {"value": net, "label": net})

--- a/tests/pnr/test_entrypoint2.py
+++ b/tests/pnr/test_entrypoint2.py
@@ -98,7 +98,15 @@ def gen_matrix_module(nm, n=3):
 def gen_primitives(run_dir):
     primitives_d = {}
     
-    for suffix in ['_a', '_b', '_c']:
+    sizes = [ ('_an', (10,10,1)),
+              ('_bn', ( 5,20,1)),
+              ('_cn', (20, 5,1)),
+              ('_af', (10,10,-1)),
+              ('_bf', ( 5,20,-1)),
+              ('_cf', (20, 5,-1))]
+             
+
+    for suffix, _ in sizes:
         atn = 'slice'
         ctn = f'{atn}{suffix}'
         primitives_d[ctn] = { 'abstract_template_name': atn,
@@ -116,16 +124,13 @@ def gen_primitives(run_dir):
     xstopdelta = 36
     yhalfwidth = 16
 
-    sizes = [ ('_a', (10,10)),
-              ('_b', ( 5,20)),
-              ('_c', (20, 5))]
 
-    for suffix, (nx,ny) in sizes:
+    for suffix, (nx,ny,sY) in sizes:
 
         bbox = [0,0,nx*xpitch,ny*ypitch]
 
         sx,ex = 2,nx-2
-        inp_y,out_y = 2,ny-2
+        inp_y,out_y = (2, ny-2) if sY == 1 else (ny-2, 2)
 
         terminals = [
             {

--- a/tests/pnr/test_entrypoint2.py
+++ b/tests/pnr/test_entrypoint2.py
@@ -1,12 +1,9 @@
 import json
 import pathlib
-import io
-import pytest
 import os
 import shutil
 import datetime
 
-from align.pnr.cmdline import cmdline
 from align.cell_fabric import pdk, gen_gds_json, gen_lef
 
 import align
@@ -19,7 +16,7 @@ else:
     os.environ['ALIGN_HOME'] = str(ALIGN_HOME)
 
 if 'ALIGN_WORK_DIR' in os.environ:
-    ALIGN_WORK_DIR = pathlib.Path( os.environ['ALIGN_WORK_DIR']).resolve() 
+    ALIGN_WORK_DIR = pathlib.Path(os.environ['ALIGN_WORK_DIR']).resolve()
 else:
     ALIGN_WORK_DIR = ALIGN_HOME / 'tests' / 'tmp'
 
@@ -28,144 +25,153 @@ pdkdir = pathlib.Path(__file__).parent.parent.parent / "pdks" / "FinFET14nm_Mock
 
 p = pdk.Pdk().load(pdkdir / 'layers.json')
 
+
 def gen_row_module(nm, n=3):
     instances = []
     for i in range(n):
-        inp = 'inp' if i==0   else f'x{i}'
-        out = 'out' if i==n-1 else f'x{i+1}'
+        inp = 'inp' if i == 0 else f'x{i}'
+        out = 'out' if i == n - 1 else f'x{i+1}'
         instance = {
             'instance_name': f'u{i}',
             'abstract_template_name': 'slice',
-            'fa_map': [ {'formal': 'inp', 'actual': inp},
-                        {'formal': 'out', 'actual': out}]
-        }    
-        instances.append( instance)
+            'fa_map': [{'formal': 'inp', 'actual': inp},
+                       {'formal': 'out', 'actual': out}]
+        }
+        instances.append(instance)
 
     topmodule = {
         'name': nm,
-        'parameters': ["inp","out"],
+        'parameters': ["inp", "out"],
         'instances': instances,
         'constraints': [
             {
                 'constraint': 'Order',
                 'direction': 'left_to_right',
-                'instances': [ f'u{i}' for i in range(n)],
+                'instances': [f'u{i}' for i in range(n)],
                 'abut': False
-            },
-            {
-                'constraint': 'SameTemplate',
-                'instances': [ f'u{i}' for i in range(n)]
             }
         ]
     }
-    
+
+    topmodule['constraints'].append(
+        {
+            'constraint': 'SameTemplate',
+            'instances': [f'u{i}' for i in range(n)]
+        }
+    )
+
     return topmodule
+
 
 def gen_matrix_module(nm, n=3):
     instances = []
     for i in range(n):
-        inp = 'inp' if i==0   else f'x{i}'
-        out = 'out' if i==n-1 else f'x{i+1}'
+        inp = 'inp' if i == 0 else f'x{i}'
+        out = 'out' if i == n - 1 else f'x{i+1}'
         instance = {
             'instance_name': f'u{i}',
             'abstract_template_name': 'row',
-            'fa_map': [ {'formal': 'inp', 'actual': inp},
-                        {'formal': 'out', 'actual': out}]
-        }    
-        instances.append( instance)
+            'fa_map': [{'formal': 'inp', 'actual': inp},
+                       {'formal': 'out', 'actual': out}]
+        }
+        instances.append(instance)
 
     topmodule = {
         'name': nm,
-        'parameters': ["inp","out"],
+        'parameters': ["inp", "out"],
         'instances': instances,
         'constraints': [
             {
                 'constraint': 'Order',
                 'direction': 'top_to_bottom',
-                'instances': [ f'u{i}' for i in range(n)],
+                'instances': [f'u{i}' for i in range(n)],
                 'abut': False
-            },
-            {
-                'constraint': 'SameTemplate',
-                'instances': [ f'u{i}' for i in range(n)]
             }
         ]
     }
-    
+
+    topmodule['constraints'].append(
+        {
+            'constraint': 'SameTemplate',
+            'instances': [f'u{i}' for i in range(n)]
+        }
+    )
+
     return topmodule
 
 
 def gen_primitives(run_dir):
     primitives_d = {}
-    
-    sizes = [ ('_an', (10,10,1)),
-              ('_bn', ( 5,20,1)),
-              ('_cn', (20, 5,1)),
-              ('_af', (10,10,-1)),
-              ('_bf', ( 5,20,-1)),
-              ('_cf', (20, 5,-1))]
-             
+
+    sizes = [('_an', (10, 10, 1)),
+             ('_bn', (5, 20, 1)),
+             ('_cn', (20, 5, 1)),
+             ('_af', (10, 10, -1)),
+             ('_bf', (5, 20, -1)),
+             ('_cf', (20, 5, -1))]
+
+    sizes = [('_a', (10, 10, 1)),
+             ('_b', (5, 20, 1)),
+             ('_c', (20, 5, 1))]
 
     for suffix, _ in sizes:
         atn = 'slice'
         ctn = f'{atn}{suffix}'
-        primitives_d[ctn] = { 'abstract_template_name': atn,
-                              'concrete_template_name': ctn}
+        primitives_d[ctn] = {'abstract_template_name': atn,
+                             'concrete_template_name': ctn}
 
-    with (run_dir / '1_topology' / f'__primitives__.json').open('wt') as fp:
-        json.dump( primitives_d, fp=fp, indent=2)
+    with (run_dir / '1_topology' / '__primitives__.json').open('wt') as fp:
+        json.dump(primitives_d, fp=fp, indent=2)
 
-    with (run_dir / '2_primitives' / f'__primitives__.json').open('wt') as fp:
-        json.dump( primitives_d, fp=fp, indent=2)
-    
+    with (run_dir / '2_primitives' / '__primitives__.json').open('wt') as fp:
+        json.dump(primitives_d, fp=fp, indent=2)
 
     xpitch = 80
     ypitch = 84
     xstopdelta = 36
     yhalfwidth = 16
 
+    for suffix, (nx, ny, sY) in sizes:
 
-    for suffix, (nx,ny,sY) in sizes:
+        bbox = [0, 0, nx * xpitch, ny * ypitch]
 
-        bbox = [0,0,nx*xpitch,ny*ypitch]
-
-        sx,ex = 2,nx-2
-        inp_y,out_y = (2, ny-2) if sY == 1 else (ny-2, 2)
+        sx, ex = 2, nx - 2
+        inp_y, out_y = (2, ny - 2) if sY == 1 else (ny - 2, 2)
 
         terminals = [
             {
                 "layer": "M2",
                 "netName": "inp",
-                "rect": [sx*xpitch-xstopdelta, inp_y*ypitch-yhalfwidth,
-                         ex*xpitch+xstopdelta, inp_y*ypitch+yhalfwidth],
+                "rect": [sx * xpitch - xstopdelta, inp_y * ypitch - yhalfwidth,
+                         ex * xpitch + xstopdelta, inp_y * ypitch + yhalfwidth],
                 "netType": "pin"
             },
             {
                 "layer": "M2",
                 "netName": "out",
-                "rect": [sx*xpitch-xstopdelta, out_y*ypitch-yhalfwidth,
-                         ex*xpitch+xstopdelta, out_y*ypitch+yhalfwidth],
+                "rect": [sx * xpitch - xstopdelta, out_y * ypitch - yhalfwidth,
+                         ex * xpitch + xstopdelta, out_y * ypitch + yhalfwidth],
                 "netType": "pin"
             }
         ]
 
-        layout_d = { 'bbox': bbox,
-                     'globalRoutes': [],
-                     'globalRouteGrid': [],
-                     'terminals': terminals
-        }
+        layout_d = {'bbox': bbox,
+                    'globalRoutes': [],
+                    'globalRouteGrid': [],
+                    'terminals': terminals
+                    }
 
         ctn = f'slice{suffix}'
 
         with (run_dir / '2_primitives' / f'{ctn}.json').open('wt') as fp:
-            json.dump( layout_d, fp=fp, indent=2)
+            json.dump(layout_d, fp=fp, indent=2)
 
         with (run_dir / '2_primitives' / f'{ctn}.json').open('rt') as fp0, \
              (run_dir / '2_primitives' / f'{ctn}.gds.json').open('wt') as fp1:
-            gen_gds_json.translate(ctn, '', 0, fp0, fp1, datetime.datetime( 2019, 1, 1, 0, 0, 0), p)
+            gen_gds_json.translate(ctn, '', 0, fp0, fp1, datetime.datetime(2019, 1, 1, 0, 0, 0), p)
 
-        gen_lef.json_lef( run_dir / '2_primitives' / f'{ctn}.json', ctn,
-                          cell_pin=['inp','out'], bodyswitch=1, blockM=0, p=p)
+        gen_lef.json_lef(run_dir / '2_primitives' / f'{ctn}.json', ctn,
+                         cell_pin=['inp', 'out'], bodyswitch=1, blockM=0, p=p)
 
 
 def test_row():
@@ -184,18 +190,18 @@ def test_row():
 
     topmodule = gen_row_module(nm)
 
-    verilog_d = { 'modules': [topmodule], 'global_signals': []}
+    verilog_d = {'modules': [topmodule], 'global_signals': []}
 
     with (run_dir / '1_topology' / f'{nm}.verilog.json').open('wt') as fp:
-        json.dump( verilog_d, fp=fp, indent=2)
+        json.dump(verilog_d, fp=fp, indent=2)
 
     gen_primitives(run_dir)
 
-    #==========================
+    # ==========================
 
     os.chdir(run_dir)
 
-    args = [ 'dummy_input_directory_can_be_anything', '-s', nm, '--flow_start', '3_pnr', '--skipGDS']
+    args = ['dummy_input_directory_can_be_anything', '-s', nm, '--flow_start', '3_pnr', '--skipGDS']
     results = align.CmdlineParser().parse_args(args)
 
     assert results is not None
@@ -218,18 +224,18 @@ def test_matrix():
     rowmodule = gen_row_module('row', n=3)
     topmodule = gen_matrix_module(nm, n=4)
 
-    verilog_d = { 'modules': [topmodule,rowmodule], 'global_signals': []}
+    verilog_d = {'modules': [topmodule, rowmodule], 'global_signals': []}
 
     with (run_dir / '1_topology' / f'{nm}.verilog.json').open('wt') as fp:
-        json.dump( verilog_d, fp=fp, indent=2)
+        json.dump(verilog_d, fp=fp, indent=2)
 
     gen_primitives(run_dir)
 
-    #==========================
+    # ==========================
 
     os.chdir(run_dir)
 
-    args = [ 'dummy_input_directory_can_be_anything', '-s', nm, '--flow_start', '3_pnr', '--skipGDS']
+    args = ['dummy_input_directory_can_be_anything', '-s', nm, '--flow_start', '3_pnr', '--skipGDS']
     results = align.CmdlineParser().parse_args(args)
 
     assert results is not None


### PR DESCRIPTION
@srini229 @854768750 @Lastdayends We don't seem to be finding a good solution for the matrix testcase any more. I suspect this has to do with the ILP flipping code but I'm not sure.

![Screenshot from 2021-08-04 10-42-32](https://user-images.githubusercontent.com/1512574/128229017-a6d7b2df-31ee-4e7d-b87d-7b4c51606723.png)

It is trying to minimize wire length (all the wires are short), but it doesn't seem to be using the best area solution (you would be able to flip the to middle rows around the y-axis to make the layout a square.)

To reproduce this, do the following:

```
export ALIGN_HOME=`pwd`
export ALIGN_WORK_DIR=$ALIGN_HOME/work

pytest -- tests/pnr/test_entrypoint2.py

cd $ALIGN_WORK_DIR/matrix_entrypoint2

schematic2layout.py this_doesnt_matter -s matrix -p /home/smburns/DARPA/ALIGN-public/pdks/FinFET14nm_Mock_PDK --flow_start 3_pnr --skipGDS --gui -n 40
```

It also seems that one variant is being generated even though we are asking for 40. We used to have several.