### PR TITLE
Move pillow version fix from setup.py to test_wheel.sh

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -264,9 +264,6 @@ workflows:
                 python-tags: "cp38-cp38"
               - platform: "quay.io/pypa/manylinux_2_24_x86_64"
                 python-tags: "cp310-cp310"
-              # Skipping this because of broken pillow dependency
-              - platform: "quay.io/pypa/manylinux2010_x86_64"
-                python-tags: "cp310-cp310"
       - build-test-coverage:
           requires:
             - build-wheel-cp38-manylinux_2_24

--- a/bin/test_wheel.sh
+++ b/bin/test_wheel.sh
@@ -28,6 +28,9 @@ for pyver in "$@"; do
     "/opt/python/${pyver}/bin/python" -m venv .venv
     source .venv/bin/activate
     pip install pip --upgrade
+    if [ "$AUDITWHEEL_PLAT" == "manylinux2010_x86_64" ]; then
+        pip install "pillow==8.3.2"
+    fi
     pip install align[test] -f "$align_root"/wheelhouse
     pytest -n "$MAX_JOBS" -vv --max-worker-restart 0 tests
     # Reset ALIGN_WORK_DIR

--- a/setup.py
+++ b/setup.py
@@ -67,7 +67,6 @@ setup(name='align',
           'bin/convert_lef_to_layout_json.py'
       ],
       install_requires=[
-          'pillow < 8.4.0; python_version<"3.8"',
           'networkx>=2.4',
           'python-gdsii',
           'matplotlib',


### PR DESCRIPTION
Hopefully the last fix. Pillow seems to be broken on manylinux2010 for version 8.4.0 irrespective of the Python version. So am simply pre-installing Pillow 8.3.2 while testing manylinux2010 wheels.