### PR TITLE
Case-insensitive Circuit Schema + Formalized Transformation Pipeline

### DIFF
--- a/align/schema/constraint.py
+++ b/align/schema/constraint.py
@@ -3,7 +3,7 @@ import more_itertools as itertools
 import re
 
 from . import types
-from .types import Union, Optional, Literal, List, String, set_context
+from .types import Union, Optional, Literal, List, SpiceStr, set_context
 from . import checker
 
 import logging
@@ -33,7 +33,7 @@ def validate_instances(cls, value):
 
 class SoftConstraint(types.BaseModel):
 
-    constraint: String
+    constraint: SpiceStr
 
     def __init__(self, *args, **kwargs):
         constraint = pattern.sub(
@@ -86,7 +86,7 @@ class PlacementConstraint(HardConstraint):
 
 
 class SameTemplate(PlacementConstraint):
-    instances: List[String]
+    instances: List[SpiceStr]
 
     def check(self, checker):
         pass
@@ -113,7 +113,7 @@ class Order(PlacementConstraint):
     If `abut` is `True`:
     > adjoining instances will touch
     '''
-    instances: List[String]
+    instances: List[SpiceStr]
     direction: Optional[Literal[
         'horizontal', 'vertical',
         'left_to_right', 'right_to_left',
@@ -184,7 +184,7 @@ class Align(PlacementConstraint):
     > `'v_right'`
     > `'v_center'`
     '''
-    instances: List[String]
+    instances: List[SpiceStr]
     line: Optional[Literal[
         'h_any', 'h_top', 'h_bottom', 'h_center',
         'v_any', 'v_left', 'v_right', 'v_center'
@@ -254,7 +254,7 @@ class Enclose(PlacementConstraint):
     > `min_aspect_ratio`
     > `max_aspect_ratio`
     '''
-    instances: Optional[List[String]]
+    instances: Optional[List[SpiceStr]]
     min_height: Optional[int]
     max_height: Optional[int]
     min_width: Optional[int]
@@ -332,7 +332,7 @@ class Spread(PlacementConstraint):
     > `'vertical'`
     '''
 
-    instances: List[String]
+    instances: List[SpiceStr]
     direction: Optional[Literal['horizontal', 'vertical']]
     distance: int  # in nm
 
@@ -378,7 +378,7 @@ class Spread(PlacementConstraint):
 
 
 class SetBoundingBox(HardConstraint):
-    instance: String
+    instance: SpiceStr
     llx: int
     lly: int
     urx: int
@@ -417,7 +417,7 @@ class AlignInOrder(UserConstraint):
 
     > `direction == 'vertical'`   => bottom_to_top
     '''
-    instances: List[String]
+    instances: List[SpiceStr]
     line: Literal[
         'top', 'bottom',
         'left', 'right',
@@ -477,7 +477,7 @@ class PlaceSymmetric(PlacementConstraint):
       2 3  |  2 3  |  3 2  |   1   |  5 4  |   6
        6   |   6   |   1   |  2 3  |  2 3  |  3 2
     '''
-    instances: List[List[String]]
+    instances: List[List[SpiceStr]]
     direction: Optional[Literal['horizontal', 'vertical']]
 
     def check(self, checker):
@@ -492,14 +492,14 @@ class PlaceSymmetric(PlacementConstraint):
 
 
 class CreateAlias(SoftConstraint):
-    instances: List[String]
-    name: String
+    instances: List[SpiceStr]
+    name: SpiceStr
 
 
 class GroupBlocks(SoftConstraint):
     ''' Force heirarchy creation '''
-    name: String
-    instances: List[String]
+    name: SpiceStr
+    instances: List[SpiceStr]
     style: Optional[Literal["tbd_interdigitated", "tbd_common_centroid"]]
 
 
@@ -507,18 +507,18 @@ class MatchBlocks(SoftConstraint):
     '''
     TODO: Can be replicated by Enclose??
     '''
-    instances: List[String]
+    instances: List[SpiceStr]
 
 
 class DoNotIdentify(SoftConstraint):
     '''
     TODO: Can be replicated by Enclose??
     '''
-    instances: List[String]
+    instances: List[SpiceStr]
 
 
 class SymmetricBlocks(SoftConstraint):
-    pairs: List[List[String]]
+    pairs: List[List[SpiceStr]]
     direction: Literal['H', 'V']
     def check(self, checker):
         '''
@@ -578,23 +578,23 @@ class GuardRing(SoftConstraint):
     '''
     Adds guard ring for particular hierarchy
     '''
-    guard_ring_primitives: String
-    global_pin: String
-    block_name: String
+    guard_ring_primitives: SpiceStr
+    global_pin: SpiceStr
+    block_name: SpiceStr
 
 
 class GroupCaps(SoftConstraint):
     ''' Common Centroid Cap '''
-    name: String  # subcircuit name
-    instances: List[String]
-    unit_cap: String  # cap value in fF
+    name: SpiceStr  # subcircuit name
+    instances: List[SpiceStr]
+    unit_cap: SpiceStr  # cap value in fF
     num_units: List
     dummy: bool  # whether to fill in dummies
 
 
 class NetConst(SoftConstraint):
-    nets: List[String]
-    shield: String
+    nets: List[SpiceStr]
+    shield: SpiceStr
     criticality: int
 
 
@@ -608,8 +608,8 @@ class PortLocation(SoftConstraint):
 
 
 class SymmetricNets(SoftConstraint):
-    net1: String
-    net2: String
+    net1: SpiceStr
+    net2: SpiceStr
     pins1: Optional[List]
     pins2: Optional[List]
     direction: Literal['H', 'V']
@@ -621,7 +621,7 @@ class AspectRatio(HardConstraint):
 
     `ratio_low` <= width/height <= `ratio_high`
     """
-    subcircuit: String
+    subcircuit: SpiceStr
     ratio_low: float = 0.1
     ratio_high: float = 10
     weight: int = 1
@@ -639,7 +639,7 @@ class Boundary(HardConstraint):
     """
     Define `max_height` and/or `max_width` on a subcircuit in micrometers.
     """
-    subcircuit: String
+    subcircuit: SpiceStr
     max_width: Optional[float] = 10000
     max_height: Optional[float] = 10000
 
@@ -656,7 +656,7 @@ class Boundary(HardConstraint):
 
 
 class MultiConnection(SoftConstraint):
-    nets: List[String]
+    nets: List[SpiceStr]
     multiplier: int
 
 

--- a/align/schema/constraint.py
+++ b/align/schema/constraint.py
@@ -3,7 +3,7 @@ import more_itertools as itertools
 import re
 
 from . import types
-from .types import Union, Optional, Literal, List, set_context
+from .types import Union, Optional, Literal, List, String, set_context
 from . import checker
 
 import logging
@@ -28,12 +28,12 @@ def validate_instances(cls, value):
     # instances = cls._validator_ctx().parent.parent.instances
     instances = get_instances_from_hacked_dataclasses(cls._validator_ctx())
     assert isinstance(instances, set), 'Could not retrieve instances from subcircuit definition'
-    assert all(x in instances or x.upper() in instances for x in value), f'One or more constraint instances {value} not found in {instances}'
+    assert all(x in instances for x in value), f'One or more constraint instances {value} not found in {instances}'
     return value
 
 class SoftConstraint(types.BaseModel):
 
-    constraint: str
+    constraint: String
 
     def __init__(self, *args, **kwargs):
         constraint = pattern.sub(
@@ -86,7 +86,7 @@ class PlacementConstraint(HardConstraint):
 
 
 class SameTemplate(PlacementConstraint):
-    instances: List[str]
+    instances: List[String]
 
     def check(self, checker):
         pass
@@ -113,7 +113,7 @@ class Order(PlacementConstraint):
     If `abut` is `True`:
     > adjoining instances will touch
     '''
-    instances: List[str]
+    instances: List[String]
     direction: Optional[Literal[
         'horizontal', 'vertical',
         'left_to_right', 'right_to_left',
@@ -184,7 +184,7 @@ class Align(PlacementConstraint):
     > `'v_right'`
     > `'v_center'`
     '''
-    instances: List[str]
+    instances: List[String]
     line: Optional[Literal[
         'h_any', 'h_top', 'h_bottom', 'h_center',
         'v_any', 'v_left', 'v_right', 'v_center'
@@ -254,7 +254,7 @@ class Enclose(PlacementConstraint):
     > `min_aspect_ratio`
     > `max_aspect_ratio`
     '''
-    instances: Optional[List[str]]
+    instances: Optional[List[String]]
     min_height: Optional[int]
     max_height: Optional[int]
     min_width: Optional[int]
@@ -332,7 +332,7 @@ class Spread(PlacementConstraint):
     > `'vertical'`
     '''
 
-    instances: List[str]
+    instances: List[String]
     direction: Optional[Literal['horizontal', 'vertical']]
     distance: int  # in nm
 
@@ -378,7 +378,7 @@ class Spread(PlacementConstraint):
 
 
 class SetBoundingBox(HardConstraint):
-    instance: str
+    instance: String
     llx: int
     lly: int
     urx: int
@@ -417,7 +417,7 @@ class AlignInOrder(UserConstraint):
 
     > `direction == 'vertical'`   => bottom_to_top
     '''
-    instances: List[str]
+    instances: List[String]
     line: Literal[
         'top', 'bottom',
         'left', 'right',
@@ -477,7 +477,7 @@ class PlaceSymmetric(PlacementConstraint):
       2 3  |  2 3  |  3 2  |   1   |  5 4  |   6
        6   |   6   |   1   |  2 3  |  2 3  |  3 2
     '''
-    instances: List[List[str]]
+    instances: List[List[String]]
     direction: Optional[Literal['horizontal', 'vertical']]
 
     def check(self, checker):
@@ -492,14 +492,14 @@ class PlaceSymmetric(PlacementConstraint):
 
 
 class CreateAlias(SoftConstraint):
-    instances: List[str]
-    name: str
+    instances: List[String]
+    name: String
 
 
 class GroupBlocks(SoftConstraint):
     ''' Force heirarchy creation '''
-    name: str
-    instances: List[str]
+    name: String
+    instances: List[String]
     style: Optional[Literal["tbd_interdigitated", "tbd_common_centroid"]]
 
 
@@ -507,18 +507,18 @@ class MatchBlocks(SoftConstraint):
     '''
     TODO: Can be replicated by Enclose??
     '''
-    instances: List[str]
+    instances: List[String]
 
 
 class DoNotIdentify(SoftConstraint):
     '''
     TODO: Can be replicated by Enclose??
     '''
-    instances: List[str]
+    instances: List[String]
 
 
 class SymmetricBlocks(SoftConstraint):
-    pairs: List[List[str]]
+    pairs: List[List[String]]
     direction: Literal['H', 'V']
     def check(self, checker):
         '''
@@ -578,23 +578,23 @@ class GuardRing(SoftConstraint):
     '''
     Adds guard ring for particular hierarchy
     '''
-    guard_ring_primitives: str
-    global_pin: str
-    block_name: str
+    guard_ring_primitives: String
+    global_pin: String
+    block_name: String
 
 
 class GroupCaps(SoftConstraint):
     ''' Common Centroid Cap '''
-    name: str  # subcircuit name
-    instances: List[str]
-    unit_cap: str  # cap value in fF
+    name: String  # subcircuit name
+    instances: List[String]
+    unit_cap: String  # cap value in fF
     num_units: List
     dummy: bool  # whether to fill in dummies
 
 
 class NetConst(SoftConstraint):
-    nets: List[str]
-    shield: str
+    nets: List[String]
+    shield: String
     criticality: int
 
 
@@ -608,8 +608,8 @@ class PortLocation(SoftConstraint):
 
 
 class SymmetricNets(SoftConstraint):
-    net1: str
-    net2: str
+    net1: String
+    net2: String
     pins1: Optional[List]
     pins2: Optional[List]
     direction: Literal['H', 'V']
@@ -621,7 +621,7 @@ class AspectRatio(HardConstraint):
 
     `ratio_low` <= width/height <= `ratio_high`
     """
-    subcircuit: str
+    subcircuit: String
     ratio_low: float = 0.1
     ratio_high: float = 10
     weight: int = 1
@@ -639,7 +639,7 @@ class Boundary(HardConstraint):
     """
     Define `max_height` and/or `max_width` on a subcircuit in micrometers.
     """
-    subcircuit: str
+    subcircuit: String
     max_width: Optional[float] = 10000
     max_height: Optional[float] = 10000
 
@@ -656,7 +656,7 @@ class Boundary(HardConstraint):
 
 
 class MultiConnection(SoftConstraint):
-    nets: List[str]
+    nets: List[String]
     multiplier: int
 
 

--- a/align/schema/constraint_placement.py
+++ b/align/schema/constraint_placement.py
@@ -1,11 +1,11 @@
-from .types import Union, Optional, Literal, List, String
+from .types import Union, Optional, Literal, List, SpiceStr
 from .constraint import PlacementConstraint
 from pydantic import validator
 
 
 class Alignment(PlacementConstraint):
     constraint: Literal["alignment"]
-    instances: List[String]
+    instances: List[SpiceStr]
     direction: Optional[Literal['horizontal', 'vertical']] = 'horizontal'
     edge: Optional[Literal['top', 'center', 'bottom', 'left', 'right']] = 'bottom'
     abut: Optional[bool] = True
@@ -24,9 +24,9 @@ class Alignment(PlacementConstraint):
 
 class Generator(PlacementConstraint):
     constraint: Literal["generator"]
-    instances: List[String]
+    instances: List[SpiceStr]
     style: Optional[Literal['cc', 'id']] = 'cc'
-    alias: Optional[String]
+    alias: Optional[SpiceStr]
     n_rows: Optional[int] = None
     add_guard_ring: Optional[bool] = False
 
@@ -36,7 +36,7 @@ class Generator(PlacementConstraint):
 
 class Orientation(PlacementConstraint):
     constraint: Literal["orientation"]
-    instances: List[String]
+    instances: List[SpiceStr]
     flip_x: Optional[bool] = False
     flip_y: Optional[bool] = False
 
@@ -46,7 +46,7 @@ class Orientation(PlacementConstraint):
 
 class Boundary(PlacementConstraint):
     constraint: Literal["boundary"]
-    subcircuits: List[String]
+    subcircuits: List[SpiceStr]
     height_min: Optional[float] = None
     height_max: Optional[float] = None
     aspect_ratio_min: Optional[float] = None

--- a/align/schema/constraint_placement.py
+++ b/align/schema/constraint_placement.py
@@ -1,11 +1,11 @@
-from .types import Union, Optional, Literal, List
+from .types import Union, Optional, Literal, List, String
 from .constraint import PlacementConstraint
 from pydantic import validator
 
 
 class Alignment(PlacementConstraint):
     constraint: Literal["alignment"]
-    instances: List[str]
+    instances: List[String]
     direction: Optional[Literal['horizontal', 'vertical']] = 'horizontal'
     edge: Optional[Literal['top', 'center', 'bottom', 'left', 'right']] = 'bottom'
     abut: Optional[bool] = True
@@ -24,9 +24,9 @@ class Alignment(PlacementConstraint):
 
 class Generator(PlacementConstraint):
     constraint: Literal["generator"]
-    instances: List[str]
+    instances: List[String]
     style: Optional[Literal['cc', 'id']] = 'cc'
-    alias: Optional[str]
+    alias: Optional[String]
     n_rows: Optional[int] = None
     add_guard_ring: Optional[bool] = False
 
@@ -36,7 +36,7 @@ class Generator(PlacementConstraint):
 
 class Orientation(PlacementConstraint):
     constraint: Literal["orientation"]
-    instances: List[str]
+    instances: List[String]
     flip_x: Optional[bool] = False
     flip_y: Optional[bool] = False
 
@@ -46,7 +46,7 @@ class Orientation(PlacementConstraint):
 
 class Boundary(PlacementConstraint):
     constraint: Literal["boundary"]
-    subcircuits: List[str]
+    subcircuits: List[String]
     height_min: Optional[float] = None
     height_max: Optional[float] = None
     aspect_ratio_min: Optional[float] = None

--- a/align/schema/gen_dot.py
+++ b/align/schema/gen_dot.py
@@ -14,7 +14,7 @@ def gen_dot_file(nm, ifn, ofn):
         txt = fp.read()
         parser.parse(txt)
 
-    q = parser.library.find(nm.upper())
+    q = parser.library.find(nm)
 
     tbl = { "GND": {}, "VSS": {}, "VDD": {}, "CLK": {}}
 

--- a/align/schema/graph.py
+++ b/align/schema/graph.py
@@ -324,7 +324,7 @@ class Graph(networkx.Graph):
                 model=element.model,
                 pins={
                     pin: subcktinst.pins[net] if net in subcktinst.pins else f'{subcktinst.name}_{net}' for pin, net in element.pins.items()},
-                parameters={key: eval(val, {}, subcktinst.parameters)
+                parameters={key: eval(val.casefold(), {}, {k.casefold(): v for k, v in subcktinst.parameters.items()} if subcktinst.parameters else {})
                             for key, val in element.parameters.items()},
                 generator = element.generator
             )

--- a/align/schema/instance.py
+++ b/align/schema/instance.py
@@ -1,18 +1,18 @@
 from . import types
-from .types import Union, Dict, Optional, List, String, set_context
+from .types import Union, Dict, Optional, List, SpiceStr, set_context
 
 import logging
 logger = logging.getLogger(__name__)
 
 class Instance(types.BaseModel):
 
-    model: String
-    name: String
-    pins : Dict[String, String]
-    parameters : Optional[Dict[String, String]]
+    model: SpiceStr
+    name: SpiceStr
+    pins : Dict[SpiceStr, SpiceStr]
+    parameters : Optional[Dict[SpiceStr, SpiceStr]]
     #TODO: associate a generator for eacj primitive during instantiation
-    generator: String #Handles different sized instantiation of same subcircuit to same generator
-    abstract_name: Optional[String] # Added during primitive generator, in case no primitive generator found = generator
+    generator: SpiceStr #Handles different sized instantiation of same subcircuit to same generator
+    abstract_name: Optional[SpiceStr] # Added during primitive generator, in case no primitive generator found = generator
     class Config:
         allow_mutation = True
 

--- a/align/schema/instance.py
+++ b/align/schema/instance.py
@@ -1,17 +1,18 @@
 from . import types
-from .types import Union, Dict, Optional, List, set_context
+from .types import Union, Dict, Optional, List, String, set_context
 
 import logging
 logger = logging.getLogger(__name__)
 
 class Instance(types.BaseModel):
 
-    model: str
-    name: str
-    pins : Dict[str, str]
-    parameters : Optional[Dict[str, str]]
-    generator: str #Handles different sized instantiation of same subcircuit to same generator
-    abstract_name: Optional[str] # Added during primitive generator, in case no primitive generator found = generator
+    model: String
+    name: String
+    pins : Dict[String, String]
+    parameters : Optional[Dict[String, String]]
+    #TODO: associate a generator for eacj primitive during instantiation
+    generator: String #Handles different sized instantiation of same subcircuit to same generator
+    abstract_name: Optional[String] # Added during primitive generator, in case no primitive generator found = generator
     class Config:
         allow_mutation = True
 
@@ -47,7 +48,6 @@ class Instance(types.BaseModel):
 
     @types.validator('model', allow_reuse=True)
     def model_exists_in_library(cls, model):
-        model = model.upper()
         assert isinstance(cls._validator_ctx().parent, List[Instance]), 'Instance can only be instanitated within List[Instance]'
         assert cls._validator_ctx().parent.parent is not None, 'List[Instance] can only be instantiated within a SubCircuit / Circuit'
         assert cls._validator_ctx().parent.parent.parent is not None, 'Circuit / SubCircuit constaining instance must be registered to a Library'
@@ -58,7 +58,6 @@ class Instance(types.BaseModel):
     def name_complies_with_model(cls, name, values):
         assert 'model' in values, 'Cannot run check without model definition'
         model = cls._get_model(cls._validator_ctx().parent.parent.parent, values['model'])
-        name = name.upper()
         if model.prefix and not name.startswith(model.prefix):
             logger.error(f"{name} does not start with {model.prefix}")
             raise AssertionError(f"{name} does not start with {model.prefix}")
@@ -68,8 +67,7 @@ class Instance(types.BaseModel):
     def pins_comply_with_model(cls, pins, values):
         assert 'model' in values, 'Cannot run check without model definition'
         model = cls._get_model(cls._validator_ctx().parent.parent.parent, values['model'])
-        pins = {k.upper(): v.upper() for k, v in pins.items()}
-        assert set(pins.keys()) == set(model.pins)
+        assert set(pins.keys()) == set(model.pins), f'{set(pins.keys())} do not match {set(model.pins)}'
         return pins
 
     @types.validator('parameters', allow_reuse=True, always=True)
@@ -77,11 +75,10 @@ class Instance(types.BaseModel):
         assert 'model' in values, 'Cannot run check without model definition'
         model = cls._get_model(cls._validator_ctx().parent.parent.parent, values['model'])
         if parameters:
-            parameters = {k.upper(): v.upper() for k, v in parameters.items()}
             assert model.parameters and set(parameters.keys()).issubset(model.parameters.keys()), \
                 f"{cls.__name__} parameters must be a subset of {model.__class__.__name__} parameters"
-            parameters = {k: parameters[k] if k in parameters else v \
-                for k, v in model.parameters.items()}
+            parameters.update({k: v for k, v in model.parameters.items() \
+                    if k not in parameters})
         elif model.parameters:
             parameters = model.parameters.copy()
         return parameters

--- a/align/schema/instance.py
+++ b/align/schema/instance.py
@@ -77,8 +77,7 @@ class Instance(types.BaseModel):
         if parameters:
             assert model.parameters and set(parameters.keys()).issubset(model.parameters.keys()), \
                 f"{cls.__name__} parameters must be a subset of {model.__class__.__name__} parameters"
-            parameters.update({k: v for k, v in model.parameters.items() \
-                    if k not in parameters})
+            parameters = type(parameters)({**model.parameters, **parameters})
         elif model.parameters:
             parameters = model.parameters.copy()
         return parameters

--- a/align/schema/library.py
+++ b/align/schema/library.py
@@ -19,7 +19,7 @@ class Library(List[Union[Model, SubCircuit]]):
             self.extend(libraries['default'])
 
     def find(self, name):
-        return next((x for x in self if x.name == name.upper()), None)
+        return next((x for x in self if x.name == name), None)
 
 #
 # Create default library

--- a/align/schema/model.py
+++ b/align/schema/model.py
@@ -66,9 +66,8 @@ class Model(types.BaseModel):
     @types.validator('parameters', always=True, allow_reuse=True)
     def parameter_check(cls, parameters, values):
         if 'base' in values and values['base']:
-            x = cls._get_base_model(cls._validator_ctx().parent, values['base']).parameters.copy()
-            x.update(parameters)
-            parameters = x
+            bparams = cls._get_base_model(cls._validator_ctx().parent, values['base']).parameters
+            parameters = type(parameters)({**bparams, **parameters})
         return parameters
 
     @types.validator('prefix', always=True, allow_reuse=True)

--- a/align/schema/model.py
+++ b/align/schema/model.py
@@ -1,7 +1,7 @@
 import logging
 from . import types
 
-from .types import Dict, List, String, Optional
+from .types import Dict, List, SpiceStr, Optional
 
 logger = logging.getLogger(__name__)
 
@@ -10,11 +10,11 @@ class Model(types.BaseModel):
     Model creation class
     '''
 
-    name : String                 # Model Name
-    base : Optional[String]       # Model Base (for derived models)
-    pins : Optional[List[String]] # List of pin names (derived from base if base exists)
-    parameters : Optional[Dict[String, String]]   # Parameter Name: Value mapping (inherits & adds to base if needed)
-    prefix : Optional[String]     # Instance name prefix, optional
+    name : SpiceStr                 # Model Name
+    base : Optional[SpiceStr]       # Model Base (for derived models)
+    pins : Optional[List[SpiceStr]] # List of pin names (derived from base if base exists)
+    parameters : Optional[Dict[SpiceStr, SpiceStr]]   # Parameter Name: Value mapping (inherits & adds to base if needed)
+    prefix : Optional[SpiceStr]     # Instance name prefix, optional
 
     def xyce(self):
         params = ' '.join(f'{k}={{{v}}}' for k, v in self.parameters.items())

--- a/align/schema/parser.py
+++ b/align/schema/parser.py
@@ -25,7 +25,7 @@ unit_multipliers = {
 }
 
 def str2float(val):
-    unit = next((x for x in unit_multipliers if val.endswith(x.upper()) or val.endswith(x.lower())), None)
+    unit = next((x for x in unit_multipliers if val.endswith(x)), None)
     numstr = val if unit is None else val[:-1*len(unit)]
     return float(numstr) * unit_multipliers[unit] if unit is not None else float(numstr)
 
@@ -115,8 +115,8 @@ class SpiceParser:
         assert all(x.type in ('NAME', 'NUMBER', 'EXPR', 'EQUALS') for x in cache), cache
         assignments = {i for i, x in enumerate(cache) if x.type == 'EQUALS'}
         assert all(cache[i-1].type == 'NAME' for i in assignments)
-        args = [SpiceParser._cast(x.value.upper(), x.type) for i, x in enumerate(cache) if len(assignments.intersection({i-1, i, i+1})) == 0]
-        kwargs = {cache[i-1].value.upper(): SpiceParser._cast(cache[i+1].value.upper(), cache[i+1].type) for i in assignments}
+        args = [SpiceParser._cast(x.value, x.type) for i, x in enumerate(cache) if len(assignments.intersection({i-1, i, i+1})) == 0]
+        kwargs = {cache[i-1].value: SpiceParser._cast(cache[i+1].value, cache[i+1].type) for i in assignments}
         return args, kwargs
 
     @staticmethod
@@ -200,9 +200,7 @@ class SpiceParser:
             self._scope.pop()
         elif decl == '.PARAM':
             assert len(args) == 0, f"unsupported arguments {args}, probably missing default values"
-            self._scope[-1].parameters.update({
-                k.upper() : str(v).upper() for k, v in kwargs.items()
-            })
+            self._scope[-1].parameters.update(kwargs)
         elif decl == '.MODEL':
             assert len(args) == 2, args
             name, base = args[0], args[1]

--- a/align/schema/subcircuit.py
+++ b/align/schema/subcircuit.py
@@ -1,4 +1,4 @@
-from .types import Optional, List, Dict, String
+from .types import Optional, List, Dict, SpiceStr
 
 from . import types
 from pydantic import validator
@@ -9,12 +9,12 @@ from .instance import Instance
 from .constraint import ConstraintDB
 
 class SubCircuit(Model):
-    name : String                 # Model Name
-    pins : Optional[List[String]] # List of pin names (derived from base if base exists)
-    parameters : Optional[Dict[String, String]]   # Parameter Name: Value mapping (inherits & adds to base if needed)
+    name : SpiceStr                 # Model Name
+    pins : Optional[List[SpiceStr]] # List of pin names (derived from base if base exists)
+    parameters : Optional[Dict[SpiceStr, SpiceStr]]   # Parameter Name: Value mapping (inherits & adds to base if needed)
     elements: List[Instance]
     constraints: ConstraintDB
-    prefix : String = 'X'         # Instance name prefix, optional
+    prefix : SpiceStr = 'X'         # Instance name prefix, optional
 
     @property
     def nets(self):
@@ -60,7 +60,7 @@ class SubCircuit(Model):
         for constraint in self.constraints:
             ret.append(f'* @: {constraint}')
         ret.append(f'.SUBCKT {self.name} ' + ' '.join(f'{x}' for x in self.pins))
-        ret.extend([f'.PARAM {x}=' + (f'{{{y}}}' if isinstance(y, String) else f'{y}') for x, y in self.parameters.items()])
+        ret.extend([f'.PARAM {x}=' + (f'{{{y}}}' if isinstance(y, SpiceStr) else f'{y}') for x, y in self.parameters.items()])
         ret.extend([element.xyce() for element in self.elements])
         ret.append(f'.ENDS {self.name}')
         return '\n'.join(ret)
@@ -68,8 +68,8 @@ class SubCircuit(Model):
 
 class Circuit(SubCircuit):
 
-    name: Optional[String]
-    pins: Optional[List[String]]
+    name: Optional[SpiceStr]
+    pins: Optional[List[SpiceStr]]
 
     def xyce(self):
         return '\n'.join([element.xyce() for element in self.elements])

--- a/align/schema/types.py
+++ b/align/schema/types.py
@@ -1,5 +1,5 @@
 __all__ = [
-    'BaseModel', 'List', 'Dict',
+    'BaseModel', 'List', 'Dict', 'String',
     'validator', 'root_validator', 'validate_arguments',
     'Optional', 'Union',
     'NamedTuple', 'Literal',
@@ -242,3 +242,33 @@ class Dict(pydantic.generics.GenericModel, typing.Generic[KeyT, DataT]):
 
     def __eq__(self, other):
         return self.__root__ == other
+
+    def __contains__(self, item):
+        return item in self.__root__
+
+    def update(self, other):
+        self.__root__.update(other)
+
+class String(str):
+
+    def __eq__(self, other):
+        return isinstance(other, str) and super().casefold() == other.casefold()
+
+    def __hash__(self) -> int:
+        return super().casefold().__hash__()
+
+    def startswith(self, prefix) -> bool:
+        return super().casefold().startswith(prefix.casefold())
+
+    def endswith(self, suffix) -> bool:
+        return super().casefold().endswith(suffix.casefold())
+
+    @classmethod
+    def __get_validators__(cls):
+        # declare validator to call
+        yield cls.validate
+
+    @classmethod
+    def validate(cls, v):
+        # force casting to 'String' instead of 'str'
+        return cls(v)

--- a/align/schema/types.py
+++ b/align/schema/types.py
@@ -1,5 +1,5 @@
 __all__ = [
-    'BaseModel', 'List', 'Dict', 'String',
+    'BaseModel', 'List', 'Dict', 'SpiceStr',
     'validator', 'root_validator', 'validate_arguments',
     'Optional', 'Union',
     'NamedTuple', 'Literal',
@@ -250,7 +250,7 @@ class Dict(pydantic.generics.GenericModel, typing.Generic[KeyT, DataT]):
         self.__root__.update(other)
 
 
-class String(str):
+class SpiceStr(str):
 
     def __eq__(self, other):
         return isinstance(other, str) and \
@@ -278,5 +278,5 @@ class String(str):
 
     @classmethod
     def validate(cls, v):
-        # force casting to 'String' instead of 'str'
+        # force casting to 'SpiceStr' instead of 'str'
         return cls(v)

--- a/align/schema/types.py
+++ b/align/schema/types.py
@@ -256,6 +256,9 @@ class SpiceStr(str):
         return isinstance(other, str) and \
             super().casefold() == other.casefold()
 
+    def __add__(self, s: str) -> str:
+        return type(self)(super().__add__(s))
+
     def __hash__(self) -> int:
         return super().casefold().__hash__()
 

--- a/align/schema/types.py
+++ b/align/schema/types.py
@@ -249,19 +249,27 @@ class Dict(pydantic.generics.GenericModel, typing.Generic[KeyT, DataT]):
     def update(self, other):
         self.__root__.update(other)
 
+
 class String(str):
 
     def __eq__(self, other):
-        return isinstance(other, str) and super().casefold() == other.casefold()
+        return isinstance(other, str) and \
+            super().casefold() == other.casefold()
 
     def __hash__(self) -> int:
         return super().casefold().__hash__()
 
+    def __contains__(self, other):
+        return isinstance(other, str) and \
+            super().casefold().__contains__(other.casefold())
+
     def startswith(self, prefix) -> bool:
-        return super().casefold().startswith(prefix.casefold())
+        return isinstance(prefix, str) and \
+            super().casefold().startswith(prefix.casefold())
 
     def endswith(self, suffix) -> bool:
-        return super().casefold().endswith(suffix.casefold())
+        return isinstance(suffix, str) and \
+            super().casefold().endswith(suffix.casefold())
 
     @classmethod
     def __get_validators__(cls):

--- a/align/schema/visitor.py
+++ b/align/schema/visitor.py
@@ -109,7 +109,7 @@ class Visitor(object):
             return self.flatten(self.visit(v) for v in node)
         elif isinstance(node, types.Dict) or isinstance(node, dict):
             return self.flatten(self.visit(v) for _, v in node.items())
-        elif isinstance(node, (str, int, type(None))):
+        elif isinstance(node, (types.String, int, type(None))):
             return None
         else:
             raise NotImplementedError( \
@@ -144,7 +144,7 @@ class Transformer(Visitor):
         elif isinstance(node, types.Dict) or isinstance(node, dict):
             new_node = {k: self.visit(v) for k, v in node.items()}
             return node if all(x is y for x, y in zip(node.values(), new_node.values())) else new_node
-        elif isinstance(node, (int, str, type(None))):
+        elif isinstance(node, (types.String, int, type(None))):
             return node
         else:
             raise NotImplementedError( \

--- a/align/schema/visitor.py
+++ b/align/schema/visitor.py
@@ -109,7 +109,7 @@ class Visitor(object):
             return self.flatten(self.visit(v) for v in node)
         elif isinstance(node, types.Dict) or isinstance(node, dict):
             return self.flatten(self.visit(v) for _, v in node.items())
-        elif isinstance(node, (types.String, int, type(None))):
+        elif isinstance(node, (types.SpiceStr, int, type(None))):
             return None
         else:
             raise NotImplementedError( \
@@ -144,7 +144,7 @@ class Transformer(Visitor):
         elif isinstance(node, types.Dict) or isinstance(node, dict):
             new_node = {k: self.visit(v) for k, v in node.items()}
             return node if all(x is y for x, y in zip(node.values(), new_node.values())) else new_node
-        elif isinstance(node, (types.String, int, type(None))):
+        elif isinstance(node, (types.SpiceStr, int, type(None))):
             return node
         else:
             raise NotImplementedError( \

--- a/tests/schema/test_constraint.py
+++ b/tests/schema/test_constraint.py
@@ -53,7 +53,6 @@ def test_Order_nblock_checking(db):
     with pytest.raises(AssertionError):
         x.check(None)
 
-@pytest.mark.skip(reason='Cannot activate this yet because of ALIGN1.0 annotation issues')
 def test_Order_validate_instances(db):
     with set_context(db):
         with pytest.raises(Exception):

--- a/tests/schema/test_graph.py
+++ b/tests/schema/test_graph.py
@@ -105,10 +105,10 @@ def test_netlist(circuit):
     assert netlist.elements == circuit.elements
     assert netlist.nets == circuit.nets
     # Advanced graphx functionality test
-    nodes = [types.String(x) for x in ('X1', 'X2', 'NET1', 'NET2', 'NET3')]
+    nodes = [types.SpiceStr(x) for x in ('X1', 'X2', 'NET1', 'NET2', 'NET3')]
     assert all(x in netlist.nodes for x in nodes)
     assert all(x in nodes for x in netlist.nodes)
-    edges = [(types.String(x[0]), types.String(x[1]), {types.String(y) for y in x[2]}) for x in [
+    edges = [(types.SpiceStr(x[0]), types.SpiceStr(x[1]), {types.SpiceStr(y) for y in x[2]}) for x in [
              # X1, net, pin
              ('X1', 'NET1', {'A'}), ('X1', 'NET2', {'B'}),
              ('NET1', 'X1', {'A'}), ('NET2', 'X1', {'B'}),
@@ -126,10 +126,10 @@ def test_netlist_shared_net(circuit):
     assert netlist.elements == circuit.elements
     assert netlist.nets == circuit.nets
     # Advanced graphx functionality test
-    nodes = [types.String(x) for x in ('X1', 'X2', 'NET1', 'NET2')]
+    nodes = [types.SpiceStr(x) for x in ('X1', 'X2', 'NET1', 'NET2')]
     assert all(x in netlist.nodes for x in nodes)
     assert all(x in nodes for x in netlist.nodes)
-    edges = [(types.String(x[0]), types.String(x[1]), {types.String(y) for y in x[2]}) for x in [
+    edges = [(types.SpiceStr(x[0]), types.SpiceStr(x[1]), {types.SpiceStr(y) for y in x[2]}) for x in [
              # X1, net, pin
              ('X1', 'NET1', {'A'}), ('X1', 'NET2', {'B'}),
              ('NET1', 'X1', {'A'}), ('NET2', 'X1', {'B'}),
@@ -143,7 +143,7 @@ def test_find_subgraph_matches(simple_circuit, matching_subckt):
     netlist, matching_netlist = Graph(simple_circuit), Graph(matching_subckt)
     # Validate true match
     assert len(netlist.find_subgraph_matches(matching_netlist)) == 1
-    assert netlist.find_subgraph_matches(matching_netlist)[0] == types.Dict[types.String, types.String]({
+    assert netlist.find_subgraph_matches(matching_netlist)[0] == types.Dict[types.SpiceStr, types.SpiceStr]({
         'X3': 'X1', 'NET3': 'PIN3', 'NET1': 'PIN1', 'X4': 'X2', 'NET2': 'PIN2'})
     # Validate false match
     with set_context(simple_circuit.parent):
@@ -165,8 +165,8 @@ def test_replace_matching_subgraph(simple_circuit, matching_subckt):
     matches = [{'X3': 'X1', 'NET3': 'PIN3', 'NET1': 'PIN1', 'X4': 'X2', 'NET2': 'PIN2'}]
     netlist.replace_matching_subgraph(matching_netlist)
     assert all(x not in netlist.nodes for x in matches[0].keys() if x.startswith('X'))
-    assert types.String('X_TEST_SUBCKT_I1_X3_X4') in netlist.nodes
-    new_edges = [(types.String(x[0]), types.String(x[1]), {types.String(y) for y in x[2]}) for x in [
+    assert types.SpiceStr('X_TEST_SUBCKT_I1_X3_X4') in netlist.nodes
+    new_edges = [(types.SpiceStr(x[0]), types.SpiceStr(x[1]), {types.SpiceStr(y) for y in x[2]}) for x in [
         ('X_TEST_SUBCKT_I1_X3_X4', 'NET3', {'PIN3'}),
         ('X_TEST_SUBCKT_I1_X3_X4', 'NET1', {'PIN1'}), 
         ('X_TEST_SUBCKT_I1_X3_X4', 'NET2', {'PIN2'})]]
@@ -181,8 +181,8 @@ def test_replace_repeated_subckts(ota):
     assert len(subckts[0].elements) == 4
     elements = {x.name for x in subckts[0].elements}
     assert elements in (
-        {types.String(x) for x in ('M10', 'M7', 'M9', 'M1')},
-        {types.String(x) for x in ('M2', 'M6', 'M8', 'M0')}
+        {types.SpiceStr(x) for x in ('M10', 'M7', 'M9', 'M1')},
+        {types.SpiceStr(x) for x in ('M2', 'M6', 'M8', 'M0')}
     )
 
 def test_replace_matching_subckts(ota, primitives):
@@ -203,7 +203,7 @@ def test_flatten(heirarchical_ckt):
     ckt = heirarchical_ckt
     netlist = Graph(ckt)
     netlist.flatten()
-    myparametermap = types.Dict[types.String, types.String]({
+    myparametermap = types.Dict[types.SpiceStr, types.SpiceStr]({
         'XSUB1_X2': '1',
         'XSUB1_X1_X1': '1',
         'XSUB1_X1_X2': '2',
@@ -211,19 +211,19 @@ def test_flatten(heirarchical_ckt):
         'XSUB2_X2': '3'
     })
     assert {x.name for x in ckt.elements} == set(myparametermap.keys())
-    assert set(ckt.nets) == {types.String(x) for x in ('NET1', 'NET2', 'NET3', 'XSUB1_NET1')}
-    assert all(element.parameters[types.String('MYPARAMETER')] == myparametermap[element.name] for element in ckt.elements)
+    assert set(ckt.nets) == {types.SpiceStr(x) for x in ('NET1', 'NET2', 'NET3', 'XSUB1_NET1')}
+    assert all(element.parameters[types.SpiceStr('MYPARAMETER')] == myparametermap[element.name] for element in ckt.elements)
 
 def test_flatten_depth1(heirarchical_ckt):
     ckt = heirarchical_ckt
     netlist = Graph(ckt)
     netlist.flatten(1)
-    myparametermap = types.Dict[types.String, types.String]({
+    myparametermap = types.Dict[types.SpiceStr, types.SpiceStr]({
         'XSUB1_X2': '1',
         'XSUB1_X1': '2',
         'XSUB2_X1': '1',
         'XSUB2_X2': '3'
     })
     assert {x.name for x in ckt.elements} == set(myparametermap.keys())
-    assert set(ckt.nets) == {types.String(x) for x in ('NET1', 'NET2', 'NET3', 'XSUB1_NET1')}
-    assert all(element.parameters[types.String('MYPARAMETER')] == myparametermap[element.name] for element in ckt.elements)
+    assert set(ckt.nets) == {types.SpiceStr(x) for x in ('NET1', 'NET2', 'NET3', 'XSUB1_NET1')}
+    assert all(element.parameters[types.SpiceStr('MYPARAMETER')] == myparametermap[element.name] for element in ckt.elements)

--- a/tests/schema/test_instance.py
+++ b/tests/schema/test_instance.py
@@ -1,29 +1,33 @@
 import pytest
+from align.schema import types
 
 from align.schema.model import Model
 from align.schema.instance import Instance
 from align.schema.subcircuit import Circuit
 from align.schema.types import set_context, List
 
+
 @pytest.fixture()
 def library():
     library = List[Model]()
     with set_context(library):
         model = Model(
-            name = 'TESTMOS',
-            pins = ['D', 'G', 'S', 'B'],
-            parameters = {
+            name='TESTMOS',
+            pins=['D', 'G', 'S', 'B'],
+            parameters={
                 'PARAM1': '1.0',
                 'PARAM2': '2'
             })
     library.append(model)
     return library
 
+
 @pytest.fixture()
 def circuit(library):
     with set_context(library):
         mock_subckt = Circuit()
     return mock_subckt
+
 
 def test_instance_model(circuit):
     with set_context(circuit.elements):
@@ -32,14 +36,14 @@ def test_instance_model(circuit):
         with pytest.raises(Exception):
             M1 = Instance(
                 name='M1',
-                pins={'D': 'NET01', 'G': 'NET02', 'S':'NET03', 'B':'NET04'},
+                pins={'D': 'NET01', 'G': 'NET02', 'S': 'NET03', 'B': 'NET04'},
                 generator='MOS'
             )
         with pytest.raises(Exception):
             M1 = Instance(
                 name='M1',
                 pins={'D': 'NET01', 'G': 'NET02', 'S': 'NET03', 'B': 'NET04'},
-                parameters={'PARAM1':'12', 'PARAM2': '13'},
+                parameters={'PARAM1': '12', 'PARAM2': '13'},
                 generator='MOS'
             )
         with pytest.raises(Exception):
@@ -47,16 +51,17 @@ def test_instance_model(circuit):
                 name='M1',
                 model='undefinedmos',
                 pins={'D': 'NET01', 'G': 'NET02', 'S': 'NET03', 'B': 'NET04'},
-                parameters={'PARAM1':'12', 'PARAM2': '13'},
+                parameters={'PARAM1': '12', 'PARAM2': '13'},
                 generator='MOS'
             )
         M1 = Instance(
             name='M1',
             model='testmos',
             pins={'D': 'NET01', 'G': 'NET02', 'S': 'NET03', 'B': 'NET04'},
-            parameters={'PARAM1':'12', 'PARAM2': '13'},
+            parameters={'PARAM1': '12', 'PARAM2': '13'},
             generator='MOS'
         )
+
 
 def test_instance_name(circuit):
     with set_context(circuit.elements):
@@ -66,6 +71,7 @@ def test_instance_name(circuit):
             M1 = Instance(name='M1')
         with pytest.raises(Exception):
             M1 = Instance(name='M1', model='testmos')
+
 
 def test_instance_pins(circuit):
     with set_context(circuit.elements):
@@ -79,7 +85,7 @@ def test_instance_pins(circuit):
             M1 = Instance(
                 name='M1',
                 model='testmos',
-                pins={'D': 'NET01', 'G': 'NET02', 'S': 'NET03', 'B':'NET04'},
+                pins={'D': 'NET01', 'G': 'NET02', 'S': 'NET03', 'B': 'NET04'},
                 parameters={'garbage': 'NET05'},
                 generator='MOS'
             )
@@ -88,19 +94,28 @@ def test_instance_pins(circuit):
                 name='M1',
                 model='testmos',
                 pins={'D': 'NET01', 'G': 'NET02', 'S': 'NET03', 'B': 'NET04'},
-                parameters={'garbage':'dfddfd'},
+                parameters={'garbage': 'dfddfd'},
                 generator='MOS'
             )
         M1 = Instance(
             name='M1',
             model='testmos',
-            pins={'D': 'NET01', 'G': 'NET02', 'S':'NET03', 'B':'NET04'},
+            pins={'D': 'NET01', 'G': 'NET02', 'S': 'NET03', 'B': 'NET04'},
             generator='MOS'
         )
-    assert M1.name == 'M1'
-    assert M1.model == 'TESTMOS'
-    assert M1.pins == {'D': 'NET01', 'G': 'NET02', 'S': 'NET03', 'B': 'NET04'}
-    assert M1.parameters == {'PARAM1': "1.0", 'PARAM2': "2"}
+    assert M1.name == types.String('M1')
+    assert M1.model == types.String('TESTMOS')
+    assert M1.pins == types.Dict[types.String, types.String]({
+        'D': 'NET01',
+        'G': 'NET02',
+        'S': 'NET03',
+        'B': 'NET04'
+    })
+    assert M1.parameters == types.Dict[types.String, types.String]({
+        'PARAM1': "1.0",
+        'PARAM2': "2"
+    })
+
 
 def test_instance_init_parameters(circuit):
     with set_context(circuit.elements):
@@ -108,41 +123,49 @@ def test_instance_init_parameters(circuit):
             name='M1',
             model='testmos',
             pins={'D': 'NET01', 'G': 'NET02', 'S': 'NET03', 'B': 'NET04'},
-            parameters={'PARAM1':'NF*4'},
+            parameters={'PARAM1': 'NF*4'},
             generator='MOS'
         )
-    assert M1.parameters == {'PARAM1': 'NF*4', 'PARAM2': "2"}
+    assert M1.parameters == types.Dict[types.String, types.String]({
+        'PARAM1': 'NF*4',
+        'PARAM2': "2"
+    })
     with set_context(circuit.elements):
         M1 = Instance(
             name='M1',
             model='testmos',
             pins={'D': 'NET01', 'G': 'NET02', 'S': 'NET03', 'B': 'NET04'},
-            parameters={'PARAM1':'12', 'PARAM2': '13'},
+            parameters={'PARAM1': '12', 'PARAM2': '13'},
             generator='MOS'
         )
-    assert M1.parameters == {'PARAM1': "12", 'PARAM2': "13"}
+    assert M1.parameters == types.Dict[types.String, types.String]({
+        'PARAM1': "12",
+        'PARAM2': "13"
+    })
+
 
 def test_model_instantiation(circuit):
     with set_context(circuit.elements):
         M1 = Instance(
-                name='m1',
-                model='testmos',
-                pins={'d': 'net01', 'G': 'Net02', 's': 'NET03', 'B': 'NeT04'},
-                parameters={'PARAM1':'nf*4', 'param2':'2.0'},
-                generator='MOS'
-            )
-        M2 =Instance(
-                name='m2',
-                model='testmos',
-                pins={'d': 'net03', 'G': 'Net02', 's': 'NET01', 'B': 'NeT04'},
-                parameters={'PARAM1':'2.0', 'param2':'nf*4'},
-                generator='MOS'
-            )
-    assert M1  != M2
+            name='m1',
+            model='testmos',
+            pins={'d': 'net01', 'G': 'Net02', 's': 'NET03', 'B': 'NeT04'},
+            parameters={'PARAM1': 'nf*4', 'param2': '2.0'},
+            generator='MOS'
+        )
+        M2 = Instance(
+            name='m2',
+            model='testmos',
+            pins={'d': 'net03', 'G': 'Net02', 's': 'NET01', 'B': 'NeT04'},
+            parameters={'PARAM1': '2.0', 'param2': 'nf*4'},
+            generator='MOS'
+        )
+    assert M1 != M2
     assert M1.name != M2.name
     assert M1.pins != M2.pins
     assert M1.parameters != M2.parameters
     assert M1.model == M2.model
+
 
 def test_instance_case_insensitivity(circuit):
     '''
@@ -154,20 +177,29 @@ def test_instance_case_insensitivity(circuit):
             name='m1',
             model='testmos',
             pins={'d': 'net01', 'G': 'Net02', 's': 'NET03', 'B': 'NeT04'},
-            parameters={'PARAM1':'nf*4', 'param2':'2.0'},
+            parameters={'PARAM1': 'nf*4', 'param2': '2.0'},
             generator='MOS'
         )
-    assert M1.name == 'M1'
-    assert M1.pins == {'D': 'NET01', 'G': 'NET02', 'S': 'NET03', 'B': 'NET04'}
-    assert M1.parameters == {'PARAM1': 'NF*4', 'PARAM2': "2.0"}
-    assert M1.generator == 'MOS'
+    assert M1.name == types.String('M1')
+    assert M1.pins == types.Dict[types.String, types.String]({
+        'D': 'NET01',
+        'G': 'NET02',
+        'S': 'NET03',
+        'B': 'NET04'
+    })
+    assert M1.parameters == types.Dict[types.String, types.String]({
+        'PARAM1': 'NF*4',
+        'PARAM2': "2.0"
+    })
+    assert M1.generator == types.String('MOS')
+
 
 def test_instance_json(circuit):
     with set_context(circuit.elements):
         M1 = Instance(
-        name='M1',
-        model='testmos',
-        pins={'D': 'NET01', 'G': 'NET02', 'S': 'NET03', 'B': 'NET04'},
-        parameters={'PARAM1':'NF*4'},
-        generator='MOS')
-    assert M1.json() == '{"model": "TESTMOS", "name": "M1", "pins": {"D": "NET01", "G": "NET02", "S": "NET03", "B": "NET04"}, "parameters": {"PARAM1": "NF*4", "PARAM2": "2"}, "generator": "MOS", "abstract_name": null}'
+            name='M1',
+            model='testmos',
+            pins={'D': 'NET01', 'G': 'NET02', 'S': 'NET03', 'B': 'NET04'},
+            parameters={'PARAM1': 'NF*4'},
+            generator='MOS')
+    assert M1.json() == '{"model": "testmos", "name": "M1", "pins": {"D": "NET01", "G": "NET02", "S": "NET03", "B": "NET04"}, "parameters": {"PARAM1": "NF*4", "PARAM2": "2"}, "generator": "MOS", "abstract_name": null}'

--- a/tests/schema/test_instance.py
+++ b/tests/schema/test_instance.py
@@ -103,15 +103,15 @@ def test_instance_pins(circuit):
             pins={'D': 'NET01', 'G': 'NET02', 'S': 'NET03', 'B': 'NET04'},
             generator='MOS'
         )
-    assert M1.name == types.String('M1')
-    assert M1.model == types.String('TESTMOS')
-    assert M1.pins == types.Dict[types.String, types.String]({
+    assert M1.name == types.SpiceStr('M1')
+    assert M1.model == types.SpiceStr('TESTMOS')
+    assert M1.pins == types.Dict[types.SpiceStr, types.SpiceStr]({
         'D': 'NET01',
         'G': 'NET02',
         'S': 'NET03',
         'B': 'NET04'
     })
-    assert M1.parameters == types.Dict[types.String, types.String]({
+    assert M1.parameters == types.Dict[types.SpiceStr, types.SpiceStr]({
         'PARAM1': "1.0",
         'PARAM2': "2"
     })
@@ -126,7 +126,7 @@ def test_instance_init_parameters(circuit):
             parameters={'PARAM1': 'NF*4'},
             generator='MOS'
         )
-    assert M1.parameters == types.Dict[types.String, types.String]({
+    assert M1.parameters == types.Dict[types.SpiceStr, types.SpiceStr]({
         'PARAM1': 'NF*4',
         'PARAM2': "2"
     })
@@ -138,7 +138,7 @@ def test_instance_init_parameters(circuit):
             parameters={'PARAM1': '12', 'PARAM2': '13'},
             generator='MOS'
         )
-    assert M1.parameters == types.Dict[types.String, types.String]({
+    assert M1.parameters == types.Dict[types.SpiceStr, types.SpiceStr]({
         'PARAM1': "12",
         'PARAM2': "13"
     })
@@ -180,18 +180,18 @@ def test_instance_case_insensitivity(circuit):
             parameters={'PARAM1': 'nf*4', 'param2': '2.0'},
             generator='MOS'
         )
-    assert M1.name == types.String('M1')
-    assert M1.pins == types.Dict[types.String, types.String]({
+    assert M1.name == types.SpiceStr('M1')
+    assert M1.pins == types.Dict[types.SpiceStr, types.SpiceStr]({
         'D': 'NET01',
         'G': 'NET02',
         'S': 'NET03',
         'B': 'NET04'
     })
-    assert M1.parameters == types.Dict[types.String, types.String]({
+    assert M1.parameters == types.Dict[types.SpiceStr, types.SpiceStr]({
         'PARAM1': 'NF*4',
         'PARAM2': "2.0"
     })
-    assert M1.generator == types.String('MOS')
+    assert M1.generator == types.SpiceStr('MOS')
 
 
 def test_instance_json(circuit):

--- a/tests/schema/test_library.py
+++ b/tests/schema/test_library.py
@@ -24,12 +24,12 @@ def test_library_registration(library):
             pins=['D', 'G', 'S', 'B'],
             parameters={'W': 0, 'L': 0, 'NFIN': 1})
     library.append(test)
-    assert any(x.name == types.String('TEST') for x in library)
+    assert any(x.name == types.SpiceStr('TEST') for x in library)
     assert test.parent == library
-    assert test.name == types.String('TEST')
+    assert test.name == types.SpiceStr('TEST')
 
 def test_NMOS(library, test_ckt):
-    assert any(x.name == types.String('NMOS') for x in library)
+    assert any(x.name == types.SpiceStr('NMOS') for x in library)
     with set_context(test_ckt.elements):
         with pytest.raises(Exception):
             inst = Instance(
@@ -48,15 +48,15 @@ def test_NMOS(library, test_ckt):
             model='NMOS',
             pins={'D': 'NET10', 'G': 'NET12', 'S': 'NET13', 'B': 'VSS'},
             generator='MOS')
-    assert inst.name == types.String('M1')
-    assert inst.model == types.String('NMOS')
-    assert inst.pins == types.Dict[types.String, types.String]({
+    assert inst.name == types.SpiceStr('M1')
+    assert inst.model == types.SpiceStr('NMOS')
+    assert inst.pins == types.Dict[types.SpiceStr, types.SpiceStr]({
         'D': 'NET10',
         'G': 'NET12',
         'S': 'NET13',
         'B': 'VSS'
     })
-    assert inst.parameters == types.Dict[types.String, types.String]({
+    assert inst.parameters == types.Dict[types.SpiceStr, types.SpiceStr]({
         'W': '0',
         'L': '0',
         'NFIN': '1'
@@ -68,14 +68,14 @@ def test_NMOS(library, test_ckt):
             pins={'D': 'NET10', 'G': 'NET12', 'S': 'NET13', 'B': 'VSS'},
             parameters={'NFIN': 2},
             generator='MOS')
-    assert inst.parameters == types.Dict[types.String, types.String]({
+    assert inst.parameters == types.Dict[types.SpiceStr, types.SpiceStr]({
         'W': '0', 
         'L': '0',
         'NFIN': '2'
     })
 
 def test_PMOS(library, test_ckt):
-    assert any(x.name == types.String('PMOS') for x in library)
+    assert any(x.name == types.SpiceStr('PMOS') for x in library)
     with set_context(test_ckt.elements):
         with pytest.raises(Exception):
             inst = Instance(
@@ -94,15 +94,15 @@ def test_PMOS(library, test_ckt):
             model='PMOS',
             pins={'D': 'NET10', 'G': 'NET12', 'S': 'NET13', 'B': 'VSS'},
             generator='MOS')
-    assert inst.name == types.String('M1')
-    assert inst.model == types.String('PMOS')
-    assert inst.pins == types.Dict[types.String, types.String]({
+    assert inst.name == types.SpiceStr('M1')
+    assert inst.model == types.SpiceStr('PMOS')
+    assert inst.pins == types.Dict[types.SpiceStr, types.SpiceStr]({
         'D': 'NET10',
         'G': 'NET12',
         'S': 'NET13',
         'B': 'VSS'
     })
-    assert inst.parameters == types.Dict[types.String, types.String]({
+    assert inst.parameters == types.Dict[types.SpiceStr, types.SpiceStr]({
         'W': '0', 
         'L': '0',
         'NFIN': '1'
@@ -114,59 +114,59 @@ def test_PMOS(library, test_ckt):
             pins={'D': 'NET10', 'G': 'NET12', 'S': 'NET13', 'B': 'VSS'},
             parameters={'NFIN': 2},
             generator='MOS')
-    assert inst.parameters == types.Dict[types.String, types.String]({
+    assert inst.parameters == types.Dict[types.SpiceStr, types.SpiceStr]({
         'W': '0', 
         'L': '0',
         'NFIN': '2'
     })
 
 def test_res(library, test_ckt):
-    assert any(x.name == types.String('RES') for x in library)
+    assert any(x.name == types.SpiceStr('RES') for x in library)
     with set_context(test_ckt.elements):
         with pytest.raises(Exception):
             inst = Instance(name='R1', model='RES', pins={'PLUS': 'NET10'},generator='MOS')
         with pytest.raises(Exception):
             inst = Instance(name='X1', model='RES', pins={'PLUS': 'NET10', 'MINUS':'NET12'}, parameters={'VALUE': '1.3'},generator='MOS')
         inst = Instance(name='R1', model='RES', pins={'PLUS': 'NET10', 'MINUS':'NET12'}, parameters={'VALUE': '1.3'},generator='MOS')
-    assert inst.name == types.String('R1')
-    assert inst.model == types.String('RES')
-    assert inst.pins == types.Dict[types.String, types.String]({
+    assert inst.name == types.SpiceStr('R1')
+    assert inst.model == types.SpiceStr('RES')
+    assert inst.pins == types.Dict[types.SpiceStr, types.SpiceStr]({
         'PLUS': 'NET10', 
         'MINUS': 'NET12'
     })
-    assert inst.parameters == types.Dict[types.String, types.String]({'VALUE': '1.3'})
+    assert inst.parameters == types.Dict[types.SpiceStr, types.SpiceStr]({'VALUE': '1.3'})
 
 def test_cap(library, test_ckt):
-    assert any(x.name == types.String('CAP') for x in library)
+    assert any(x.name == types.SpiceStr('CAP') for x in library)
     with set_context(test_ckt.elements):
         with pytest.raises(Exception):
             inst = Instance(name='C1', model='CAP', pins={'PLUS': 'NET10'},generator='MOS')
         with pytest.raises(Exception):
             inst = Instance(name='X1', model='CAP', pins={'PLUS': 'NET10', 'MINUS':'NET12'}, parameters={'VALUE': '1.3'},generator='MOS')
         inst = Instance(name='C1', model='CAP', pins={'PLUS': 'NET10', 'MINUS':'NET12'}, parameters={'VALUE': '1.3'},generator='MOS')
-    assert inst.name == types.String('C1')
-    assert inst.model == types.String('CAP')
-    assert inst.pins == types.Dict[types.String, types.String]({
+    assert inst.name == types.SpiceStr('C1')
+    assert inst.model == types.SpiceStr('CAP')
+    assert inst.pins == types.Dict[types.SpiceStr, types.SpiceStr]({
         'PLUS': 'NET10',
         'MINUS': 'NET12'
     })
-    assert inst.parameters == types.Dict[types.String, types.String]({
+    assert inst.parameters == types.Dict[types.SpiceStr, types.SpiceStr]({
         'VALUE': '1.3'
     })
 
 def test_ind(library, test_ckt):
-    assert any(x.name == types.String('IND') for x in library)
+    assert any(x.name == types.SpiceStr('IND') for x in library)
     with set_context(test_ckt.elements):
         with pytest.raises(Exception):
             inst = Instance(name='L1', model='IND', pins={'PLUS': 'NET10'},generator='MOS')
         with pytest.raises(Exception):
             inst = Instance(name='X1', model='IND', pins={'PLUS': 'NET10', 'MINUS':'NET12'}, parameters={'VALUE': '1.3'},generator='MOS')
         inst = Instance(name='L1', model='IND', pins={'PLUS': 'NET10', 'MINUS':'NET12'}, parameters={'VALUE': '1.3'},generator='MOS')
-    assert inst.name == types.String('L1')
-    assert inst.model == types.String('IND')
-    assert inst.pins == types.Dict[types.String, types.String]({
+    assert inst.name == types.SpiceStr('L1')
+    assert inst.model == types.SpiceStr('IND')
+    assert inst.pins == types.Dict[types.SpiceStr, types.SpiceStr]({
         'PLUS': 'NET10',
         'MINUS': 'NET12'
     })
-    assert inst.parameters == types.Dict[types.String, types.String]({'VALUE': '1.3'})
+    assert inst.parameters == types.Dict[types.SpiceStr, types.SpiceStr]({'VALUE': '1.3'})
 

--- a/tests/schema/test_library.py
+++ b/tests/schema/test_library.py
@@ -4,7 +4,8 @@ from align.schema.library import Library
 from align.schema.model import Model
 from align.schema.subcircuit import Circuit
 from align.schema.instance import Instance
-from align.schema.types import set_context, List
+from align.schema.types import set_context
+from align.schema import types
 
 @pytest.fixture
 def library():
@@ -23,12 +24,12 @@ def test_library_registration(library):
             pins=['D', 'G', 'S', 'B'],
             parameters={'W': 0, 'L': 0, 'NFIN': 1})
     library.append(test)
-    assert any(x.name == 'TEST' for x in library)
+    assert any(x.name == types.String('TEST') for x in library)
     assert test.parent == library
-    assert test.name == 'TEST'
+    assert test.name == types.String('TEST')
 
 def test_NMOS(library, test_ckt):
-    assert any(x.name == 'NMOS' for x in library)
+    assert any(x.name == types.String('NMOS') for x in library)
     with set_context(test_ckt.elements):
         with pytest.raises(Exception):
             inst = Instance(
@@ -47,13 +48,19 @@ def test_NMOS(library, test_ckt):
             model='NMOS',
             pins={'D': 'NET10', 'G': 'NET12', 'S': 'NET13', 'B': 'VSS'},
             generator='MOS')
-    assert inst.name == 'M1'
-    assert inst.model == 'NMOS'
-    assert inst.pins == {'D': 'NET10', 'G': 'NET12', 'S': 'NET13', 'B': 'VSS'}
-    assert list(inst.parameters.keys()) == ['W', 'L', 'NFIN']
-    assert inst.parameters['W'] == '0'
-    assert inst.parameters['L'] == '0'
-    assert inst.parameters['NFIN'] == '1'
+    assert inst.name == types.String('M1')
+    assert inst.model == types.String('NMOS')
+    assert inst.pins == types.Dict[types.String, types.String]({
+        'D': 'NET10',
+        'G': 'NET12',
+        'S': 'NET13',
+        'B': 'VSS'
+    })
+    assert inst.parameters == types.Dict[types.String, types.String]({
+        'W': '0',
+        'L': '0',
+        'NFIN': '1'
+    })
     with set_context(test_ckt.elements):
         inst = Instance(
             name='M1',
@@ -61,10 +68,14 @@ def test_NMOS(library, test_ckt):
             pins={'D': 'NET10', 'G': 'NET12', 'S': 'NET13', 'B': 'VSS'},
             parameters={'NFIN': 2},
             generator='MOS')
-    assert inst.parameters['NFIN'] == '2'
+    assert inst.parameters == types.Dict[types.String, types.String]({
+        'W': '0', 
+        'L': '0',
+        'NFIN': '2'
+    })
 
 def test_PMOS(library, test_ckt):
-    assert any(x.name == 'PMOS' for x in library)
+    assert any(x.name == types.String('PMOS') for x in library)
     with set_context(test_ckt.elements):
         with pytest.raises(Exception):
             inst = Instance(
@@ -83,13 +94,19 @@ def test_PMOS(library, test_ckt):
             model='PMOS',
             pins={'D': 'NET10', 'G': 'NET12', 'S': 'NET13', 'B': 'VSS'},
             generator='MOS')
-    assert inst.name == 'M1'
-    assert inst.model == 'PMOS'
-    assert inst.pins == {'D': 'NET10', 'G': 'NET12', 'S': 'NET13', 'B': 'VSS'}
-    assert list(inst.parameters.keys()) == ['W', 'L', 'NFIN']
-    assert inst.parameters['W'] == '0'
-    assert inst.parameters['L'] == '0'
-    assert inst.parameters['NFIN'] == '1'
+    assert inst.name == types.String('M1')
+    assert inst.model == types.String('PMOS')
+    assert inst.pins == types.Dict[types.String, types.String]({
+        'D': 'NET10',
+        'G': 'NET12',
+        'S': 'NET13',
+        'B': 'VSS'
+    })
+    assert inst.parameters == types.Dict[types.String, types.String]({
+        'W': '0', 
+        'L': '0',
+        'NFIN': '1'
+    })
     with set_context(test_ckt.elements):
         inst = Instance(
             name='M1',
@@ -97,44 +114,59 @@ def test_PMOS(library, test_ckt):
             pins={'D': 'NET10', 'G': 'NET12', 'S': 'NET13', 'B': 'VSS'},
             parameters={'NFIN': 2},
             generator='MOS')
-    assert inst.parameters['NFIN'] == '2'
+    assert inst.parameters == types.Dict[types.String, types.String]({
+        'W': '0', 
+        'L': '0',
+        'NFIN': '2'
+    })
 
 def test_res(library, test_ckt):
-    assert any(x.name == 'RES' for x in library)
+    assert any(x.name == types.String('RES') for x in library)
     with set_context(test_ckt.elements):
         with pytest.raises(Exception):
             inst = Instance(name='R1', model='RES', pins={'PLUS': 'NET10'},generator='MOS')
         with pytest.raises(Exception):
             inst = Instance(name='X1', model='RES', pins={'PLUS': 'NET10', 'MINUS':'NET12'}, parameters={'VALUE': '1.3'},generator='MOS')
         inst = Instance(name='R1', model='RES', pins={'PLUS': 'NET10', 'MINUS':'NET12'}, parameters={'VALUE': '1.3'},generator='MOS')
-    assert inst.name == 'R1'
-    assert inst.model == 'RES'
-    assert inst.pins == {'PLUS': 'NET10', 'MINUS': 'NET12'}
-    assert inst.parameters['VALUE'] == '1.3'
+    assert inst.name == types.String('R1')
+    assert inst.model == types.String('RES')
+    assert inst.pins == types.Dict[types.String, types.String]({
+        'PLUS': 'NET10', 
+        'MINUS': 'NET12'
+    })
+    assert inst.parameters == types.Dict[types.String, types.String]({'VALUE': '1.3'})
 
 def test_cap(library, test_ckt):
-    assert any(x.name == 'CAP' for x in library)
+    assert any(x.name == types.String('CAP') for x in library)
     with set_context(test_ckt.elements):
         with pytest.raises(Exception):
             inst = Instance(name='C1', model='CAP', pins={'PLUS': 'NET10'},generator='MOS')
         with pytest.raises(Exception):
             inst = Instance(name='X1', model='CAP', pins={'PLUS': 'NET10', 'MINUS':'NET12'}, parameters={'VALUE': '1.3'},generator='MOS')
         inst = Instance(name='C1', model='CAP', pins={'PLUS': 'NET10', 'MINUS':'NET12'}, parameters={'VALUE': '1.3'},generator='MOS')
-    assert inst.name == 'C1'
-    assert inst.model == 'CAP'
-    assert inst.pins == {'PLUS': 'NET10', 'MINUS': 'NET12'}
-    assert inst.parameters['VALUE'] == '1.3'
+    assert inst.name == types.String('C1')
+    assert inst.model == types.String('CAP')
+    assert inst.pins == types.Dict[types.String, types.String]({
+        'PLUS': 'NET10',
+        'MINUS': 'NET12'
+    })
+    assert inst.parameters == types.Dict[types.String, types.String]({
+        'VALUE': '1.3'
+    })
 
 def test_ind(library, test_ckt):
-    assert any(x.name == 'IND' for x in library)
+    assert any(x.name == types.String('IND') for x in library)
     with set_context(test_ckt.elements):
         with pytest.raises(Exception):
             inst = Instance(name='L1', model='IND', pins={'PLUS': 'NET10'},generator='MOS')
         with pytest.raises(Exception):
             inst = Instance(name='X1', model='IND', pins={'PLUS': 'NET10', 'MINUS':'NET12'}, parameters={'VALUE': '1.3'},generator='MOS')
         inst = Instance(name='L1', model='IND', pins={'PLUS': 'NET10', 'MINUS':'NET12'}, parameters={'VALUE': '1.3'},generator='MOS')
-    assert inst.name == 'L1'
-    assert inst.model == 'IND'
-    assert inst.pins == {'PLUS': 'NET10', 'MINUS': 'NET12'}
-    assert inst.parameters['VALUE'] == '1.3'
+    assert inst.name == types.String('L1')
+    assert inst.model == types.String('IND')
+    assert inst.pins == types.Dict[types.String, types.String]({
+        'PLUS': 'NET10',
+        'MINUS': 'NET12'
+    })
+    assert inst.parameters == types.Dict[types.String, types.String]({'VALUE': '1.3'})
 

--- a/tests/schema/test_model.py
+++ b/tests/schema/test_model.py
@@ -72,10 +72,10 @@ def test_base_model_case_insensitivity(library):
                 'PARAM1': 'nf*4',
                 'param2': '2'
             })
-    assert isinstance(MyDevice.name, types.String), type(MyDevice.name)
-    assert MyDevice.name == types.String('MYDEVICE')
-    assert MyDevice.pins == types.List[types.String](['D', 'S'])
-    assert MyDevice.parameters == types.Dict[types.String, types.String]({
+    assert isinstance(MyDevice.name, types.SpiceStr), type(MyDevice.name)
+    assert MyDevice.name == types.SpiceStr('MYDEVICE')
+    assert MyDevice.pins == types.List[types.SpiceStr](['D', 'S'])
+    assert MyDevice.parameters == types.Dict[types.SpiceStr, types.SpiceStr]({
         'PARAM1': 'NF*4',
         'PARAM2': '2'
     })
@@ -87,10 +87,10 @@ def test_derived_model_case_insensitivity(testmos):
             name='DerivedMOS',
             base='testmos',
             parameters={'param1': 'nf*4'})
-    assert DerivedMOS.name == types.String('DERIVEDMOS')
-    assert DerivedMOS.base == types.String('TESTMOS')
-    assert DerivedMOS.pins == types.List[types.String](['D', 'G', 'S', 'B'])
-    assert DerivedMOS.parameters == types.Dict[types.String, types.String]({
+    assert DerivedMOS.name == types.SpiceStr('DERIVEDMOS')
+    assert DerivedMOS.base == types.SpiceStr('TESTMOS')
+    assert DerivedMOS.pins == types.List[types.SpiceStr](['D', 'G', 'S', 'B'])
+    assert DerivedMOS.parameters == types.Dict[types.SpiceStr, types.SpiceStr]({
         'PARAM1': 'NF*4',
         'PARAM2': '2'
     })
@@ -104,7 +104,7 @@ def test_derived_model_new_parameters(testmos):
             parameters={
                 'PARAM1': 'NF*6',
                 'PARAM3': 'NF*4'})
-    assert DerivedMOS.parameters == types.Dict[types.String, types.String]({
+    assert DerivedMOS.parameters == types.Dict[types.SpiceStr, types.SpiceStr]({
         'PARAM1': 'NF*6',
         'PARAM2': '2',
         'PARAM3': 'NF*4'
@@ -124,7 +124,7 @@ def test_model_str_casting(library):
                 'PARAM1': 1.0,
                 'PARAM2': 2
             })
-    assert MyDevice.parameters == types.Dict[types.String, types.String]({
+    assert MyDevice.parameters == types.Dict[types.SpiceStr, types.SpiceStr]({
         'PARAM1': '1.0',
         'PARAM2': '2'
     })

--- a/tests/schema/test_model.py
+++ b/tests/schema/test_model.py
@@ -1,4 +1,6 @@
+import pydantic
 import pytest
+from align.schema import types
 
 from align.schema.model import Model
 from align.schema.types import set_context, List
@@ -25,7 +27,7 @@ def testmos(library):
 
 def test_new_model(library):
     with set_context(library):
-        with pytest.raises(Exception):     
+        with pytest.raises(Exception):
             MyDevice = Model()
         with pytest.raises(Exception):
             MyDevice = Model(name='MyDevice')
@@ -70,12 +72,13 @@ def test_base_model_case_insensitivity(library):
                 'PARAM1': 'nf*4',
                 'param2': '2'
             })
-    assert MyDevice.name == 'MYDEVICE'
-    assert MyDevice.pins == ['D', 'S']
-    assert MyDevice.parameters == {
+    assert isinstance(MyDevice.name, types.String), type(MyDevice.name)
+    assert MyDevice.name == types.String('MYDEVICE')
+    assert MyDevice.pins == types.List[types.String](['D', 'S'])
+    assert MyDevice.parameters == types.Dict[types.String, types.String]({
         'PARAM1': 'NF*4',
         'PARAM2': '2'
-    }
+    })
 
 
 def test_derived_model_case_insensitivity(testmos):
@@ -84,10 +87,13 @@ def test_derived_model_case_insensitivity(testmos):
             name='DerivedMOS',
             base='testmos',
             parameters={'param1': 'nf*4'})
-    assert DerivedMOS.name == 'DERIVEDMOS'
-    assert DerivedMOS.base == 'TESTMOS'
-    assert DerivedMOS.pins == ['D', 'G', 'S', 'B']
-    assert DerivedMOS.parameters == {'PARAM1': 'NF*4', 'PARAM2': '2'}
+    assert DerivedMOS.name == types.String('DERIVEDMOS')
+    assert DerivedMOS.base == types.String('TESTMOS')
+    assert DerivedMOS.pins == types.List[types.String](['D', 'G', 'S', 'B'])
+    assert DerivedMOS.parameters == types.Dict[types.String, types.String]({
+        'PARAM1': 'NF*4',
+        'PARAM2': '2'
+    })
 
 
 def test_derived_model_new_parameters(testmos):
@@ -98,11 +104,11 @@ def test_derived_model_new_parameters(testmos):
             parameters={
                 'PARAM1': 'NF*6',
                 'PARAM3': 'NF*4'})
-    assert DerivedMOS.parameters == {
+    assert DerivedMOS.parameters == types.Dict[types.String, types.String]({
         'PARAM1': 'NF*6',
         'PARAM2': '2',
         'PARAM3': 'NF*4'
-    }
+    })
 
 
 def test_model_str_casting(library):
@@ -118,10 +124,10 @@ def test_model_str_casting(library):
                 'PARAM1': 1.0,
                 'PARAM2': 2
             })
-    assert MyDevice.parameters == {
+    assert MyDevice.parameters == types.Dict[types.String, types.String]({
         'PARAM1': '1.0',
         'PARAM2': '2'
-    }
+    })
 
 
 def test_model_json(testmos):
@@ -136,4 +142,4 @@ def test_model_xyce(testmos):
         newmos = Model(name='newmos', base='TESTMOS',
                        parameters={'param3': '3'})
     assert newmos.xyce(
-    ) == '.MODEL NEWMOS TESTMOS PARAM1={1.0} PARAM2={2} PARAM3={3}'
+    ) == '.MODEL newmos TESTMOS PARAM1={1.0} PARAM2={2} param3={3}'

--- a/tests/schema/test_subcircuit.py
+++ b/tests/schema/test_subcircuit.py
@@ -2,7 +2,7 @@ import pytest
 
 from align.schema.subcircuit import Model, SubCircuit, Circuit, Instance
 from align.schema.library import Library
-from align.schema.types import set_context
+from align.schema.types import set_context, Dict, String
 
 @pytest.fixture
 def library():
@@ -36,18 +36,20 @@ def test_subckt_definition(library, test_ckt):
         inst = Instance(name='X1', model='subckt', pins={'PIN1': 'NET10', 'PIN2': 'NET12'},generator='Dummy')
     assert inst.name == 'X1'
     assert inst.model == 'SUBCKT'
-    assert inst.pins == {'PIN1': 'NET10', 'PIN2': 'NET12'}
+    assert list(inst.pins.keys()) == ['PIN1', 'PIN2']
+    assert list(inst.pins.values()) == ['NET10', 'NET12']
+    assert inst.pins == {String('PIN1'): String('NET10'), String('PIN2'): 'NET12'}
     assert list(inst.parameters.keys()) == ['PARAM1', 'PARAM2', 'PARAM3', 'PARAM4']
-    assert inst.parameters['PARAM1'] == '1'
-    assert inst.parameters['PARAM2'] == '1E-3'
-    assert inst.parameters['PARAM3'] == '0.1F'
-    assert inst.parameters['PARAM4'] == 'HELLO'
+    assert inst.parameters[String('PARAM1')] == '1'
+    assert inst.parameters[String('PARAM2')] == '1E-3'
+    assert inst.parameters[String('PARAM3')] == '0.1F'
+    assert inst.parameters[String('PARAM4')] == 'HELLO'
     with set_context(test_ckt.elements):
         with pytest.raises(Exception):
             inst = subckt(name='X1', model='subckt', pins={'PIN1': 'NET10', 'PIN2': 'NET12'}, parameters={'garbage':''},generator='Dummy')
         inst = Instance(name='X1', model='subckt', pins={'PIN1': 'NET10', 'PIN2': 'NET12'}, parameters={'param1': '2', 'param3': '1e-16'},generator='Dummy')
-    assert inst.parameters['PARAM1'] == '2'
-    assert inst.parameters['PARAM3'] == '1E-16'
+    assert inst.parameters[String('PARAM1')] == '2'
+    assert inst.parameters[String('PARAM3')] == '1E-16'
 
 def test_subckt_instantiation(library, test_ckt):
     with set_context(library):
@@ -71,5 +73,11 @@ def test_subckt_instantiation(library, test_ckt):
         inst = Instance(name='X1', model='subckt', pins={'PIN1': 'NET10', 'PIN2': 'NET12'},generator='Dummy')
     assert inst.name == 'X1'
     assert inst.model == 'SUBCKT'
-    assert inst.pins == {'PIN1': 'NET10', 'PIN2': 'NET12'}
-    assert inst.parameters == {'PARAM1': '1', 'PARAM2': '0.001', 'PARAM3': '1E-16', 'PARAM4': 'HELLO'}
+    assert isinstance(inst.pins, Dict)
+    assert all(isinstance(x, String) for x in inst.pins.keys())
+    assert all(isinstance(x, String) for x in inst.pins.values())
+    assert inst.pins == {String('PIN1'): String('NET10'), String('PIN2'): String('NET12')}
+    assert isinstance(inst.parameters, Dict)
+    assert all(isinstance(x, String) for x in inst.parameters.keys())
+    assert all(isinstance(x, String) for x in inst.parameters.values())
+    assert inst.parameters == {String('PARAM1'): String('1'), String('PARAM2'): String('0.001'), String('PARAM3'): String('1E-16'), String('PARAM4'): String('HELLO')}

--- a/tests/schema/test_subcircuit.py
+++ b/tests/schema/test_subcircuit.py
@@ -2,7 +2,7 @@ import pytest
 
 from align.schema.subcircuit import Model, SubCircuit, Circuit, Instance
 from align.schema.library import Library
-from align.schema.types import set_context, Dict, String
+from align.schema.types import set_context, Dict, SpiceStr
 
 @pytest.fixture
 def library():
@@ -38,18 +38,18 @@ def test_subckt_definition(library, test_ckt):
     assert inst.model == 'SUBCKT'
     assert list(inst.pins.keys()) == ['PIN1', 'PIN2']
     assert list(inst.pins.values()) == ['NET10', 'NET12']
-    assert inst.pins == {String('PIN1'): String('NET10'), String('PIN2'): 'NET12'}
+    assert inst.pins == {SpiceStr('PIN1'): SpiceStr('NET10'), SpiceStr('PIN2'): 'NET12'}
     assert list(inst.parameters.keys()) == ['PARAM1', 'PARAM2', 'PARAM3', 'PARAM4']
-    assert inst.parameters[String('PARAM1')] == '1'
-    assert inst.parameters[String('PARAM2')] == '1E-3'
-    assert inst.parameters[String('PARAM3')] == '0.1F'
-    assert inst.parameters[String('PARAM4')] == 'HELLO'
+    assert inst.parameters[SpiceStr('PARAM1')] == '1'
+    assert inst.parameters[SpiceStr('PARAM2')] == '1E-3'
+    assert inst.parameters[SpiceStr('PARAM3')] == '0.1F'
+    assert inst.parameters[SpiceStr('PARAM4')] == 'HELLO'
     with set_context(test_ckt.elements):
         with pytest.raises(Exception):
             inst = subckt(name='X1', model='subckt', pins={'PIN1': 'NET10', 'PIN2': 'NET12'}, parameters={'garbage':''},generator='Dummy')
         inst = Instance(name='X1', model='subckt', pins={'PIN1': 'NET10', 'PIN2': 'NET12'}, parameters={'param1': '2', 'param3': '1e-16'},generator='Dummy')
-    assert inst.parameters[String('PARAM1')] == '2'
-    assert inst.parameters[String('PARAM3')] == '1E-16'
+    assert inst.parameters[SpiceStr('PARAM1')] == '2'
+    assert inst.parameters[SpiceStr('PARAM3')] == '1E-16'
 
 def test_subckt_instantiation(library, test_ckt):
     with set_context(library):
@@ -74,10 +74,10 @@ def test_subckt_instantiation(library, test_ckt):
     assert inst.name == 'X1'
     assert inst.model == 'SUBCKT'
     assert isinstance(inst.pins, Dict)
-    assert all(isinstance(x, String) for x in inst.pins.keys())
-    assert all(isinstance(x, String) for x in inst.pins.values())
-    assert inst.pins == {String('PIN1'): String('NET10'), String('PIN2'): String('NET12')}
+    assert all(isinstance(x, SpiceStr) for x in inst.pins.keys())
+    assert all(isinstance(x, SpiceStr) for x in inst.pins.values())
+    assert inst.pins == {SpiceStr('PIN1'): SpiceStr('NET10'), SpiceStr('PIN2'): SpiceStr('NET12')}
     assert isinstance(inst.parameters, Dict)
-    assert all(isinstance(x, String) for x in inst.parameters.keys())
-    assert all(isinstance(x, String) for x in inst.parameters.values())
-    assert inst.parameters == {String('PARAM1'): String('1'), String('PARAM2'): String('0.001'), String('PARAM3'): String('1E-16'), String('PARAM4'): String('HELLO')}
+    assert all(isinstance(x, SpiceStr) for x in inst.parameters.keys())
+    assert all(isinstance(x, SpiceStr) for x in inst.parameters.values())
+    assert inst.parameters == {SpiceStr('PARAM1'): SpiceStr('1'), SpiceStr('PARAM2'): SpiceStr('0.001'), SpiceStr('PARAM3'): SpiceStr('1E-16'), SpiceStr('PARAM4'): SpiceStr('HELLO')}

--- a/tests/schema/test_types.py
+++ b/tests/schema/test_types.py
@@ -70,6 +70,15 @@ def test_case_insensitive_string():
     assert "burns" != SpiceStr("Steve")
     assert SpiceStr("Steve") != "burns"
 
+    # Appending a standard str to a SpiceStr
+    # should return a SpiceStr
+    assert isinstance(SpiceStr("heLLo") + 'someone', SpiceStr)
+    assert SpiceStr("heLLo") + 'someone'== "hellosomeone"
+    # WARNING: appending the other way round does
+    #          not hold true
+    assert not isinstance("heLLo" + SpiceStr('someone'), SpiceStr)
+    assert "heLLo" + SpiceStr('someone') != "hellosomeone"
+
     # As long as parent string is of type
     # `SpiceStr`, contains works as expected
     assert SpiceStr("Ste") in SpiceStr("steve")

--- a/tests/schema/test_types.py
+++ b/tests/schema/test_types.py
@@ -1,17 +1,17 @@
 import pytest
 
-from align.schema.types import BaseModel, List, Dict
+from align.schema.types import BaseModel, List, Dict, String
 
 
 class BaseType(BaseModel):
-    name: str
+    name: String
 
 
 class CompositionalType(BaseModel):
-    name: str
+    name: String
     child: BaseType
     children: List[BaseType]
-    children_as_dict: Dict[str, BaseType]
+    children_as_dict: Dict[String, BaseType]
 
 
 def test_type_inference():
@@ -32,7 +32,7 @@ def test_type_inference():
     assert isinstance(myobj.children, List)
     assert isinstance(myobj.children_as_dict, Dict)
     assert all(isinstance(x, BaseType) for x in myobj.children)
-    assert all(isinstance(x, str) for x in myobj.children_as_dict.keys())
+    assert all(isinstance(x, String) for x in myobj.children_as_dict.keys())
     assert all(isinstance(x, BaseType) for x in myobj.children_as_dict.values())
 
 def test_type_relationships():
@@ -57,3 +57,47 @@ def test_type_relationships():
     assert len(myobj.children_as_dict) == 2
     assert myobj.children_as_dict['child1'].parent == myobj.children_as_dict['child2'].parent
     assert myobj.children_as_dict['child1'].parent.parent == myobj
+
+def test_case_insensitive_string():
+    # Core functionality we are trying to achieve
+    assert String("Steve") == String("steve")
+    assert String("Steve") != String("burns")
+
+    # Comparison to built-in str works 
+    # both ways as well !!!
+    assert "sTeVe" == String("Steve")
+    assert String("Steve") == "sTeVe"
+    assert "burns" != String("Steve")
+    assert String("Steve") != "burns"
+
+    # As long as parent string is of type
+    # `String`, contains works as expected
+    assert String("Ste") in String("steve")
+    assert "sTeVe" in String("steve")
+    assert "StE" in String("steve")
+    assert "Burns" not in String("steve")
+    # WARNING: parent string MUST be of type
+    # `String` for contain to work. See below
+    assert String("ste") not in "Steve"
+
+    # WARNING: Object behaves like built-in str
+    # for almost everything else
+
+    # Slicing returns built-in str (not `String`)
+    x, y = String("Steve")[0], String("Steve")[0:3]
+    assert type(x) == str
+    assert type(y) == str
+    assert x == 'S'
+    assert y == 'Ste'
+    # Reverse via slicing works returns
+    # built-in str (not `String`)
+    x = String("Steve")[::-1]
+    assert type(x) == str
+    assert x == "evetS"
+
+    # `reverse` returns iterator
+    assert list(reversed(String("Steve"))) == list("evetS")
+
+    # len, list comprehension etc works like str
+    assert len(String("Steve")) == 5
+    assert list("Steve") == [c for c in String("Steve")]

--- a/tests/schema/test_types.py
+++ b/tests/schema/test_types.py
@@ -1,17 +1,17 @@
 import pytest
 
-from align.schema.types import BaseModel, List, Dict, String
+from align.schema.types import BaseModel, List, Dict, SpiceStr
 
 
 class BaseType(BaseModel):
-    name: String
+    name: SpiceStr
 
 
 class CompositionalType(BaseModel):
-    name: String
+    name: SpiceStr
     child: BaseType
     children: List[BaseType]
-    children_as_dict: Dict[String, BaseType]
+    children_as_dict: Dict[SpiceStr, BaseType]
 
 
 def test_type_inference():
@@ -32,7 +32,7 @@ def test_type_inference():
     assert isinstance(myobj.children, List)
     assert isinstance(myobj.children_as_dict, Dict)
     assert all(isinstance(x, BaseType) for x in myobj.children)
-    assert all(isinstance(x, String) for x in myobj.children_as_dict.keys())
+    assert all(isinstance(x, SpiceStr) for x in myobj.children_as_dict.keys())
     assert all(isinstance(x, BaseType) for x in myobj.children_as_dict.values())
 
 def test_type_relationships():
@@ -60,44 +60,44 @@ def test_type_relationships():
 
 def test_case_insensitive_string():
     # Core functionality we are trying to achieve
-    assert String("Steve") == String("steve")
-    assert String("Steve") != String("burns")
+    assert SpiceStr("Steve") == SpiceStr("steve")
+    assert SpiceStr("Steve") != SpiceStr("burns")
 
     # Comparison to built-in str works 
     # both ways as well !!!
-    assert "sTeVe" == String("Steve")
-    assert String("Steve") == "sTeVe"
-    assert "burns" != String("Steve")
-    assert String("Steve") != "burns"
+    assert "sTeVe" == SpiceStr("Steve")
+    assert SpiceStr("Steve") == "sTeVe"
+    assert "burns" != SpiceStr("Steve")
+    assert SpiceStr("Steve") != "burns"
 
     # As long as parent string is of type
-    # `String`, contains works as expected
-    assert String("Ste") in String("steve")
-    assert "sTeVe" in String("steve")
-    assert "StE" in String("steve")
-    assert "Burns" not in String("steve")
+    # `SpiceStr`, contains works as expected
+    assert SpiceStr("Ste") in SpiceStr("steve")
+    assert "sTeVe" in SpiceStr("steve")
+    assert "StE" in SpiceStr("steve")
+    assert "Burns" not in SpiceStr("steve")
     # WARNING: parent string MUST be of type
-    # `String` for contain to work. See below
-    assert String("ste") not in "Steve"
+    # `SpiceStr` for contain to work. See below
+    assert SpiceStr("ste") not in "Steve"
 
     # WARNING: Object behaves like built-in str
     # for almost everything else
 
-    # Slicing returns built-in str (not `String`)
-    x, y = String("Steve")[0], String("Steve")[0:3]
+    # Slicing returns built-in str (not `SpiceStr`)
+    x, y = SpiceStr("Steve")[0], SpiceStr("Steve")[0:3]
     assert type(x) == str
     assert type(y) == str
     assert x == 'S'
     assert y == 'Ste'
     # Reverse via slicing works returns
-    # built-in str (not `String`)
-    x = String("Steve")[::-1]
+    # built-in str (not `SpiceStr`)
+    x = SpiceStr("Steve")[::-1]
     assert type(x) == str
     assert x == "evetS"
 
     # `reverse` returns iterator
-    assert list(reversed(String("Steve"))) == list("evetS")
+    assert list(reversed(SpiceStr("Steve"))) == list("evetS")
 
     # len, list comprehension etc works like str
-    assert len(String("Steve")) == 5
-    assert list("Steve") == [c for c in String("Steve")]
+    assert len(SpiceStr("Steve")) == 5
+    assert list("Steve") == [c for c in SpiceStr("Steve")]

--- a/tests/schema/test_visitor.py
+++ b/tests/schema/test_visitor.py
@@ -1,17 +1,17 @@
 import pytest
 
-from align.schema.types import BaseModel, Optional, List, Dict, String
+from align.schema.types import BaseModel, Optional, List, Dict, SpiceStr
 from align.schema.visitor import Visitor, Transformer, cache
 
 @pytest.fixture
 def dummy():
     class DummyModel(BaseModel):
-        arg1: String
-        arg2: Optional[String]
-        arg3: List[String]
-        arg4: List[Optional[String]]
-        arg5: Dict[String, String]
-        arg6: Dict[String, Optional[String]]
+        arg1: SpiceStr
+        arg2: Optional[SpiceStr]
+        arg3: List[SpiceStr]
+        arg4: List[Optional[SpiceStr]]
+        arg5: Dict[SpiceStr, SpiceStr]
+        arg6: Dict[SpiceStr, Optional[SpiceStr]]
         arg7: "Optional[DummyModel]"
         arg8: "Optional[List[DummyModel]]"
     DummyModel.update_forward_refs()
@@ -40,7 +40,7 @@ def test_visitor_no_output(dummy):
 def test_visitor_raw_output(dummy):
 
     class StrValVisitor(Visitor):
-        def visit_String(self, node):
+        def visit_SpiceStr(self, node):
             return node
 
     assert StrValVisitor().visit(dummy) == [
@@ -85,24 +85,24 @@ def test_transformer_no_visitor(dummy):
 def test_transformer_string_visitor(dummy):
 
     class AddStringPrefix(Transformer):
-        def visit_String(self, node):
+        def visit_SpiceStr(self, node):
             return 'prefix_' + node
 
     transformed = AddStringPrefix().visit(dummy)
     assert isinstance(transformed, dummy.__class__)
-    # String in subtree
+    # SpiceStr in subtree
     assert transformed.arg1 == 'prefix_arg1'
     assert transformed.arg1 is not dummy.arg1
     # No string in subtree
     assert transformed.arg2 == None
     assert transformed.arg2 is dummy.arg2
-    # String in subtree
+    # SpiceStr in subtree
     assert transformed.arg3 == ['prefix_arg3_1', 'prefix_arg3_2']
     assert transformed.arg3 is not dummy.arg3
     # No string in subtree
     assert transformed.arg4 == []
     assert transformed.arg4 is dummy.arg4, f'old:({id(dummy.arg4)}, {dummy.arg4}), new:({id(transformed.arg4)}, {transformed.arg4})'
-    # String in subtree
+    # SpiceStr in subtree
     assert transformed.arg5 == {'arg5_k': 'prefix_arg5_v'}
     assert transformed.arg5 is not dummy.arg5
     # No string in subtree
@@ -118,10 +118,10 @@ def test_transformer_string_visitor(dummy):
                 'arg6': {'arg6_k': None},
                 'arg7': None,
                 'arg8': None}
-    # String in subtree
+    # SpiceStr in subtree
     assert transformed.arg7 == basedict
     assert transformed.arg7 is not dummy.arg7
-    # String in subtree
+    # SpiceStr in subtree
     assert transformed.arg8 == [basedict, basedict]
     assert transformed.arg8 is not dummy.arg8
     # Ensure cache is working for generic_visitor

--- a/tests/schema/test_visitor.py
+++ b/tests/schema/test_visitor.py
@@ -1,17 +1,17 @@
 import pytest
 
-from align.schema.types import BaseModel, Optional, List, Dict
+from align.schema.types import BaseModel, Optional, List, Dict, String
 from align.schema.visitor import Visitor, Transformer, cache
 
 @pytest.fixture
 def dummy():
     class DummyModel(BaseModel):
-        arg1: str
-        arg2: Optional[str]
-        arg3: List[str]
-        arg4: List[Optional[str]]
-        arg5: Dict[str, str]
-        arg6: Dict[str, Optional[str]]
+        arg1: String
+        arg2: Optional[String]
+        arg3: List[String]
+        arg4: List[Optional[String]]
+        arg5: Dict[String, String]
+        arg6: Dict[String, Optional[String]]
         arg7: "Optional[DummyModel]"
         arg8: "Optional[List[DummyModel]]"
     DummyModel.update_forward_refs()
@@ -40,7 +40,7 @@ def test_visitor_no_output(dummy):
 def test_visitor_raw_output(dummy):
 
     class StrValVisitor(Visitor):
-        def visit_str(self, node):
+        def visit_String(self, node):
             return node
 
     assert StrValVisitor().visit(dummy) == [
@@ -85,7 +85,7 @@ def test_transformer_no_visitor(dummy):
 def test_transformer_string_visitor(dummy):
 
     class AddStringPrefix(Transformer):
-        def visit_str(self, node):
+        def visit_String(self, node):
             return 'prefix_' + node
 
     transformed = AddStringPrefix().visit(dummy)


### PR DESCRIPTION
This PR was started to make the schema itself case-insensitive instead of casting all SPICE identifiers to upper-case as we do right now. This would allow us to retain the original names for back-annotation purposes, re-importing to the original library etc.

However, doing so has uncovered case dependencies elsewhere in the compiler flow. I intend to rewrite the compiler as a pipeline of transformations while digging into this deeper.
