### PR TITLE
Stubs for adding new placement injection function

### DIFF
--- a/PlaceRouteHierFlow/PnR-pybind11.cpp
+++ b/PlaceRouteHierFlow/PnR-pybind11.cpp
@@ -455,6 +455,7 @@ PYBIND11_MODULE(PnR, m) {
     .def( "AddingPowerPins", &PnRdatabase::AddingPowerPins)
     .def( "Extract_RemovePowerPins", &PnRdatabase::Extract_RemovePowerPins)
     .def( "CheckinHierNode", &PnRdatabase::CheckinHierNode)
+    .def( "setPlacementInfoFromJson", &PnRdatabase::setPlacementInfoFromJson)
     .def( "TransformNode", &PnRdatabase::TransformNode)
     .def( "TransformBbox", &PnRdatabase::TransformBbox)
     .def( "TransformPoint", &PnRdatabase::TransformPoint)

--- a/PlaceRouteHierFlow/PnR-pybind11.cpp
+++ b/PlaceRouteHierFlow/PnR-pybind11.cpp
@@ -227,6 +227,7 @@ PYBIND11_MODULE(PnR, m) {
       .def_readwrite("n_copy", &hierNode::n_copy)
       .def_readwrite("numPlacement", &hierNode::numPlacement)
       .def_readwrite("name", &hierNode::name)
+      .def_readwrite("concrete_name", &hierNode::concrete_name)
       .def_readwrite("gdsFile", &hierNode::gdsFile)
       .def_readwrite("parent", &hierNode::parent)
       .def_readwrite("Blocks", &hierNode::Blocks)

--- a/PlaceRouteHierFlow/PnR-pybind11.cpp
+++ b/PlaceRouteHierFlow/PnR-pybind11.cpp
@@ -455,7 +455,6 @@ PYBIND11_MODULE(PnR, m) {
     .def( "AddingPowerPins", &PnRdatabase::AddingPowerPins)
     .def( "Extract_RemovePowerPins", &PnRdatabase::Extract_RemovePowerPins)
     .def( "CheckinHierNode", &PnRdatabase::CheckinHierNode)
-    .def( "setPlacementInfoFromJson", &PnRdatabase::setPlacementInfoFromJson)
     .def( "TransformNode", &PnRdatabase::TransformNode)
     .def( "TransformBbox", &PnRdatabase::TransformBbox)
     .def( "TransformPoint", &PnRdatabase::TransformPoint)
@@ -489,6 +488,8 @@ PYBIND11_MODULE(PnR, m) {
     .def_readwrite("COUNT_LIMIT", &PlacerHyperparameters::COUNT_LIMIT)
     .def_readwrite("LAMBDA", &PlacerHyperparameters::LAMBDA)
     .def_readwrite("use_analytical_placer", &PlacerHyperparameters::use_analytical_placer)
+    .def_readwrite("placement_info_json", &PlacerHyperparameters::placement_info_json)
+    .def_readwrite("use_external_placement_info", &PlacerHyperparameters::use_external_placement_info)
     ;
 
   py::class_<PlacerIfc>( m, "PlacerIfc")

--- a/PlaceRouteHierFlow/PnRDB/PnRdatabase.cpp
+++ b/PlaceRouteHierFlow/PnRDB/PnRdatabase.cpp
@@ -895,7 +895,8 @@ void PnRdatabase::CheckinHierNode(int nodeID, const PnRDB::hierNode& updatedNode
 
           lhs.instNum++;
           b.gdsFile = updatedNode.gdsFile;
-          //update terminal to pin information
+          b.lefmaster = updatedNode.concrete_name;
+          // update terminal to pin information
 
           b.HPWL_extend_wo_terminal = updatedNode.HPWL_extend_wo_terminal;
           

--- a/PlaceRouteHierFlow/PnRDB/PnRdatabase.cpp
+++ b/PlaceRouteHierFlow/PnRDB/PnRdatabase.cpp
@@ -170,12 +170,6 @@ void PnRdatabase::updatePowerPins(PnRDB::pin& temp_pin){
 
 }
 
-void PnRdatabase::setPlacementInfoFromJson(const string& json_string) {
-  auto logger = spdlog::default_logger()->clone("PnRDB.PnRdatabase.setPlacementInfoFromJson");
-
-  logger->info("Calling setPlacementInfoFromJson");
-}
-
 void PnRdatabase::TransformNode(PnRDB::hierNode& updatedNode, PnRDB::point translate, PnRDB::Omark ort, PnRDB::TransformType transform_type) {
   /*
   this function transform all points and inside the node according to translate and orient,

--- a/PlaceRouteHierFlow/PnRDB/PnRdatabase.cpp
+++ b/PlaceRouteHierFlow/PnRDB/PnRdatabase.cpp
@@ -170,6 +170,12 @@ void PnRdatabase::updatePowerPins(PnRDB::pin& temp_pin){
 
 }
 
+void PnRdatabase::setPlacementInfoFromJson(const string& json_string) {
+  auto logger = spdlog::default_logger()->clone("PnRDB.PnRdatabase.setPlacementInfoFromJson");
+
+  logger->info("Calling setPlacementInfoFromJson");
+}
+
 void PnRdatabase::TransformNode(PnRDB::hierNode& updatedNode, PnRDB::point translate, PnRDB::Omark ort, PnRDB::TransformType transform_type) {
   /*
   this function transform all points and inside the node according to translate and orient,

--- a/PlaceRouteHierFlow/PnRDB/PnRdatabase.h
+++ b/PlaceRouteHierFlow/PnRDB/PnRdatabase.h
@@ -122,6 +122,8 @@ class PnRdatabase
     void CheckinChildnodetoBlock(PnRDB::hierNode &parent, int blockID, const PnRDB::hierNode &updatedNode, PnRDB::Omark ort);
     void updatePowerPins(PnRDB::pin &temp_pin);
 
+    void setPlacementInfoFromJson(const string& json_string);
+
     //these functions are used to transform internal info of nodes
     void TransformNode(PnRDB::hierNode& updatedNode, PnRDB::point translate, PnRDB::Omark ort, PnRDB::TransformType tranform_type);
     void TransformTerminal(PnRDB::terminal &terminal, PnRDB::point translate, int width, int height, PnRDB::Omark ort, PnRDB::TransformType tranform_type);

--- a/PlaceRouteHierFlow/PnRDB/PnRdatabase.h
+++ b/PlaceRouteHierFlow/PnRDB/PnRdatabase.h
@@ -122,8 +122,6 @@ class PnRdatabase
     void CheckinChildnodetoBlock(PnRDB::hierNode &parent, int blockID, const PnRDB::hierNode &updatedNode, PnRDB::Omark ort);
     void updatePowerPins(PnRDB::pin &temp_pin);
 
-    void setPlacementInfoFromJson(const string& json_string);
-
     //these functions are used to transform internal info of nodes
     void TransformNode(PnRDB::hierNode& updatedNode, PnRDB::point translate, PnRDB::Omark ort, PnRDB::TransformType tranform_type);
     void TransformTerminal(PnRDB::terminal &terminal, PnRDB::point translate, int width, int height, PnRDB::Omark ort, PnRDB::TransformType tranform_type);

--- a/PlaceRouteHierFlow/PnRDB/datatype.h
+++ b/PlaceRouteHierFlow/PnRDB/datatype.h
@@ -385,7 +385,8 @@ struct hierNode {
   int n_copy = 0;           // number of hiernodes of the same type used in the whole design 
   int numPlacement = 0;
   string name = "";
-  string gdsFile="";
+  string concrete_name = "";
+  string gdsFile = "";
   vector<int> parent;
   vector<blockComplex> Blocks;
   map<string, int> Block_name_map;//map from block name to block index

--- a/PlaceRouteHierFlow/placer/CMakeLists.txt
+++ b/PlaceRouteHierFlow/placer/CMakeLists.txt
@@ -27,5 +27,6 @@ target_link_libraries(
      spdlog::spdlog
      lpsolve::lpsolve55
      Boost::boost
+     nlohmann_json::nlohmann_json
 )
 target_code_coverage(placer)

--- a/PlaceRouteHierFlow/placer/ILP_solver.h
+++ b/PlaceRouteHierFlow/placer/ILP_solver.h
@@ -34,6 +34,8 @@ using std::string;
 using std::vector;
 
 class ILP_solver {
+  friend class Placer;
+
   private:
   struct Block {
     int x = 0, y = 0;         // LL of each block

--- a/PlaceRouteHierFlow/placer/Placer.cpp
+++ b/PlaceRouteHierFlow/placer/Placer.cpp
@@ -15,6 +15,13 @@ Placer::Placer(PnRDB::hierNode& node, string opath, int effort, PnRDB::Drc_info&
 }
 
 Placer::Placer(std::vector<PnRDB::hierNode>& nodeVec, string opath, int effort, PnRDB::Drc_info& drcInfo, const PlacerHyperparameters& hyper_in, bool select_in_ILP = false) : hyper(hyper_in) {
+  auto logger = spdlog::default_logger()->clone("placer.Placer");
+
+  if (hyper.use_external_placement_info) {
+    logger->info("Requesting placement from JSON");
+    logger->info(hyper.placement_info_json);
+  }
+
 //#define analytical_placer
   if(hyper.use_analytical_placer)
     PlacementRegularAspectRatio_ILP_Analytical(nodeVec, opath, effort, drcInfo, select_in_ILP);

--- a/PlaceRouteHierFlow/placer/Placer.cpp
+++ b/PlaceRouteHierFlow/placer/Placer.cpp
@@ -18,7 +18,7 @@ Placer::Placer(std::vector<PnRDB::hierNode>& nodeVec, string opath, int effort, 
   auto logger = spdlog::default_logger()->clone("placer.Placer");
   if (hyper.use_external_placement_info) {
     logger->info("Requesting placement from JSON");
-    logger->info(hyper.placement_info_json);
+    //logger->info(hyper.placement_info_json);
     setPlacementInfoFromJson(nodeVec, opath, drcInfo);
   }else{
     if (hyper.use_analytical_placer)
@@ -49,7 +49,8 @@ void Placer::setPlacementInfoFromJson(std::vector<PnRDB::hierNode>& nodeVec, str
       auto& sol = spVec[idx].second;
       auto& sp = spVec[idx].first;
       auto& Blocks = sol.Blocks;
-      for(auto instance:m["instances"]){
+      nodeVec[idx].concrete_name = m["concrete_name"];
+      for (auto instance : m["instances"]) {
         int block_id = nodeVec.back().Block_name_map[instance["instance_name"]];
         int sel = -1;
         for (int i = 0; i < int(nodeVec.back().Blocks[block_id].instance.size());i++){

--- a/PlaceRouteHierFlow/placer/Placer.cpp
+++ b/PlaceRouteHierFlow/placer/Placer.cpp
@@ -16,23 +16,143 @@ Placer::Placer(PnRDB::hierNode& node, string opath, int effort, PnRDB::Drc_info&
 
 Placer::Placer(std::vector<PnRDB::hierNode>& nodeVec, string opath, int effort, PnRDB::Drc_info& drcInfo, const PlacerHyperparameters& hyper_in, bool select_in_ILP = false) : hyper(hyper_in) {
   auto logger = spdlog::default_logger()->clone("placer.Placer");
-
   if (hyper.use_external_placement_info) {
     logger->info("Requesting placement from JSON");
     logger->info(hyper.placement_info_json);
+    setPlacementInfoFromJson(nodeVec, opath, drcInfo);
+  }else{
+    if (hyper.use_analytical_placer)
+      //#define analytical_placer
+      PlacementRegularAspectRatio_ILP_Analytical(nodeVec, opath, effort, drcInfo, select_in_ILP);
+    else
+      PlacementRegularAspectRatio_ILP(nodeVec, opath, effort, drcInfo, select_in_ILP);
   }
-
-//#define analytical_placer
-  if(hyper.use_analytical_placer)
-    PlacementRegularAspectRatio_ILP_Analytical(nodeVec, opath, effort, drcInfo, select_in_ILP);
-  else
-    PlacementRegularAspectRatio_ILP(nodeVec, opath, effort, drcInfo, select_in_ILP);
 }
 
-void Placer::setPlacementInfoFromJson() {
+void Placer::setPlacementInfoFromJson(std::vector<PnRDB::hierNode>& nodeVec, string opath, PnRDB::Drc_info& drcInfo) {
   auto logger = spdlog::default_logger()->clone("placer.Placer.setPlacementInfoFromJson");
-
   logger->info("Calling setPlacementInfoFromJson");
+  json modules = json::parse(hyper.placement_info_json);
+  int nodeSize = nodeVec.size();
+  int mode=0;
+  // Read design netlist and constraints
+  design designData(nodeVec.back());
+  //designData.PrintDesign();
+  // Initialize simulate annealing with initial solution
+  SeqPair curr_sp(designData, size_t(1. * log(hyper.T_MIN/hyper.T_INT)/log(hyper.ALPHA)));
+  //curr_sp.PrintSeqPair();
+  ILP_solver curr_sol(designData);
+  std::vector<std::pair<SeqPair, ILP_solver>> spVec(nodeSize, make_pair(curr_sp, curr_sol));
+  int idx=0;
+  for(auto m:modules) {
+    if(m["abstract_name"]==designData.name){
+      auto& sol = spVec[idx].second;
+      auto& sp = spVec[idx].first;
+      auto& Blocks = sol.Blocks;
+      for(auto instance:m["instances"]){
+        int block_id = nodeVec.back().Block_name_map[instance["instance_name"]];
+        int sel = -1;
+        for (int i = 0; i < int(nodeVec.back().Blocks[block_id].instance.size());i++){
+          if(nodeVec.back().Blocks[block_id].instance[i].lefmaster==instance["concrete_template_name"]){
+            sel = i;
+            break;
+          }
+        }
+        if (sel < 0) logger->error("instance_name: {0} concrete_template_name: {1} not found.", instance["instance_name"], instance["concrete_template_name"]);
+        sp.selected[block_id] = sel;
+        Blocks[block_id].x = 2 * (int)instance["transformation"]["oX"];
+        Blocks[block_id].y = 2 * (int)instance["transformation"]["oY"];
+        if(instance["transformation"]["sX"] == -1){
+          Blocks[block_id].H_flip = 1;
+          Blocks[block_id].x -= nodeVec.back().Blocks[block_id].instance[sel].width;
+        }
+        if(instance["transformation"]["sY"] == -1){
+          Blocks[block_id].V_flip = 1;
+          Blocks[block_id].y -= nodeVec.back().Blocks[block_id].instance[sel].height;
+        }
+      }
+      sol.LL.x = INT_MAX, sol.LL.y = INT_MAX;
+      sol.UR.x = INT_MIN, sol.UR.y = INT_MIN;
+      for (int i = 0; i < designData.Blocks.size(); i++) {
+        sol.LL.x = std::min(sol.LL.x, Blocks[i].x);
+        sol.LL.y = std::min(sol.LL.y, Blocks[i].y);
+        sol.UR.x = std::max(sol.UR.x, Blocks[i].x + nodeVec.back().Blocks[i].instance[sp.selected[i]].width);
+        sol.UR.y = std::max(sol.UR.y, Blocks[i].y + nodeVec.back().Blocks[i].instance[sp.selected[i]].height);
+      }
+      sol.area = double(sol.UR.x - sol.LL.x) * double(sol.UR.y - sol.LL.y);
+      sol.area_norm = sol.area * 0.1 / designData.GetMaxBlockAreaSum();
+      sol.ratio = double(sol.UR.x - sol.LL.x) / double(sol.UR.y - sol.LL.y);
+      sol.HPWL = 0;
+      sol.HPWL_extend = 0;
+      sol.HPWL_extend_terminal = 0;
+      for (auto neti : designData.Nets) {
+        int HPWL_min_x = sol.UR.x, HPWL_min_y = sol.UR.y, HPWL_max_x = 0, HPWL_max_y = 0;
+        int HPWL_extend_min_x = sol.UR.x, HPWL_extend_min_y = sol.UR.y, HPWL_extend_max_x = 0, HPWL_extend_max_y = 0;
+        for (auto connectedj : neti.connected) {
+          if (connectedj.type == placerDB::Block) {
+            int iter2 = connectedj.iter2, iter = connectedj.iter;
+            for (auto centerk : designData.Blocks[iter2][sp.selected[iter2]].blockPins[iter].center) {
+              // calculate contact center
+              int pin_x = centerk.x;
+              int pin_y = centerk.y;
+              if (Blocks[iter2].H_flip) pin_x = designData.Blocks[iter2][sp.selected[iter2]].width - pin_x;
+              if (Blocks[iter2].V_flip) pin_y = designData.Blocks[iter2][sp.selected[iter2]].height - pin_y;
+              pin_x += Blocks[iter2].x;
+              pin_y += Blocks[iter2].y;
+              HPWL_min_x = std::min(HPWL_min_x, pin_x);
+              HPWL_max_x = std::max(HPWL_max_x, pin_x);
+              HPWL_min_y = std::min(HPWL_min_y, pin_y);
+              HPWL_max_y = std::max(HPWL_max_y, pin_y);
+            }
+            for (auto boundaryk : designData.Blocks[iter2][sp.selected[iter2]].blockPins[iter].boundary) {
+              int pin_llx = boundaryk.polygon[0].x, pin_urx = boundaryk.polygon[2].x;
+              int pin_lly = boundaryk.polygon[0].y, pin_ury = boundaryk.polygon[2].y;
+              if (Blocks[iter2].H_flip) {
+                pin_llx = designData.Blocks[iter2][sp.selected[iter2]].width - boundaryk.polygon[2].x;
+                pin_urx = designData.Blocks[iter2][sp.selected[iter2]].width - boundaryk.polygon[0].x;
+              }
+              if (Blocks[iter2].V_flip) {
+                pin_lly = designData.Blocks[iter2][sp.selected[iter2]].height - boundaryk.polygon[2].y;
+                pin_ury = designData.Blocks[iter2][sp.selected[iter2]].height - boundaryk.polygon[0].y;
+              }
+              pin_llx += Blocks[iter2].x;
+              pin_urx += Blocks[iter2].x;
+              pin_lly += Blocks[iter2].y;
+              pin_ury += Blocks[iter2].y;
+              HPWL_extend_min_x = std::min(HPWL_extend_min_x, pin_llx);
+              HPWL_extend_max_x = std::max(HPWL_extend_max_x, pin_urx);
+              HPWL_extend_min_y = std::min(HPWL_extend_min_y, pin_lly);
+              HPWL_extend_max_y = std::max(HPWL_extend_max_y, pin_ury);
+            }
+          }
+        }
+        sol.HPWL += (HPWL_max_y - HPWL_min_y) + (HPWL_max_x - HPWL_min_x);
+        sol.HPWL_extend += (HPWL_extend_max_y - HPWL_extend_min_y) + (HPWL_extend_max_x - HPWL_extend_min_x);
+        bool is_terminal_net = false;
+        for (auto c : neti.connected) {
+          if (c.type == placerDB::Terminal) {
+            is_terminal_net = true;
+            break;
+          }
+        }
+        if (is_terminal_net) sol.HPWL_extend_terminal += (HPWL_extend_max_y - HPWL_extend_min_y) + (HPWL_extend_max_x - HPWL_extend_min_x);
+      }
+      if (!designData.Nets.empty()) sol.HPWL_norm = sol.HPWL_extend / designData.GetMaxBlockHPWLSum() / double(designData.Nets.size());
+      sol.cost = sol.CalculateCost(designData, sp);
+      idx++;
+    }
+  }
+  if ((int)spVec.size() < nodeSize) {
+    nodeSize=spVec.size();
+    nodeVec.resize(nodeSize);
+  }
+  idx=0;
+  for(std::vector<std::pair<SeqPair, ILP_solver>>::iterator it=spVec.begin(); it!=spVec.end() and idx<nodeSize; ++it, ++idx) {
+    it->second.updateTerminalCenter(designData, it->first);
+    it->second.WritePlacement(designData, it->first, opath + nodeVec.back().name + "_" + std::to_string(idx) + ".pl");
+    it->second.PlotPlacement(designData, it->first, opath + nodeVec.back().name + "_" + std::to_string(idx) + ".plt");
+    it->second.UpdateHierNode(designData, it->first, nodeVec[idx], drcInfo);
+  }
 }
 
 //PnRDB::hierNode Placer::CheckoutHierNode() {

--- a/PlaceRouteHierFlow/placer/Placer.cpp
+++ b/PlaceRouteHierFlow/placer/Placer.cpp
@@ -22,6 +22,12 @@ Placer::Placer(std::vector<PnRDB::hierNode>& nodeVec, string opath, int effort, 
     PlacementRegularAspectRatio_ILP(nodeVec, opath, effort, drcInfo, select_in_ILP);
 }
 
+void Placer::setPlacementInfoFromJson() {
+  auto logger = spdlog::default_logger()->clone("placer.Placer.setPlacementInfoFromJson");
+
+  logger->info("Calling setPlacementInfoFromJson");
+}
+
 //PnRDB::hierNode Placer::CheckoutHierNode() {
 //  return this->node;
 //}

--- a/PlaceRouteHierFlow/placer/Placer.h
+++ b/PlaceRouteHierFlow/placer/Placer.h
@@ -1,22 +1,26 @@
 #ifndef PLACER_H_
 #define PLACER_H_
 
-#include <thread>
-#include <stdlib.h>     /* srand, rand */
-#include <time.h>       /* time */
+#include <stdlib.h> /* srand, rand */
+#include <time.h>   /* time */
+
 #include <cmath>
-#include "PlacerHyperparameters.h"
-#include "design.h"
+#include <nlohmann/json.hpp>
+#include <thread>
+
+#include "../PnRDB/datatype.h"
 #include "Aplace.h"
-#include "SeqPair.h"
 #include "ConstGraph.h"
 #include "ILP_solver.h"
-#include "../PnRDB/datatype.h"
+#include "PlacerHyperparameters.h"
+#include "SeqPair.h"
+#include "design.h"
 #ifdef PERFORMANCE_DRIVEN
 #include <Python.h>
 #endif
 using std::cout;
 using std::endl;
+using namespace nlohmann;
 
 //#define MAX_TIMEOUT 4300000 //4.3 seconds = 4300000 us
 
@@ -51,7 +55,7 @@ class Placer {
     void PlacementMixAPAspectRatio(std::vector<PnRDB::hierNode>& nodeVec, string opath, int effort, PnRDB::Drc_info& drcInfo);
     void PlacementRegularAspectRatio_ILP(std::vector<PnRDB::hierNode>& nodeVec, string opath, int effort, PnRDB::Drc_info& drcInfo, bool select_in_ILP);
     void PlacementRegularAspectRatio_ILP_Analytical(std::vector<PnRDB::hierNode>& nodeVec, string opath, int effort, PnRDB::Drc_info& drcInfo, bool select_in_ILP);
-    void setPlacementInfoFromJson();
+    void setPlacementInfoFromJson(std::vector<PnRDB::hierNode>& nodeVec, string opath, PnRDB::Drc_info& drcInfo);
     PlacerHyperparameters hyper;
 
 public:

--- a/PlaceRouteHierFlow/placer/Placer.h
+++ b/PlaceRouteHierFlow/placer/Placer.h
@@ -51,10 +51,10 @@ class Placer {
     void PlacementMixAPAspectRatio(std::vector<PnRDB::hierNode>& nodeVec, string opath, int effort, PnRDB::Drc_info& drcInfo);
     void PlacementRegularAspectRatio_ILP(std::vector<PnRDB::hierNode>& nodeVec, string opath, int effort, PnRDB::Drc_info& drcInfo, bool select_in_ILP);
     void PlacementRegularAspectRatio_ILP_Analytical(std::vector<PnRDB::hierNode>& nodeVec, string opath, int effort, PnRDB::Drc_info& drcInfo, bool select_in_ILP);
-
+    void setPlacementInfoFromJson();
     PlacerHyperparameters hyper;
 
-  public:
+public:
     Placer(PnRDB::hierNode& node, string opath, int effort, PnRDB::Drc_info& drcInfo, const PlacerHyperparameters& hyper_in);
     Placer(std::vector<PnRDB::hierNode>& nodeVec, string opath, int effort, PnRDB::Drc_info& drcInfo, const PlacerHyperparameters& hyper_in, bool select_in_ILP);
     //Placer(PnRDB::hierNode& input_node); // Constructor

--- a/PlaceRouteHierFlow/placer/PlacerHyperparameters.h
+++ b/PlaceRouteHierFlow/placer/PlacerHyperparameters.h
@@ -13,6 +13,8 @@ public:
   double LAMBDA = 1.0;
 
   bool use_analytical_placer = false;
+  string placement_info_json_path = "";
+  bool use_external_placement_info = false;
 };
 
 #endif

--- a/PlaceRouteHierFlow/placer/PlacerHyperparameters.h
+++ b/PlaceRouteHierFlow/placer/PlacerHyperparameters.h
@@ -1,6 +1,8 @@
 #ifndef PLACERHYPERPARAMETERS_H_
 #define PLACERHYPERPARAMETERS_H_
 
+#include <string>
+
 class PlacerHyperparameters {
 public:  
   double T_INT = 1e6;
@@ -13,7 +15,7 @@ public:
   double LAMBDA = 1.0;
 
   bool use_analytical_placer = false;
-  std::string placement_info_json_path = "";
+  std::string placement_info_json; // Should be initialized to the empty string
   bool use_external_placement_info = false;
 };
 

--- a/PlaceRouteHierFlow/placer/PlacerHyperparameters.h
+++ b/PlaceRouteHierFlow/placer/PlacerHyperparameters.h
@@ -13,7 +13,7 @@ public:
   double LAMBDA = 1.0;
 
   bool use_analytical_placer = false;
-  string placement_info_json_path = "";
+  std::string placement_info_json_path = "";
   bool use_external_placement_info = false;
 };
 

--- a/PlaceRouteHierFlow/placer/SeqPair.h
+++ b/PlaceRouteHierFlow/placer/SeqPair.h
@@ -75,6 +75,7 @@ class SeqPair
 {
   private:
     friend class ILP_solver;
+    friend class Placer;
     vector<int> posPair;
     vector<int> negPair;
     vector<placerDB::Omark> orient;

--- a/align/pnr/main.py
+++ b/align/pnr/main.py
@@ -19,7 +19,7 @@ from .checkers import gen_viewer_json, gen_transformation
 from ..cell_fabric import gen_gds_json, transformation
 from .write_constraint import PnRConstraintWriter
 from .. import PnR
-from .toplevel import toplevel, toplevel_route_only
+from .toplevel import toplevel
 from ..schema.hacks import VerilogJsonTop, VerilogJsonModule
 
 logger = logging.getLogger(__name__)

--- a/align/pnr/toplevel.py
+++ b/align/pnr/toplevel.py
@@ -545,10 +545,14 @@ def place_and_route(*, DB, opath, fpath, numLayout, effort, adr_mode, PDN_mode, 
                     router_mode, gui, skipGDS, lambda_coeff, scale_factor,
                     reference_placement_verilog_json, nroutings, select_in_ILP, seed, use_analytical_placer):
 
-    for idx in DB.TraverseHierTree():
-        place(DB=DB, opath=opath, fpath=fpath, numLayout=numLayout, effort=effort, idx=idx,
-              lambda_coeff=lambda_coeff, select_in_ILP=select_in_ILP,
-              seed=seed, use_analytical_placer=use_analytical_placer)
+    if reference_placement_verilog_json:
+        with open(reference_placement_verilog_json, "rt") as fp:
+            DB.setPlacementInfoFromJson( fp.read())
+    else:
+        for idx in DB.TraverseHierTree():
+            place(DB=DB, opath=opath, fpath=fpath, numLayout=numLayout, effort=effort, idx=idx,
+                  lambda_coeff=lambda_coeff, select_in_ILP=select_in_ILP,
+                  seed=seed, use_analytical_placer=use_analytical_placer)
 
     placements_to_run = None
     if verilog_d is not None:

--- a/examples/cascode_current_mirror_ota/CASCODE_CURRENT_MIRROR_OTA_0.scaled_placement_verilog.json
+++ b/examples/cascode_current_mirror_ota/CASCODE_CURRENT_MIRROR_OTA_0.scaled_placement_verilog.json
@@ -1,0 +1,1107 @@
+{
+  "global_signals": [
+    {
+      "actual": "VSS",
+      "formal": "supply0",
+      "prefix": "global_power"
+    },
+    {
+      "actual": "VDD",
+      "formal": "supply1",
+      "prefix": "global_power"
+    }
+  ],
+  "leaves": [
+    {
+      "abstract_name": "NMOS_NFIN3_NF1_M1_N12_X1_Y1_RVT",
+      "bbox": [
+        0,
+        0,
+        640,
+        2352
+      ],
+      "concrete_name": "NMOS_NFIN3_NF1_M1_N12_X1_Y1_RVT",
+      "terminals": [
+        {
+          "name": "B",
+          "rect": [
+            124,
+            1748,
+            356,
+            1780
+          ]
+        },
+        {
+          "name": "D",
+          "rect": [
+            124,
+            152,
+            356,
+            184
+          ]
+        },
+        {
+          "name": "G",
+          "rect": [
+            124,
+            908,
+            356,
+            940
+          ]
+        },
+        {
+          "name": "S",
+          "rect": [
+            204,
+            68,
+            436,
+            100
+          ]
+        }
+      ]
+    },
+    {
+      "abstract_name": "NMOS_NFIN5_NF1_M1_N12_X1_Y1_RVT",
+      "bbox": [
+        0,
+        0,
+        640,
+        2352
+      ],
+      "concrete_name": "NMOS_NFIN5_NF1_M1_N12_X1_Y1_RVT",
+      "terminals": [
+        {
+          "name": "B",
+          "rect": [
+            124,
+            1748,
+            356,
+            1780
+          ]
+        },
+        {
+          "name": "D",
+          "rect": [
+            124,
+            152,
+            356,
+            184
+          ]
+        },
+        {
+          "name": "G",
+          "rect": [
+            124,
+            908,
+            356,
+            940
+          ]
+        },
+        {
+          "name": "S",
+          "rect": [
+            204,
+            68,
+            436,
+            100
+          ]
+        }
+      ]
+    },
+    {
+      "abstract_name": "PMOS_NFIN5_NF1_M1_N12_X1_Y1_RVT",
+      "bbox": [
+        0,
+        0,
+        640,
+        2352
+      ],
+      "concrete_name": "PMOS_NFIN5_NF1_M1_N12_X1_Y1_RVT",
+      "terminals": [
+        {
+          "name": "B",
+          "rect": [
+            124,
+            1748,
+            356,
+            1780
+          ]
+        },
+        {
+          "name": "D",
+          "rect": [
+            124,
+            152,
+            356,
+            184
+          ]
+        },
+        {
+          "name": "G",
+          "rect": [
+            124,
+            908,
+            356,
+            940
+          ]
+        },
+        {
+          "name": "S",
+          "rect": [
+            204,
+            68,
+            436,
+            100
+          ]
+        }
+      ]
+    },
+    {
+      "abstract_name": "PMOS_NFIN120_NF1_M1_N12_X5_Y2_RVT",
+      "bbox": [
+        0,
+        0,
+        1280,
+        3528
+      ],
+      "concrete_name": "PMOS_NFIN120_NF1_M1_N12_X5_Y2_RVT",
+      "terminals": [
+        {
+          "name": "B",
+          "rect": [
+            284,
+            2924,
+            996,
+            2956
+          ]
+        },
+        {
+          "name": "D",
+          "rect": [
+            460,
+            132,
+            500,
+            1380
+          ]
+        },
+        {
+          "name": "G",
+          "rect": [
+            540,
+            888,
+            580,
+            2136
+          ]
+        },
+        {
+          "name": "S",
+          "rect": [
+            380,
+            48,
+            420,
+            1296
+          ]
+        }
+      ]
+    },
+    {
+      "abstract_name": "PMOS_NFIN60_NF1_M1_N12_X5_Y1_RVT",
+      "bbox": [
+        0,
+        0,
+        1280,
+        2352
+      ],
+      "concrete_name": "PMOS_NFIN60_NF1_M1_N12_X5_Y1_RVT",
+      "terminals": [
+        {
+          "name": "B",
+          "rect": [
+            284,
+            1748,
+            996,
+            1780
+          ]
+        },
+        {
+          "name": "D",
+          "rect": [
+            284,
+            152,
+            996,
+            184
+          ]
+        },
+        {
+          "name": "G",
+          "rect": [
+            284,
+            908,
+            996,
+            940
+          ]
+        },
+        {
+          "name": "S",
+          "rect": [
+            204,
+            68,
+            1076,
+            100
+          ]
+        }
+      ]
+    },
+    {
+      "abstract_name": "PMOS_NFIN10_NF1_M1_N12_X1_Y1_RVT",
+      "bbox": [
+        0,
+        0,
+        640,
+        2352
+      ],
+      "concrete_name": "PMOS_NFIN10_NF1_M1_N12_X1_Y1_RVT",
+      "terminals": [
+        {
+          "name": "B",
+          "rect": [
+            124,
+            1748,
+            356,
+            1780
+          ]
+        },
+        {
+          "name": "D",
+          "rect": [
+            124,
+            152,
+            356,
+            184
+          ]
+        },
+        {
+          "name": "G",
+          "rect": [
+            124,
+            908,
+            356,
+            940
+          ]
+        },
+        {
+          "name": "S",
+          "rect": [
+            204,
+            68,
+            436,
+            100
+          ]
+        }
+      ]
+    },
+    {
+      "abstract_name": "CMC_NMOS_NFIN30_NF1_M1_N12_X3_Y1_RVT",
+      "bbox": [
+        0,
+        0,
+        1440,
+        2352
+      ],
+      "concrete_name": "CMC_NMOS_NFIN30_NF1_M1_N12_X3_Y1_RVT",
+      "terminals": [
+        {
+          "name": "DA",
+          "rect": [
+            284,
+            152,
+            996,
+            184
+          ]
+        },
+        {
+          "name": "DB",
+          "rect": [
+            444,
+            236,
+            1156,
+            268
+          ]
+        },
+        {
+          "name": "G",
+          "rect": [
+            284,
+            908,
+            1156,
+            940
+          ]
+        },
+        {
+          "name": "S",
+          "rect": [
+            460,
+            48,
+            500,
+            1800
+          ]
+        }
+      ]
+    },
+    {
+      "abstract_name": "CMC_S_NMOS_B_NFIN24_NF1_M1_N12_X2_Y1_RVT",
+      "bbox": [
+        0,
+        0,
+        2560,
+        2352
+      ],
+      "concrete_name": "CMC_S_NMOS_B_NFIN24_NF1_M1_N12_X2_Y1_RVT",
+      "terminals": [
+        {
+          "name": "B",
+          "rect": [
+            284,
+            1748,
+            2276,
+            1780
+          ]
+        },
+        {
+          "name": "DA",
+          "rect": [
+            284,
+            152,
+            2276,
+            184
+          ]
+        },
+        {
+          "name": "DB",
+          "rect": [
+            924,
+            320,
+            1636,
+            352
+          ]
+        },
+        {
+          "name": "G",
+          "rect": [
+            284,
+            908,
+            2276,
+            940
+          ]
+        },
+        {
+          "name": "SA",
+          "rect": [
+            204,
+            68,
+            2356,
+            100
+          ]
+        },
+        {
+          "name": "SB",
+          "rect": [
+            844,
+            236,
+            1716,
+            268
+          ]
+        }
+      ]
+    },
+    {
+      "abstract_name": "SCM_NMOS_NFIN15_NF1_M1_N12_X2_Y1_RVT",
+      "bbox": [
+        0,
+        0,
+        1120,
+        2352
+      ],
+      "concrete_name": "SCM_NMOS_NFIN15_NF1_M1_N12_X2_Y1_RVT",
+      "terminals": [
+        {
+          "name": "DA",
+          "rect": [
+            380,
+            132,
+            420,
+            960
+          ]
+        },
+        {
+          "name": "DB",
+          "rect": [
+            444,
+            236,
+            676,
+            268
+          ]
+        },
+        {
+          "name": "S",
+          "rect": [
+            300,
+            48,
+            340,
+            1800
+          ]
+        }
+      ]
+    },
+    {
+      "abstract_name": "DP_NMOS_B_NFIN30_NF1_M1_N12_X3_Y1_RVT",
+      "bbox": [
+        0,
+        0,
+        1440,
+        2352
+      ],
+      "concrete_name": "DP_NMOS_B_NFIN30_NF1_M1_N12_X3_Y1_RVT",
+      "terminals": [
+        {
+          "name": "B",
+          "rect": [
+            284,
+            1748,
+            1156,
+            1780
+          ]
+        },
+        {
+          "name": "DA",
+          "rect": [
+            284,
+            152,
+            996,
+            184
+          ]
+        },
+        {
+          "name": "DB",
+          "rect": [
+            444,
+            236,
+            1156,
+            268
+          ]
+        },
+        {
+          "name": "GA",
+          "rect": [
+            284,
+            908,
+            996,
+            940
+          ]
+        },
+        {
+          "name": "GB",
+          "rect": [
+            444,
+            992,
+            1156,
+            1024
+          ]
+        },
+        {
+          "name": "S",
+          "rect": [
+            204,
+            68,
+            1236,
+            100
+          ]
+        }
+      ]
+    }
+  ],
+  "modules": [
+    {
+      "abstract_name": "CASCODE_CURRENT_MIRROR_OTA",
+      "bbox": [
+        0,
+        0,
+        5840,
+        9408
+      ],
+      "concrete_name": "CASCODE_CURRENT_MIRROR_OTA_0",
+      "constraints": [
+        {
+          "constraint": "power_ports",
+          "ports": [
+            "VDD"
+          ]
+        },
+        {
+          "constraint": "ground_ports",
+          "ports": [
+            "VSS"
+          ]
+        },
+        {
+          "constraint": "do_not_use_lib",
+          "libraries": [
+            "CASCODED_SCM_NMOS",
+            "CASCODED_SCM_PMOS"
+          ],
+          "propagate": null
+        },
+        {
+          "constraint": "symmetric_blocks",
+          "direction": "V",
+          "pairs": [
+            [
+              "X_CASCODED_CMC_PMOS_M20_M21_M22_M26",
+              "X_CASCODED_CMC_PMOS_M18_M19_M23_M27"
+            ],
+            [
+              "X_DP_NMOS_B_M15_M17"
+            ]
+          ]
+        },
+        {
+          "constraint": "symmetric_nets",
+          "direction": "V",
+          "net1": "NET16",
+          "net2": "NET27",
+          "pins1": [
+            "X_CASCODED_CMC_PMOS_M20_M21_M22_M26/DB",
+            "X_DP_NMOS_B_M15_M17/DA"
+          ],
+          "pins2": [
+            "X_CASCODED_CMC_PMOS_M18_M19_M23_M27/DB",
+            "X_DP_NMOS_B_M15_M17/DB"
+          ]
+        },
+        {
+          "constraint": "symmetric_nets",
+          "direction": "V",
+          "net1": "VINN",
+          "net2": "VINP",
+          "pins1": [
+            "X_DP_NMOS_B_M15_M17/GA",
+            "VINN"
+          ],
+          "pins2": [
+            "X_DP_NMOS_B_M15_M17/GB",
+            "VINP"
+          ]
+        }
+      ],
+      "instances": [
+        {
+          "abstract_template_name": "NMOS_NFIN3_NF1_M1_N12_X1_Y1_RVT",
+          "concrete_template_name": "NMOS_NFIN3_NF1_M1_N12_X1_Y1_RVT",
+          "fa_map": [
+            {
+              "actual": "VSS",
+              "formal": "B"
+            },
+            {
+              "actual": "VBIASN",
+              "formal": "D"
+            },
+            {
+              "actual": "VBIASN",
+              "formal": "G"
+            },
+            {
+              "actual": "NET9B",
+              "formal": "S"
+            }
+          ],
+          "instance_name": "M1NUP",
+          "transformation": {
+            "oX": 2560,
+            "oY": 7056,
+            "sX": 1,
+            "sY": 1
+          }
+        },
+        {
+          "abstract_template_name": "NMOS_NFIN5_NF1_M1_N12_X1_Y1_RVT",
+          "concrete_template_name": "NMOS_NFIN5_NF1_M1_N12_X1_Y1_RVT",
+          "fa_map": [
+            {
+              "actual": "VSS",
+              "formal": "B"
+            },
+            {
+              "actual": "NET9B",
+              "formal": "D"
+            },
+            {
+              "actual": "NET9B",
+              "formal": "G"
+            },
+            {
+              "actual": "VSS",
+              "formal": "S"
+            }
+          ],
+          "instance_name": "M1NDOWN",
+          "transformation": {
+            "oX": 3200,
+            "oY": 7056,
+            "sX": 1,
+            "sY": 1
+          }
+        },
+        {
+          "abstract_template_name": "PMOS_NFIN5_NF1_M1_N12_X1_Y1_RVT",
+          "concrete_template_name": "PMOS_NFIN5_NF1_M1_N12_X1_Y1_RVT",
+          "fa_map": [
+            {
+              "actual": "VDD",
+              "formal": "B"
+            },
+            {
+              "actual": "NET8B",
+              "formal": "D"
+            },
+            {
+              "actual": "NET8B",
+              "formal": "G"
+            },
+            {
+              "actual": "VDD",
+              "formal": "S"
+            }
+          ],
+          "instance_name": "M1PUP",
+          "transformation": {
+            "oX": 640,
+            "oY": 2352,
+            "sX": -1,
+            "sY": 1
+          }
+        },
+        {
+          "abstract_template_name": "PMOS_NFIN5_NF1_M1_N12_X1_Y1_RVT",
+          "concrete_template_name": "PMOS_NFIN5_NF1_M1_N12_X1_Y1_RVT",
+          "fa_map": [
+            {
+              "actual": "VDD",
+              "formal": "B"
+            },
+            {
+              "actual": "VBIASP",
+              "formal": "D"
+            },
+            {
+              "actual": "VBIASP",
+              "formal": "G"
+            },
+            {
+              "actual": "NET8B",
+              "formal": "S"
+            }
+          ],
+          "instance_name": "M1PDOWN",
+          "transformation": {
+            "oX": 640,
+            "oY": 2352,
+            "sX": -1,
+            "sY": -1
+          }
+        },
+        {
+          "abstract_template_name": "CASCODED_CMC_PMOS_PG0",
+          "concrete_template_name": "CASCODED_CMC_PMOS_PG0_0",
+          "fa_map": [
+            {
+              "actual": "VOUTP",
+              "formal": "DA"
+            },
+            {
+              "actual": "NET27",
+              "formal": "DB"
+            },
+            {
+              "actual": "VBIASP",
+              "formal": "GA"
+            }
+          ],
+          "instance_name": "X_CASCODED_CMC_PMOS_M18_M19_M23_M27",
+          "transformation": {
+            "oX": 3280,
+            "oY": 0,
+            "sX": -1,
+            "sY": 1
+          }
+        },
+        {
+          "abstract_template_name": "CASCODED_CMC_PMOS_PG0",
+          "concrete_template_name": "CASCODED_CMC_PMOS_PG0_0",
+          "fa_map": [
+            {
+              "actual": "VBIASND",
+              "formal": "DA"
+            },
+            {
+              "actual": "NET16",
+              "formal": "DB"
+            },
+            {
+              "actual": "VBIASP",
+              "formal": "GA"
+            }
+          ],
+          "instance_name": "X_CASCODED_CMC_PMOS_M20_M21_M22_M26",
+          "transformation": {
+            "oX": 3280,
+            "oY": 0,
+            "sX": 1,
+            "sY": 1
+          }
+        },
+        {
+          "abstract_template_name": "CASCODED_CMC_NMOS_PG0",
+          "concrete_template_name": "CASCODED_CMC_NMOS_PG0_0",
+          "fa_map": [
+            {
+              "actual": "VBIASND",
+              "formal": "DA"
+            },
+            {
+              "actual": "VOUTP",
+              "formal": "DB"
+            },
+            {
+              "actual": "VBIASN",
+              "formal": "GA"
+            }
+          ],
+          "instance_name": "X_CASCODED_CMC_NMOS_M10_M11_M24_M25",
+          "transformation": {
+            "oX": 0,
+            "oY": 4704,
+            "sX": 1,
+            "sY": 1
+          }
+        },
+        {
+          "abstract_template_name": "SCM_NMOS_NFIN15_NF1_M1_N12_X2_Y1_RVT",
+          "concrete_template_name": "SCM_NMOS_NFIN15_NF1_M1_N12_X2_Y1_RVT",
+          "fa_map": [
+            {
+              "actual": "ID",
+              "formal": "DA"
+            },
+            {
+              "actual": "NET24",
+              "formal": "DB"
+            },
+            {
+              "actual": "VSS",
+              "formal": "S"
+            }
+          ],
+          "instance_name": "X_SCM_NMOS_M14_M16",
+          "transformation": {
+            "oX": 4000,
+            "oY": 4704,
+            "sX": 1,
+            "sY": 1
+          }
+        },
+        {
+          "abstract_template_name": "DP_NMOS_B_NFIN30_NF1_M1_N12_X3_Y1_RVT",
+          "concrete_template_name": "DP_NMOS_B_NFIN30_NF1_M1_N12_X3_Y1_RVT",
+          "fa_map": [
+            {
+              "actual": "VSS",
+              "formal": "B"
+            },
+            {
+              "actual": "NET16",
+              "formal": "DA"
+            },
+            {
+              "actual": "NET27",
+              "formal": "DB"
+            },
+            {
+              "actual": "VINN",
+              "formal": "GA"
+            },
+            {
+              "actual": "VINP",
+              "formal": "GB"
+            },
+            {
+              "actual": "NET24",
+              "formal": "S"
+            }
+          ],
+          "instance_name": "X_DP_NMOS_B_M15_M17",
+          "transformation": {
+            "oX": 4000,
+            "oY": 4704,
+            "sX": -1,
+            "sY": 1
+          }
+        }
+      ],
+      "parameters": [
+        "ID",
+        "VBIASN",
+        "VBIASND",
+        "VBIASP",
+        "VINN",
+        "VINP",
+        "VOUTP"
+      ]
+    },
+    {
+      "abstract_name": "CASCODED_CMC_PMOS_PG0",
+      "bbox": [
+        0,
+        0,
+        2560,
+        4704
+      ],
+      "concrete_name": "CASCODED_CMC_PMOS_PG0_0",
+      "constraints": [],
+      "instances": [
+        {
+          "abstract_template_name": "PMOS_NFIN120_NF1_M1_N12_X5_Y2_RVT",
+          "concrete_template_name": "PMOS_NFIN120_NF1_M1_N12_X5_Y2_RVT",
+          "fa_map": [
+            {
+              "actual": "VDD",
+              "formal": "B"
+            },
+            {
+              "actual": "DA",
+              "formal": "D"
+            },
+            {
+              "actual": "GA",
+              "formal": "G"
+            },
+            {
+              "actual": "SA",
+              "formal": "S"
+            }
+          ],
+          "instance_name": "M0",
+          "transformation": {
+            "oX": 1280,
+            "oY": 3528,
+            "sX": 1,
+            "sY": -1
+          }
+        },
+        {
+          "abstract_template_name": "PMOS_NFIN60_NF1_M1_N12_X5_Y1_RVT",
+          "concrete_template_name": "PMOS_NFIN60_NF1_M1_N12_X5_Y1_RVT",
+          "fa_map": [
+            {
+              "actual": "VDD",
+              "formal": "B"
+            },
+            {
+              "actual": "DB",
+              "formal": "D"
+            },
+            {
+              "actual": "GA",
+              "formal": "G"
+            },
+            {
+              "actual": "SB",
+              "formal": "S"
+            }
+          ],
+          "instance_name": "M1",
+          "transformation": {
+            "oX": 0,
+            "oY": 2352,
+            "sX": 1,
+            "sY": -1
+          }
+        },
+        {
+          "abstract_template_name": "PMOS_NFIN10_NF1_M1_N12_X1_Y1_RVT",
+          "concrete_template_name": "PMOS_NFIN10_NF1_M1_N12_X1_Y1_RVT",
+          "fa_map": [
+            {
+              "actual": "VDD",
+              "formal": "B"
+            },
+            {
+              "actual": "SA",
+              "formal": "D"
+            },
+            {
+              "actual": "DB",
+              "formal": "G"
+            },
+            {
+              "actual": "VDD",
+              "formal": "S"
+            }
+          ],
+          "instance_name": "M2",
+          "transformation": {
+            "oX": 1280,
+            "oY": 2352,
+            "sX": -1,
+            "sY": 1
+          }
+        },
+        {
+          "abstract_template_name": "PMOS_NFIN5_NF1_M1_N12_X1_Y1_RVT",
+          "concrete_template_name": "PMOS_NFIN5_NF1_M1_N12_X1_Y1_RVT",
+          "fa_map": [
+            {
+              "actual": "VDD",
+              "formal": "B"
+            },
+            {
+              "actual": "SB",
+              "formal": "D"
+            },
+            {
+              "actual": "DB",
+              "formal": "G"
+            },
+            {
+              "actual": "VDD",
+              "formal": "S"
+            }
+          ],
+          "instance_name": "M3",
+          "transformation": {
+            "oX": 640,
+            "oY": 2352,
+            "sX": -1,
+            "sY": 1
+          }
+        }
+      ],
+      "parameters": [
+        "DA",
+        "GA",
+        "DB"
+      ]
+    },
+    {
+      "abstract_name": "CASCODED_CMC_NMOS_PG0",
+      "bbox": [
+        0,
+        0,
+        2560,
+        4704
+      ],
+      "concrete_name": "CASCODED_CMC_NMOS_PG0_0",
+      "constraints": [
+        {
+          "constraint": "symmetric_blocks",
+          "direction": "V",
+          "pairs": [
+            [
+              "X_CMC_NMOS_M2_M3"
+            ],
+            [
+              "X_CMC_S_NMOS_B_M0_M1"
+            ]
+          ]
+        },
+        {
+          "constraint": "symmetric_nets",
+          "direction": "V",
+          "net1": "SA",
+          "net2": "SB",
+          "pins1": [
+            "X_CMC_NMOS_M2_M3/DA",
+            "X_CMC_S_NMOS_B_M0_M1/SA"
+          ],
+          "pins2": [
+            "X_CMC_NMOS_M2_M3/DB",
+            "X_CMC_S_NMOS_B_M0_M1/SB"
+          ]
+        }
+      ],
+      "instances": [
+        {
+          "abstract_template_name": "CMC_NMOS_NFIN30_NF1_M1_N12_X3_Y1_RVT",
+          "concrete_template_name": "CMC_NMOS_NFIN30_NF1_M1_N12_X3_Y1_RVT",
+          "fa_map": [
+            {
+              "actual": "SA",
+              "formal": "DA"
+            },
+            {
+              "actual": "SB",
+              "formal": "DB"
+            },
+            {
+              "actual": "DA",
+              "formal": "G"
+            },
+            {
+              "actual": "VSS",
+              "formal": "S"
+            }
+          ],
+          "instance_name": "X_CMC_NMOS_M2_M3",
+          "transformation": {
+            "oX": 2000,
+            "oY": 2352,
+            "sX": -1,
+            "sY": -1
+          }
+        },
+        {
+          "abstract_template_name": "CMC_S_NMOS_B_NFIN24_NF1_M1_N12_X2_Y1_RVT",
+          "concrete_template_name": "CMC_S_NMOS_B_NFIN24_NF1_M1_N12_X2_Y1_RVT",
+          "fa_map": [
+            {
+              "actual": "VSS",
+              "formal": "B"
+            },
+            {
+              "actual": "DA",
+              "formal": "DA"
+            },
+            {
+              "actual": "DB",
+              "formal": "DB"
+            },
+            {
+              "actual": "GA",
+              "formal": "G"
+            },
+            {
+              "actual": "SA",
+              "formal": "SA"
+            },
+            {
+              "actual": "SB",
+              "formal": "SB"
+            }
+          ],
+          "instance_name": "X_CMC_S_NMOS_B_M0_M1",
+          "transformation": {
+            "oX": 0,
+            "oY": 2352,
+            "sX": 1,
+            "sY": 1
+          }
+        }
+      ],
+      "parameters": [
+        "DA",
+        "GA",
+        "DB"
+      ]
+    }
+  ]
+}

--- a/examples/five_transistor_ota/FIVE_TRANSISTOR_OTA_0.scaled_placement_verilog.json
+++ b/examples/five_transistor_ota/FIVE_TRANSISTOR_OTA_0.scaled_placement_verilog.json
@@ -1,0 +1,320 @@
+{
+  "global_signals": [
+    {
+      "actual": "VSS",
+      "formal": "supply0",
+      "prefix": "global_power"
+    },
+    {
+      "actual": "VDD",
+      "formal": "supply1",
+      "prefix": "global_power"
+    }
+  ],
+  "leaves": [
+    {
+      "abstract_name": "NMOS_NFIN4_NF2_M8_N12",
+      "bbox": [
+        0,
+        0,
+        1440,
+        2352
+      ],
+      "concrete_name": "NMOS_NFIN4_NF2_M8_N12_X6_Y1",
+      "terminals": [
+        {
+          "name": "B",
+          "rect": [
+            284,
+            1748,
+            1156,
+            1780
+          ]
+        },
+        {
+          "name": "D",
+          "rect": [
+            284,
+            152,
+            1156,
+            184
+          ]
+        },
+        {
+          "name": "G",
+          "rect": [
+            284,
+            908,
+            1156,
+            940
+          ]
+        },
+        {
+          "name": "S",
+          "rect": [
+            204,
+            68,
+            1236,
+            100
+          ]
+        }
+      ]
+    },
+    {
+      "abstract_name": "SCM_PMOS_NFIN4_NF2_M4_N12",
+      "bbox": [
+        0,
+        0,
+        1440,
+        2352
+      ],
+      "concrete_name": "SCM_PMOS_NFIN4_NF2_M4_N12_X3_Y1",
+      "terminals": [
+        {
+          "name": "DA",
+          "rect": [
+            540,
+            132,
+            580,
+            960
+          ]
+        },
+        {
+          "name": "DB",
+          "rect": [
+            444,
+            236,
+            1156,
+            268
+          ]
+        },
+        {
+          "name": "S",
+          "rect": [
+            460,
+            48,
+            500,
+            1800
+          ]
+        }
+      ]
+    },
+    {
+      "abstract_name": "DP_NMOS_B_NFIN4_NF2_M16_N12",
+      "bbox": [
+        0,
+        0,
+        4000,
+        2352
+      ],
+      "concrete_name": "DP_NMOS_B_NFIN4_NF2_M16_N12_X11_Y1",
+      "terminals": [
+        {
+          "name": "B",
+          "rect": [
+            284,
+            1748,
+            3716,
+            1780
+          ]
+        },
+        {
+          "name": "DA",
+          "rect": [
+            284,
+            152,
+            3556,
+            184
+          ]
+        },
+        {
+          "name": "DB",
+          "rect": [
+            444,
+            236,
+            3716,
+            268
+          ]
+        },
+        {
+          "name": "GA",
+          "rect": [
+            284,
+            908,
+            3556,
+            940
+          ]
+        },
+        {
+          "name": "GB",
+          "rect": [
+            444,
+            992,
+            3716,
+            1024
+          ]
+        },
+        {
+          "name": "S",
+          "rect": [
+            204,
+            68,
+            3796,
+            100
+          ]
+        }
+      ]
+    }
+  ],
+  "modules": [
+    {
+      "abstract_name": "FIVE_TRANSISTOR_OTA",
+      "bbox": [
+        0,
+        0,
+        4160,
+        4704
+      ],
+      "concrete_name": "FIVE_TRANSISTOR_OTA_0",
+      "constraints": [
+        {
+          "constraint": "power_ports",
+          "ports": [
+            "VDD"
+          ]
+        },
+        {
+          "constraint": "ground_ports",
+          "ports": [
+            "VSS"
+          ]
+        },
+        {
+          "constraint": "symmetric_blocks",
+          "direction": "V",
+          "pairs": [
+            [
+              "X_DP_NMOS_B_MN2_MN3"
+            ],
+            [
+              "X_SCM_PMOS_MP4_MP5"
+            ]
+          ]
+        },
+        {
+          "constraint": "symmetric_nets",
+          "direction": "V",
+          "net1": "VIN",
+          "net2": "VIP",
+          "pins1": [
+            "X_DP_NMOS_B_MN2_MN3/GA",
+            "VIN"
+          ],
+          "pins2": [
+            "X_DP_NMOS_B_MN2_MN3/GB",
+            "VIP"
+          ]
+        }
+      ],
+      "instances": [
+        {
+          "abstract_template_name": "NMOS_NFIN4_NF2_M8_N12",
+          "concrete_template_name": "NMOS_NFIN4_NF2_M8_N12_X6_Y1",
+          "fa_map": [
+            {
+              "actual": "VSS",
+              "formal": "B"
+            },
+            {
+              "actual": "TAIL",
+              "formal": "D"
+            },
+            {
+              "actual": "VBIAS",
+              "formal": "G"
+            },
+            {
+              "actual": "VSS",
+              "formal": "S"
+            }
+          ],
+          "instance_name": "MN1",
+          "transformation": {
+            "oX": 2720,
+            "oY": 2352,
+            "sX": 1,
+            "sY": -1
+          }
+        },
+        {
+          "abstract_template_name": "SCM_PMOS_NFIN4_NF2_M4_N12",
+          "concrete_template_name": "SCM_PMOS_NFIN4_NF2_M4_N12_X3_Y1",
+          "fa_map": [
+            {
+              "actual": "VOP",
+              "formal": "DA"
+            },
+            {
+              "actual": "VON",
+              "formal": "DB"
+            },
+            {
+              "actual": "VDD",
+              "formal": "S"
+            }
+          ],
+          "instance_name": "X_SCM_PMOS_MP4_MP5",
+          "transformation": {
+            "oX": 2720,
+            "oY": 2352,
+            "sX": -1,
+            "sY": -1
+          }
+        },
+        {
+          "abstract_template_name": "DP_NMOS_B_NFIN4_NF2_M16_N12",
+          "concrete_template_name": "DP_NMOS_B_NFIN4_NF2_M16_N12_X11_Y1",
+          "fa_map": [
+            {
+              "actual": "VSS",
+              "formal": "B"
+            },
+            {
+              "actual": "VON",
+              "formal": "DA"
+            },
+            {
+              "actual": "VOP",
+              "formal": "DB"
+            },
+            {
+              "actual": "VIN",
+              "formal": "GA"
+            },
+            {
+              "actual": "VIP",
+              "formal": "GB"
+            },
+            {
+              "actual": "TAIL",
+              "formal": "S"
+            }
+          ],
+          "instance_name": "X_DP_NMOS_B_MN2_MN3",
+          "transformation": {
+            "oX": 0,
+            "oY": 2352,
+            "sX": 1,
+            "sY": 1
+          }
+        }
+      ],
+      "parameters": [
+        "VBIAS",
+        "VON",
+        "VIN",
+        "VIP"
+      ]
+    }
+  ]
+}

--- a/examples/high_speed_comparator/HIGH_SPEED_COMPARATOR_0.scaled_placement_verilog.json
+++ b/examples/high_speed_comparator/HIGH_SPEED_COMPARATOR_0.scaled_placement_verilog.json
@@ -1,0 +1,1145 @@
+{
+  "global_signals": [
+    {
+      "actual": "VSS",
+      "formal": "supply0",
+      "prefix": "global_power"
+    },
+    {
+      "actual": "VCC",
+      "formal": "supply1",
+      "prefix": "global_power"
+    }
+  ],
+  "leaves": [
+    {
+      "abstract_name": "NMOS_NFIN6_NF2_M8_N12",
+      "bbox": [
+        0,
+        0,
+        1760,
+        2352
+      ],
+      "concrete_name": "NMOS_NFIN6_NF2_M8_N12_X8_Y1",
+      "terminals": [
+        {
+          "name": "B",
+          "rect": [
+            284,
+            1748,
+            1476,
+            1780
+          ]
+        },
+        {
+          "name": "D",
+          "rect": [
+            284,
+            152,
+            1476,
+            184
+          ]
+        },
+        {
+          "name": "G",
+          "rect": [
+            284,
+            908,
+            1476,
+            940
+          ]
+        },
+        {
+          "name": "S",
+          "rect": [
+            204,
+            68,
+            1556,
+            100
+          ]
+        }
+      ]
+    },
+    {
+      "abstract_name": "PMOS_NFIN6_NF2_M1_N12",
+      "bbox": [
+        0,
+        0,
+        640,
+        2352
+      ],
+      "concrete_name": "PMOS_NFIN6_NF2_M1_N12_X1_Y1",
+      "terminals": [
+        {
+          "name": "B",
+          "rect": [
+            124,
+            1748,
+            356,
+            1780
+          ]
+        },
+        {
+          "name": "D",
+          "rect": [
+            124,
+            152,
+            356,
+            184
+          ]
+        },
+        {
+          "name": "G",
+          "rect": [
+            124,
+            908,
+            356,
+            940
+          ]
+        },
+        {
+          "name": "S",
+          "rect": [
+            204,
+            68,
+            436,
+            100
+          ]
+        }
+      ]
+    },
+    {
+      "abstract_name": "DP_NMOS_B_NFIN6_NF2_M16_N12",
+      "bbox": [
+        0,
+        0,
+        3040,
+        3528
+      ],
+      "concrete_name": "DP_NMOS_B_NFIN6_NF2_M16_N12_X8_Y2",
+      "terminals": [
+        {
+          "name": "B",
+          "rect": [
+            284,
+            2924,
+            2756,
+            2956
+          ]
+        },
+        {
+          "name": "DA",
+          "rect": [
+            1260,
+            132,
+            1300,
+            1380
+          ]
+        },
+        {
+          "name": "DB",
+          "rect": [
+            1340,
+            216,
+            1380,
+            1464
+          ]
+        },
+        {
+          "name": "GA",
+          "rect": [
+            1420,
+            888,
+            1460,
+            2136
+          ]
+        },
+        {
+          "name": "GB",
+          "rect": [
+            1500,
+            972,
+            1540,
+            2220
+          ]
+        },
+        {
+          "name": "S",
+          "rect": [
+            1180,
+            48,
+            1220,
+            1296
+          ]
+        }
+      ]
+    },
+    {
+      "abstract_name": "CCP_S_NMOS_B_NFIN6_NF2_M8_N12",
+      "bbox": [
+        0,
+        0,
+        5120,
+        3528
+      ],
+      "concrete_name": "CCP_S_NMOS_B_NFIN6_NF2_M8_N12_X4_Y2",
+      "terminals": [
+        {
+          "name": "B",
+          "rect": [
+            284,
+            2924,
+            4836,
+            2956
+          ]
+        },
+        {
+          "name": "DA",
+          "rect": [
+            2540,
+            216,
+            2580,
+            2136
+          ]
+        },
+        {
+          "name": "DB",
+          "rect": [
+            2620,
+            300,
+            2660,
+            2220
+          ]
+        },
+        {
+          "name": "SA",
+          "rect": [
+            2380,
+            48,
+            2420,
+            1296
+          ]
+        },
+        {
+          "name": "SB",
+          "rect": [
+            2460,
+            132,
+            2500,
+            1380
+          ]
+        }
+      ]
+    },
+    {
+      "abstract_name": "CCP_PMOS_NFIN6_NF2_M4_N12",
+      "bbox": [
+        0,
+        0,
+        1760,
+        2352
+      ],
+      "concrete_name": "CCP_PMOS_NFIN6_NF2_M4_N12_X4_Y1",
+      "terminals": [
+        {
+          "name": "DA",
+          "rect": [
+            700,
+            132,
+            740,
+            960
+          ]
+        },
+        {
+          "name": "DB",
+          "rect": [
+            780,
+            216,
+            820,
+            1044
+          ]
+        },
+        {
+          "name": "S",
+          "rect": [
+            620,
+            48,
+            660,
+            1800
+          ]
+        }
+      ]
+    },
+    {
+      "abstract_name": "NMOS_NFIN6_NF2_M1_N12",
+      "bbox": [
+        0,
+        0,
+        640,
+        2352
+      ],
+      "concrete_name": "NMOS_NFIN6_NF2_M1_N12_X1_Y1",
+      "terminals": [
+        {
+          "name": "B",
+          "rect": [
+            124,
+            1748,
+            356,
+            1780
+          ]
+        },
+        {
+          "name": "D",
+          "rect": [
+            124,
+            152,
+            356,
+            184
+          ]
+        },
+        {
+          "name": "G",
+          "rect": [
+            124,
+            908,
+            356,
+            940
+          ]
+        },
+        {
+          "name": "S",
+          "rect": [
+            204,
+            68,
+            436,
+            100
+          ]
+        }
+      ]
+    }
+  ],
+  "modules": [
+    {
+      "abstract_name": "HIGH_SPEED_COMPARATOR",
+      "bbox": [
+        0,
+        0,
+        5600,
+        11760
+      ],
+      "concrete_name": "HIGH_SPEED_COMPARATOR_0",
+      "constraints": [
+        {
+          "constraint": "power_ports",
+          "ports": [
+            "VCC"
+          ]
+        },
+        {
+          "constraint": "ground_ports",
+          "ports": [
+            "VSS"
+          ]
+        },
+        {
+          "constraint": "clock_ports",
+          "ports": [
+            "clk"
+          ]
+        },
+        {
+          "abs_distance": 0,
+          "constraint": "horizontal_distance"
+        },
+        {
+          "abs_distance": 0,
+          "constraint": "vertical_distance"
+        },
+        {
+          "constraint": "symmetric_blocks",
+          "direction": "V",
+          "pairs": [
+            [
+              "MN0"
+            ],
+            [
+              "X_DP_MN1_MN2"
+            ],
+            [
+              "X_CCN_MN3_MN4"
+            ],
+            [
+              "X_CCP_MP5_MP6"
+            ],
+            [
+              "MP7",
+              "MP8"
+            ],
+            [
+              "MP9",
+              "MP10"
+            ],
+            [
+              "X_INV_N_MP11_MN13",
+              "X_INV_P_MP12_MN14"
+            ]
+          ]
+        },
+        {
+          "abut": false,
+          "constraint": "order",
+          "direction": "top_to_bottom",
+          "instances": [
+            "MN0",
+            "X_DP_MN1_MN2",
+            "X_CCN_MN3_MN4",
+            "X_CCP_MP5_MP6"
+          ]
+        },
+        {
+          "constraint": "align",
+          "instances": [
+            "MP9",
+            "MP7",
+            "X_DP_MN1_MN2",
+            "MP8",
+            "MP10"
+          ],
+          "line": "h_bottom"
+        },
+        {
+          "constraint": "align",
+          "instances": [
+            "X_INV_N_MP11_MN13",
+            "X_CCP_MP5_MP6",
+            "X_INV_P_MP12_MN14"
+          ],
+          "line": "h_bottom"
+        },
+        {
+          "constraint": "do_not_identify",
+          "instances": [
+            "X_CCN_MN3_MN4",
+            "X_CCP_MP5_MP6",
+            "X_DP_MN1_MN2",
+            "X_INV_N_MP11_MN13",
+            "X_INV_P_MP12_MN14",
+            "MN0",
+            "MP10",
+            "MP7",
+            "MP8",
+            "MP9"
+          ]
+        },
+        {
+          "constraint": "symmetric_nets",
+          "direction": "V",
+          "net1": "VIN",
+          "net2": "VIP",
+          "pins1": [
+            "X_DP_MN1_MN2/VIN",
+            "VIN"
+          ],
+          "pins2": [
+            "X_DP_MN1_MN2/VIP",
+            "VIP"
+          ]
+        },
+        {
+          "constraint": "symmetric_nets",
+          "direction": "V",
+          "net1": "VIN_D",
+          "net2": "VIP_D",
+          "pins1": [
+            "MP7/D",
+            "X_DP_MN1_MN2/VIN_D",
+            "X_CCN_MN3_MN4/VIN_D"
+          ],
+          "pins2": [
+            "MP8/D",
+            "X_DP_MN1_MN2/VIP_D",
+            "X_CCN_MN3_MN4/VIP_D"
+          ]
+        },
+        {
+          "constraint": "symmetric_nets",
+          "direction": "V",
+          "net1": "VIN_O",
+          "net2": "VIP_O",
+          "pins1": [
+            "MP9/D",
+            "X_CCN_MN3_MN4/VIN_O",
+            "X_CCP_MP5_MP6/VIN_O"
+          ],
+          "pins2": [
+            "MP10/D",
+            "X_CCN_MN3_MN4/VIP_O",
+            "X_CCP_MP5_MP6/VIP_O"
+          ]
+        },
+        {
+          "constraint": "symmetric_blocks",
+          "direction": "V",
+          "pairs": [
+            [
+              "X_DP_MN1_MN2"
+            ]
+          ]
+        },
+        {
+          "constraint": "symmetric_blocks",
+          "direction": "V",
+          "pairs": [
+            [
+              "MP7",
+              "MP8"
+            ],
+            [
+              "X_CCN_MN3_MN4"
+            ]
+          ]
+        },
+        {
+          "constraint": "symmetric_blocks",
+          "direction": "V",
+          "pairs": [
+            [
+              "MP9",
+              "MP10"
+            ],
+            [
+              "X_CCP_MP5_MP6"
+            ]
+          ]
+        }
+      ],
+      "instances": [
+        {
+          "abstract_template_name": "NMOS_NFIN6_NF2_M8_N12",
+          "concrete_template_name": "NMOS_NFIN6_NF2_M8_N12_X8_Y1",
+          "fa_map": [
+            {
+              "actual": "VSS",
+              "formal": "B"
+            },
+            {
+              "actual": "VCOM",
+              "formal": "D"
+            },
+            {
+              "actual": "CLK",
+              "formal": "G"
+            },
+            {
+              "actual": "VSS",
+              "formal": "S"
+            }
+          ],
+          "instance_name": "MN0",
+          "transformation": {
+            "oX": 1920,
+            "oY": 9408,
+            "sX": 1,
+            "sY": 1
+          }
+        },
+        {
+          "abstract_template_name": "PMOS_NFIN6_NF2_M1_N12",
+          "concrete_template_name": "PMOS_NFIN6_NF2_M1_N12_X1_Y1",
+          "fa_map": [
+            {
+              "actual": "VCC",
+              "formal": "B"
+            },
+            {
+              "actual": "VIN_D",
+              "formal": "D"
+            },
+            {
+              "actual": "CLK",
+              "formal": "G"
+            },
+            {
+              "actual": "VCC",
+              "formal": "S"
+            }
+          ],
+          "instance_name": "MP7",
+          "transformation": {
+            "oX": 4320,
+            "oY": 5880,
+            "sX": 1,
+            "sY": 1
+          }
+        },
+        {
+          "abstract_template_name": "PMOS_NFIN6_NF2_M1_N12",
+          "concrete_template_name": "PMOS_NFIN6_NF2_M1_N12_X1_Y1",
+          "fa_map": [
+            {
+              "actual": "VCC",
+              "formal": "B"
+            },
+            {
+              "actual": "VIP_D",
+              "formal": "D"
+            },
+            {
+              "actual": "CLK",
+              "formal": "G"
+            },
+            {
+              "actual": "VCC",
+              "formal": "S"
+            }
+          ],
+          "instance_name": "MP8",
+          "transformation": {
+            "oX": 1280,
+            "oY": 5880,
+            "sX": -1,
+            "sY": 1
+          }
+        },
+        {
+          "abstract_template_name": "PMOS_NFIN6_NF2_M1_N12",
+          "concrete_template_name": "PMOS_NFIN6_NF2_M1_N12_X1_Y1",
+          "fa_map": [
+            {
+              "actual": "VCC",
+              "formal": "B"
+            },
+            {
+              "actual": "VIN_O",
+              "formal": "D"
+            },
+            {
+              "actual": "CLK",
+              "formal": "G"
+            },
+            {
+              "actual": "VCC",
+              "formal": "S"
+            }
+          ],
+          "instance_name": "MP9",
+          "transformation": {
+            "oX": 4960,
+            "oY": 5880,
+            "sX": 1,
+            "sY": 1
+          }
+        },
+        {
+          "abstract_template_name": "PMOS_NFIN6_NF2_M1_N12",
+          "concrete_template_name": "PMOS_NFIN6_NF2_M1_N12_X1_Y1",
+          "fa_map": [
+            {
+              "actual": "VCC",
+              "formal": "B"
+            },
+            {
+              "actual": "VIP_O",
+              "formal": "D"
+            },
+            {
+              "actual": "CLK",
+              "formal": "G"
+            },
+            {
+              "actual": "VCC",
+              "formal": "S"
+            }
+          ],
+          "instance_name": "MP10",
+          "transformation": {
+            "oX": 640,
+            "oY": 5880,
+            "sX": -1,
+            "sY": 1
+          }
+        },
+        {
+          "abstract_template_name": "DP_PG0",
+          "concrete_template_name": "DP_PG0_0",
+          "fa_map": [
+            {
+              "actual": "VCOM",
+              "formal": "VCOM"
+            },
+            {
+              "actual": "VIN",
+              "formal": "VIN"
+            },
+            {
+              "actual": "VIN_D",
+              "formal": "VIN_D"
+            },
+            {
+              "actual": "VIP",
+              "formal": "VIP"
+            },
+            {
+              "actual": "VIP_D",
+              "formal": "VIP_D"
+            }
+          ],
+          "instance_name": "X_DP_MN1_MN2",
+          "transformation": {
+            "oX": 4320,
+            "oY": 9408,
+            "sX": -1,
+            "sY": -1
+          }
+        },
+        {
+          "abstract_template_name": "CCN_PG0",
+          "concrete_template_name": "CCN_PG0_0",
+          "fa_map": [
+            {
+              "actual": "VIN_D",
+              "formal": "VIN_D"
+            },
+            {
+              "actual": "VIN_O",
+              "formal": "VIN_O"
+            },
+            {
+              "actual": "VIP_D",
+              "formal": "VIP_D"
+            },
+            {
+              "actual": "VIP_O",
+              "formal": "VIP_O"
+            }
+          ],
+          "instance_name": "X_CCN_MN3_MN4",
+          "transformation": {
+            "oX": 5360,
+            "oY": 5880,
+            "sX": -1,
+            "sY": -1
+          }
+        },
+        {
+          "abstract_template_name": "CCP_PG0",
+          "concrete_template_name": "CCP_PG0_0",
+          "fa_map": [
+            {
+              "actual": "VIN_O",
+              "formal": "VIN_O"
+            },
+            {
+              "actual": "VIP_O",
+              "formal": "VIP_O"
+            }
+          ],
+          "instance_name": "X_CCP_MP5_MP6",
+          "transformation": {
+            "oX": 3680,
+            "oY": 2352,
+            "sX": -1,
+            "sY": -1
+          }
+        },
+        {
+          "abstract_template_name": "INV_N_PG0",
+          "concrete_template_name": "INV_N_PG0_0",
+          "fa_map": [
+            {
+              "actual": "VIP_O",
+              "formal": "VIP_O"
+            },
+            {
+              "actual": "VOP",
+              "formal": "VOP"
+            }
+          ],
+          "instance_name": "X_INV_N_MP11_MN13",
+          "transformation": {
+            "oX": 1280,
+            "oY": 2352,
+            "sX": -1,
+            "sY": -1
+          }
+        },
+        {
+          "abstract_template_name": "INV_P_PG0",
+          "concrete_template_name": "INV_P_PG0_0",
+          "fa_map": [
+            {
+              "actual": "VIN_O",
+              "formal": "VIN_O"
+            },
+            {
+              "actual": "VON",
+              "formal": "VON"
+            }
+          ],
+          "instance_name": "X_INV_P_MP12_MN14",
+          "transformation": {
+            "oX": 4320,
+            "oY": 2352,
+            "sX": 1,
+            "sY": -1
+          }
+        }
+      ],
+      "parameters": [
+        "CLK",
+        "VIN",
+        "VIP",
+        "VON",
+        "VOP"
+      ]
+    },
+    {
+      "abstract_name": "DP_PG0",
+      "bbox": [
+        0,
+        0,
+        3040,
+        3528
+      ],
+      "concrete_name": "DP_PG0_0",
+      "constraints": [
+        {
+          "abs_distance": 0,
+          "constraint": "horizontal_distance"
+        },
+        {
+          "abs_distance": 0,
+          "constraint": "vertical_distance"
+        }
+      ],
+      "instances": [
+        {
+          "abstract_template_name": "DP_NMOS_B_NFIN6_NF2_M16_N12",
+          "concrete_template_name": "DP_NMOS_B_NFIN6_NF2_M16_N12_X8_Y2",
+          "fa_map": [
+            {
+              "actual": "VSS",
+              "formal": "B"
+            },
+            {
+              "actual": "VIN_D",
+              "formal": "DA"
+            },
+            {
+              "actual": "VIP_D",
+              "formal": "DB"
+            },
+            {
+              "actual": "VIN",
+              "formal": "GA"
+            },
+            {
+              "actual": "VIP",
+              "formal": "GB"
+            },
+            {
+              "actual": "VCOM",
+              "formal": "S"
+            }
+          ],
+          "instance_name": "X_DP_NMOS_B_MN1_MN2",
+          "transformation": {
+            "oX": 0,
+            "oY": 0,
+            "sX": 1,
+            "sY": 1
+          }
+        }
+      ],
+      "parameters": [
+        "VCOM",
+        "VIP_D",
+        "VIN",
+        "VIP",
+        "VIN_D"
+      ]
+    },
+    {
+      "abstract_name": "CCN_PG0",
+      "bbox": [
+        0,
+        0,
+        5120,
+        3528
+      ],
+      "concrete_name": "CCN_PG0_0",
+      "constraints": [
+        {
+          "abs_distance": 0,
+          "constraint": "horizontal_distance"
+        },
+        {
+          "abs_distance": 0,
+          "constraint": "vertical_distance"
+        }
+      ],
+      "instances": [
+        {
+          "abstract_template_name": "CCP_S_NMOS_B_NFIN6_NF2_M8_N12",
+          "concrete_template_name": "CCP_S_NMOS_B_NFIN6_NF2_M8_N12_X4_Y2",
+          "fa_map": [
+            {
+              "actual": "VSS",
+              "formal": "B"
+            },
+            {
+              "actual": "VIN_O",
+              "formal": "DA"
+            },
+            {
+              "actual": "VIP_O",
+              "formal": "DB"
+            },
+            {
+              "actual": "VIN_D",
+              "formal": "SA"
+            },
+            {
+              "actual": "VIP_D",
+              "formal": "SB"
+            }
+          ],
+          "instance_name": "X_CCP_S_NMOS_B_MN3_MN4",
+          "transformation": {
+            "oX": 0,
+            "oY": 0,
+            "sX": 1,
+            "sY": 1
+          }
+        }
+      ],
+      "parameters": [
+        "VIP_O",
+        "VIP_D",
+        "VIN_D",
+        "VIN_O"
+      ]
+    },
+    {
+      "abstract_name": "CCP_PG0",
+      "bbox": [
+        0,
+        0,
+        1760,
+        2352
+      ],
+      "concrete_name": "CCP_PG0_0",
+      "constraints": [
+        {
+          "abs_distance": 0,
+          "constraint": "horizontal_distance"
+        },
+        {
+          "abs_distance": 0,
+          "constraint": "vertical_distance"
+        }
+      ],
+      "instances": [
+        {
+          "abstract_template_name": "CCP_PMOS_NFIN6_NF2_M4_N12",
+          "concrete_template_name": "CCP_PMOS_NFIN6_NF2_M4_N12_X4_Y1",
+          "fa_map": [
+            {
+              "actual": "VIN_O",
+              "formal": "DA"
+            },
+            {
+              "actual": "VIP_O",
+              "formal": "DB"
+            },
+            {
+              "actual": "VCC",
+              "formal": "S"
+            }
+          ],
+          "instance_name": "X_CCP_PMOS_MP5_MP6",
+          "transformation": {
+            "oX": 0,
+            "oY": 0,
+            "sX": 1,
+            "sY": 1
+          }
+        }
+      ],
+      "parameters": [
+        "VIP_O",
+        "VIN_O"
+      ]
+    },
+    {
+      "abstract_name": "INV_N_PG0",
+      "bbox": [
+        0,
+        0,
+        1280,
+        2352
+      ],
+      "concrete_name": "INV_N_PG0_0",
+      "constraints": [
+        {
+          "abs_distance": 0,
+          "constraint": "horizontal_distance"
+        },
+        {
+          "abs_distance": 0,
+          "constraint": "vertical_distance"
+        }
+      ],
+      "instances": [
+        {
+          "abstract_template_name": "INV_PG0",
+          "concrete_template_name": "INV_PG0_0",
+          "fa_map": [
+            {
+              "actual": "VIP_O",
+              "formal": "I"
+            },
+            {
+              "actual": "VOP",
+              "formal": "ZN"
+            }
+          ],
+          "instance_name": "X_INV_MN13_MP11",
+          "transformation": {
+            "oX": 0,
+            "oY": 0,
+            "sX": 1,
+            "sY": 1
+          }
+        }
+      ],
+      "parameters": [
+        "VOP",
+        "VIP_O"
+      ]
+    },
+    {
+      "abstract_name": "INV_PG0",
+      "bbox": [
+        0,
+        0,
+        1280,
+        2352
+      ],
+      "concrete_name": "INV_PG0_0",
+      "constraints": [],
+      "instances": [
+        {
+          "abstract_template_name": "NMOS_NFIN6_NF2_M1_N12",
+          "concrete_template_name": "NMOS_NFIN6_NF2_M1_N12_X1_Y1",
+          "fa_map": [
+            {
+              "actual": "VSS",
+              "formal": "B"
+            },
+            {
+              "actual": "ZN",
+              "formal": "D"
+            },
+            {
+              "actual": "I",
+              "formal": "G"
+            },
+            {
+              "actual": "VSS",
+              "formal": "S"
+            }
+          ],
+          "instance_name": "M0",
+          "transformation": {
+            "oX": 640,
+            "oY": 0,
+            "sX": 1,
+            "sY": 1
+          }
+        },
+        {
+          "abstract_template_name": "PMOS_NFIN6_NF2_M1_N12",
+          "concrete_template_name": "PMOS_NFIN6_NF2_M1_N12_X1_Y1",
+          "fa_map": [
+            {
+              "actual": "VCC",
+              "formal": "B"
+            },
+            {
+              "actual": "ZN",
+              "formal": "D"
+            },
+            {
+              "actual": "I",
+              "formal": "G"
+            },
+            {
+              "actual": "VCC",
+              "formal": "S"
+            }
+          ],
+          "instance_name": "M1",
+          "transformation": {
+            "oX": 640,
+            "oY": 0,
+            "sX": -1,
+            "sY": 1
+          }
+        }
+      ],
+      "parameters": [
+        "I",
+        "ZN"
+      ]
+    },
+    {
+      "abstract_name": "INV_P_PG0",
+      "bbox": [
+        0,
+        0,
+        1280,
+        2352
+      ],
+      "concrete_name": "INV_P_PG0_0",
+      "constraints": [
+        {
+          "abs_distance": 0,
+          "constraint": "horizontal_distance"
+        },
+        {
+          "abs_distance": 0,
+          "constraint": "vertical_distance"
+        }
+      ],
+      "instances": [
+        {
+          "abstract_template_name": "INV_PG0",
+          "concrete_template_name": "INV_PG0_0",
+          "fa_map": [
+            {
+              "actual": "VIN_O",
+              "formal": "I"
+            },
+            {
+              "actual": "VON",
+              "formal": "ZN"
+            }
+          ],
+          "instance_name": "X_INV_MN14_MP12",
+          "transformation": {
+            "oX": 0,
+            "oY": 0,
+            "sX": 1,
+            "sY": 1
+          }
+        }
+      ],
+      "parameters": [
+        "VON",
+        "VIN_O"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
@854768750 Here is a PR with the stub added.
Please work on the method: `void PnRdatabase::setPlacementInfoFromJson(const string& json_string)`

To test, you can try:
```
export ALIGN_HOME=/path/to/align-public
export ALIGN_WORK_DIR=$ALIGN_HOME/work
mkdir -p $ALIGN_WORK_DIR
cd $ALIGN_WORK_DIR
mkdir five_transistor_ota
cd five_transistor_ota
schematic2layout.py ../../examples/five_transistor_ota --reference_placement_verilog_json `pwd`/../../examples/five_transistor_ota/FIVE_TRANSISTOR_OTA_0.scaled_placement_verilog.json
```
Here, instead of running the placer Python procedure we are running this new C++ method with the example placement verilog json file. 
Let me know if you want this to be different. We can scale the JSON file differently if you want as well. Currently it should be in the units described by scale_factor in the PDK Json file.

It currently crashes because we are not populating the data structures yet.
