### PR TITLE
Bugfix unsat core display

### DIFF
--- a/align/schema/checker.py
+++ b/align/schema/checker.py
@@ -158,7 +158,11 @@ class Z3Checker(AbstractChecker):
                 labels=self._solver.unsat_core())
 
     def label(self, object):
-        return z3.Bool(str(id(object)))
+        # Z3 throws 'index out of bounds' error
+        # if more than 9 digits are used
+        return z3.Bool(
+            hash(repr(object)) % 10**9
+        )
 
     def checkpoint(self):
         self._solver.push()

--- a/align/schema/constraint.py
+++ b/align/schema/constraint.py
@@ -719,6 +719,7 @@ class ConstraintDB(types.List[ConstraintType]):
                 )
             except checker.CheckerError as e:
                 logger.debug(f'Checker raised error:\n {e}')
+                assert self._checker.label(constraint) in e.labels, "Something went terribly wrong. Current constraint not in unsat core"
                 core = [x.json() for x in self.__root__ if self._checker.label(x) in e.labels and x != constraint]
                 logger.error(f'Failed to add constraint {constraint.json()}')
                 logger.error(f'   due to conflict with {core}')

--- a/align/schema/constraint.py
+++ b/align/schema/constraint.py
@@ -722,7 +722,7 @@ class ConstraintDB(types.List[ConstraintType]):
                 core = [x.json() for x in self.__root__ if self._checker.label(x) in e.labels and x != constraint]
                 logger.error(f'Failed to add constraint {constraint.json()}')
                 logger.error(f'   due to conflict with {core}')
-                raise e
+                raise checker.CheckerError(f'Failed to add constraint {constraint.json()} due to conflict with {core}')
 
     @types.validate_arguments
     def append(self, constraint: ConstraintType):


### PR DESCRIPTION
See #839 for details

Uncontrolled use of copy in the pnr frontend was causing issues with object ID based tracking variable permanence

Using hash(repr()) instead now to generate tracking variables.
