### PR TITLE
Generic Solver Interface  + Translate entire subcircuit

### DIFF
--- a/align/compiler/user_const.py
+++ b/align/compiler/user_const.py
@@ -50,7 +50,9 @@ class ConstraintParser:
             json_path = json_path[0]
             logger.debug(f"JSON input const file for block {design_name} {json_path}")
             with types.set_context(node):
-                node.constraints.extend(constraint.ConstraintDB.parse_file(json_path))
+                constraints = constraint.ConstraintDB.parse_file(json_path)
+            with types.set_context(node.constraints):
+                node.constraints.extend(constraints)
             # ALL inst in caps
             for const in node.constraints:
                 if hasattr(const, "instances") and len(const.instances) > 0:

--- a/align/pnr/checker.py
+++ b/align/pnr/checker.py
@@ -27,8 +27,8 @@ def check_placement(placement_verilog_d, scale_factor):
         bbox = transformation.Rect(*module['bbox'])
         with types.set_context(constraints):
             constraints.append(
-                constraint.SetBoundingBox(
-                    instance='subcircuit',
+                constraint.AssignBboxVariables(
+                    bbox_name='subcircuit',
                     llx=bbox.llx/scale_factor,
                     lly=bbox.lly/scale_factor,
                     urx=bbox.urx/scale_factor,
@@ -46,8 +46,8 @@ def check_placement(placement_verilog_d, scale_factor):
             bbox = transformation.Transformation(**t).hitRect(transformation.Rect(*r)).canonical()
             with types.set_context(constraints):
                 constraints.append(
-                    constraint.SetBoundingBox(
-                        instance=inst['instance_name'],
+                    constraint.AssignBboxVariables(
+                        bbox_name=inst['instance_name'],
                         llx=bbox.llx/scale_factor,
                         lly=bbox.lly/scale_factor,
                         urx=bbox.urx/scale_factor,

--- a/align/pnr/checker.py
+++ b/align/pnr/checker.py
@@ -28,12 +28,11 @@ def check_placement(placement_verilog_d, scale_factor):
         with types.set_context(constraints):
             constraints.append(
                 constraint.SetBoundingBox(
-                    instance=module['concrete_name'],
+                    instance='subcircuit',
                     llx=bbox.llx/scale_factor,
                     lly=bbox.lly/scale_factor,
                     urx=bbox.urx/scale_factor,
-                    ury=bbox.ury/scale_factor,
-                    is_subcircuit=True
+                    ury=bbox.ury/scale_factor
                 )
             )
         for inst in module['instances']:

--- a/align/schema/constraint.py
+++ b/align/schema/constraint.py
@@ -366,7 +366,7 @@ class AssignBboxVariables(HardConstraint):
         return value
 
     def translate(self, solver):
-        bvar = solver.bbox_vars(self.instance)
+        bvar = solver.bbox_vars(self.bbox_name)
         yield bvar.llx == self.llx
         yield bvar.lly == self.lly
         yield bvar.urx == self.urx

--- a/align/schema/constraint.py
+++ b/align/schema/constraint.py
@@ -348,8 +348,8 @@ class Spread(HardConstraint):
                 )
 
 
-class SetBoundingBox(HardConstraint):
-    instance: str
+class AssignBboxVariables(HardConstraint):
+    bbox_name: str
     llx: int
     lly: int
     urx: int
@@ -793,7 +793,7 @@ ConstraintType = Union[
     # ALIGN Internal DSL
     Order, Align,
     Enclose, Spread,
-    SetBoundingBox,
+    AssignBboxVariables,
     AspectRatio,
     Boundary,
     # Additional User constraints

--- a/align/schema/hacks.py
+++ b/align/schema/hacks.py
@@ -75,7 +75,7 @@ class VerilogJsonModule(DictEmulator):
 
     def translate(self, solver):
         # Initialize subcircuit bounding box
-        bb = solver.bbox_vars('subckt')
+        bb = solver.bbox_vars('subcircuit')
         yield bb.llx < bb.urx
         yield bb.lly < bb.ury
         # Initialize element bounding boxes

--- a/align/schema/instance.py
+++ b/align/schema/instance.py
@@ -21,6 +21,15 @@ class Instance(types.BaseModel):
             f' {self.model.name} ' + \
             ' '.join(f'{x}={{{y}}}' for x, y in self.parameters.items())
 
+    def translate(self, solver):
+        '''
+        Bounding boxes must have non-zero
+        height & width
+        '''
+        b = solver.bbox_vars(self.name)
+        yield b.llx < b.urx
+        yield b.lly < b.ury
+
     #
     # Private attributes affecting class behavior
     #

--- a/align/schema/subcircuit.py
+++ b/align/schema/subcircuit.py
@@ -1,3 +1,4 @@
+import itertools
 import logging
 from .types import Optional, List, Dict
 
@@ -8,14 +9,19 @@ from .types import set_context
 from .model import Model
 from .instance import Instance
 from .constraint import ConstraintDB
+from . import checker
+
+import logging
+logger = logging.getLogger(__name__)
+
 
 class SubCircuit(Model):
-    name : str                 # Model Name
-    pins : Optional[List[str]] # List of pin names (derived from base if base exists)
-    parameters : Optional[Dict[str, str]]   # Parameter Name: Value mapping (inherits & adds to base if needed)
+    name: str                 # Model Name
+    pins: Optional[List[str]]  # List of pin names (derived from base if base exists)
+    parameters: Optional[Dict[str, str]]   # Parameter Name: Value mapping (inherits & adds to base if needed)
     elements: List[Instance]
     constraints: ConstraintDB
-    prefix : str = 'X'         # Instance name prefix, optional
+    prefix: str = 'X'         # Instance name prefix, optional
 
     @property
     def nets(self):
@@ -26,15 +32,16 @@ class SubCircuit(Model):
 
     def get_element(self, name):
         return next((x for x in self.elements if x.name == name.upper()), None)
-    def update_element(self,name,kwargs):
-        i, inst = next(((i,x) for i,x in enumerate(self.elements) if x.name == name.upper()),None)
+
+    def update_element(self, name, kwargs):
+        i, inst = next(((i, x) for i, x in enumerate(self.elements) if x.name == name.upper()), None)
         with set_context(self.elements):
             new_inst = Instance(name=name,
-                model= (kwargs['model'] if 'model' in kwargs else inst.model),
-                pins= (kwargs['pins'] if 'pins' in kwargs else inst.pins),
-                parameters= (kwargs['parameters'] if 'parameters' in kwargs else inst.parameters),
-                generator= (kwargs['generator'] if 'generator' in kwargs else inst.generator)
-                )
+                                model=(kwargs['model'] if 'model' in kwargs else inst.model),
+                                pins=(kwargs['pins'] if 'pins' in kwargs else inst.pins),
+                                parameters=(kwargs['parameters'] if 'parameters' in kwargs else inst.parameters),
+                                generator=(kwargs['generator'] if 'generator' in kwargs else inst.generator)
+                                )
             self.elements[i] = new_inst
 
     def __init__(self, *args, **kwargs):
@@ -52,8 +59,8 @@ class SubCircuit(Model):
         # process constraints
         with types.set_context(self.constraints):
             self.constraints.extend(constraints)
-    #TODO: Add validator for duplicate name
-    #TODO: Add validator for duplicate pins
+    # TODO: Add validator for duplicate name
+    # TODO: Add validator for duplicate pins
 
     def xyce(self):
         ret = []
@@ -64,6 +71,57 @@ class SubCircuit(Model):
         ret.extend([element.xyce() for element in self.elements])
         ret.append(f'.ENDS {self.name}')
         return '\n'.join(ret)
+
+    def translate(self, solver):
+        # Initialize subcircuit bounding box
+        bb = solver.bbox_vars('subcircuit')
+        yield bb.llx < bb.urx
+        yield bb.lly < bb.ury
+        # Initialize element bounding boxes
+        yield from self.elements.translate(solver)
+        bvars = solver.iter_bbox_vars([x.name for x in self.elements])
+        # Elements must be within subckt bbox
+        for b in bvars:
+            yield b.llx >= bb.llx
+            yield b.lly >= bb.lly
+            yield b.urx <= bb.urx
+            yield b.ury <= bb.ury
+        # Elements may not overlap with each other
+        for b1, b2 in itertools.combinations(bvars, 2):
+            yield solver.Or(
+                b1.urx <= b2.llx,
+                b2.urx <= b1.llx,
+                b1.ury <= b2.lly,
+                b2.ury <= b1.lly,
+            )
+        # Load constraints
+        yield from self.constraints.translate(solver)
+
+    def verify(self, formulae=None):
+        if formulae is None:
+            self._checker = checker.Z3Checker()
+            formulae = self.translate(self._checker)
+        else:
+            assert self._checker is not None, "Incremental verification is not possible as solver hasn't been instantiated yet"
+        for x in formulae:
+            self._checker.append(x)
+        self._check()
+
+    #
+    # Private attribute affecting class behavior
+    #
+    _checker = types.PrivateAttr(None)
+
+    def _check(self):
+        try:
+            self._checker.solve()
+        except checker.SolutionNotFoundError as e:
+            logger.debug(f'Checker raised error:\n {e}')
+            core = [x.json() for x in itertools.chain(self.elements, self.constraints) if self._checker.label(x) in e.labels]
+            logger.error(f'Solution not found due to conflict between:')
+            for x in core:
+                logger.error(f'{x}')
+            raise checker.SolutionNotFoundError(message=e.message, labels=e.labels)
 
 
 class Circuit(SubCircuit):

--- a/align/schema/types.py
+++ b/align/schema/types.py
@@ -198,6 +198,21 @@ class List(pydantic.generics.GenericModel, typing.Generic[DataT]):
             self._revert()
             self.revert(name)
 
+    def _translate_and_annotate(self, item, solver):
+        generator = item.translate(solver)
+        if generator is None:
+            raise NotImplementedError(f'{item}.translate() did not return a valid generator')
+        assert solver is not None
+        formulae = list(generator)
+        if len(formulae) == 0:
+            raise NotImplementedError(f'{item}.translate() yielded an empty list of expressions')
+        yield from solver.annotate(formulae, solver.label(item))
+
+    def translate(self, solver):
+        for item in self:
+            if hasattr(item, 'translate'):
+                yield from self._translate_and_annotate(item, solver)
+
 
 class Dict(pydantic.generics.GenericModel, typing.Generic[KeyT, DataT]):
     __root__: typing.Mapping[KeyT, DataT]

--- a/tests/compiler/test_user_constraint.py
+++ b/tests/compiler/test_user_constraint.py
@@ -4,7 +4,7 @@ import json
 import shutil
 
 from align.compiler.compiler import compiler_input, constraint_generator
-from align.schema.checker import CheckerError
+from align.schema.checker import SolutionNotFoundError
 
 pdk_dir = (
     pathlib.Path(__file__).resolve().parent.parent.parent
@@ -80,7 +80,7 @@ def test_constraint_checking(dir_name):
         / dir_name
         / (circuit_name + ".sp")
     )
-    with pytest.raises(CheckerError):
+    with pytest.raises(SolutionNotFoundError):
         updated_cktlib = compiler_input(test_path, circuit_name, pdk_dir, config_path)
 
 

--- a/tests/compiler/test_writer.py
+++ b/tests/compiler/test_writer.py
@@ -53,7 +53,7 @@ def test_verilog_writer():
             name in available_cell_generator
             or name.split("_type")[0] in available_cell_generator
         ):
-            const = ConstraintDB()
+            pass
         else:
             with set_context(subckt.constraints):
                 subckt.constraints.append(constraint.PowerPorts(ports=['VDD!']))

--- a/tests/pnr/test_write_constraint.py
+++ b/tests/pnr/test_write_constraint.py
@@ -64,8 +64,10 @@ def test_group_block_hsc(results_file, mock_circuit):
     tmp_file = tmp_dir / (name + '.pnr.const.json')
     with types.set_context(mock_circuit):
         constraints = constraint.ConstraintDB.parse_file(constraint_file)
+    with types.set_context(mock_circuit.constraints):
+        mock_circuit.constraints.extend(constraints)
     with open(tmp_file, 'w') as outfile:
-        json.dump(PnRConstraintWriter().map_valid_const(constraints), outfile, indent=4)
+        json.dump(PnRConstraintWriter().map_valid_const(mock_circuit.constraints), outfile, indent=4)
     with open(tmp_file, "r") as const_fp:
         gen_const = json.load(const_fp)["constraints"]
         gen_const.sort(key=lambda item: item.get("const_name"))

--- a/tests/schema/test_checker.py
+++ b/tests/schema/test_checker.py
@@ -1,20 +1,27 @@
 import pytest
-from align.schema.checker import Z3Checker, CheckerError
+from align.schema.checker import Z3Checker, SolutionNotFoundError
+
 
 @pytest.fixture
 def checker():
     return Z3Checker()
 
+
 def test_single_bbox_checking(checker):
     b1 = checker.bbox_vars('M1')
     checker.append(b1.llx < b1.urx)
-    with pytest.raises(CheckerError):
-        checker.append(b1.urx < b1.llx)
+    checker.solve()
+    checker.append(b1.urx < b1.llx)
+    with pytest.raises(SolutionNotFoundError):
+        checker.solve()
+
 
 def test_multi_bbox_checking(checker):
     b1, b2 = checker.iter_bbox_vars(['M1', 'M2'])
     checker.append(b1.llx < b1.urx)
     checker.append(b2.llx < b2.urx)
     checker.append(b2.urx <= b1.llx)
-    with pytest.raises(CheckerError):
-        checker.append(b1.urx <= b1.llx)
+    checker.solve()
+    checker.append(b1.urx <= b1.llx)
+    with pytest.raises(SolutionNotFoundError):
+        checker.solve()

--- a/tests/schema/test_constraint.py
+++ b/tests/schema/test_constraint.py
@@ -1,8 +1,9 @@
 import pytest
 import pathlib
 from align.schema import constraint, Model, Instance, SubCircuit, Library
-from align.schema.checker import CheckerError
+from align.schema.checker import SolutionNotFoundError
 from align.schema.types import set_context
+
 
 @pytest.fixture
 def db():
@@ -14,18 +15,19 @@ def db():
             parameters={'MYPARAMETER': '3'})
         library.append(model)
         subckt = SubCircuit(
-            name = 'SUBCKT',
-            pins = ['PIN1', 'PIN2'],
-            parameters = {'PARAM1':1, 'PARAM2':'1E-3'})
+            name='SUBCKT',
+            pins=['PIN1', 'PIN2'],
+            parameters={'PARAM1': 1, 'PARAM2': '1E-3'})
         library.append(subckt)
     with set_context(subckt.elements):
-        subckt.elements.append(Instance(name='M1', model='TwoTerminalDevice', pins={'A': 'NET1', 'B': 'NET2'},generator='Dummy'))
-        subckt.elements.append(Instance(name='M2', model='TwoTerminalDevice', pins={'A': 'NET2', 'B': 'NET3'},generator='Dummy'))
-        subckt.elements.append(Instance(name='M3', model='TwoTerminalDevice', pins={'A': 'NET1', 'B': 'NET2'},generator='Dummy'))
-        subckt.elements.append(Instance(name='M4', model='TwoTerminalDevice', pins={'A': 'NET2', 'B': 'NET3'},generator='Dummy'))
-        subckt.elements.append(Instance(name='M5', model='TwoTerminalDevice', pins={'A': 'NET1', 'B': 'NET2'},generator='Dummy'))
-        subckt.elements.append(Instance(name='M6', model='TwoTerminalDevice', pins={'A': 'NET2', 'B': 'NET3'},generator='Dummy'))
+        subckt.elements.append(Instance(name='M1', model='TwoTerminalDevice', pins={'A': 'NET1', 'B': 'NET2'}, generator='Dummy'))
+        subckt.elements.append(Instance(name='M2', model='TwoTerminalDevice', pins={'A': 'NET2', 'B': 'NET3'}, generator='Dummy'))
+        subckt.elements.append(Instance(name='M3', model='TwoTerminalDevice', pins={'A': 'NET1', 'B': 'NET2'}, generator='Dummy'))
+        subckt.elements.append(Instance(name='M4', model='TwoTerminalDevice', pins={'A': 'NET2', 'B': 'NET3'}, generator='Dummy'))
+        subckt.elements.append(Instance(name='M5', model='TwoTerminalDevice', pins={'A': 'NET1', 'B': 'NET2'}, generator='Dummy'))
+        subckt.elements.append(Instance(name='M6', model='TwoTerminalDevice', pins={'A': 'NET2', 'B': 'NET3'}, generator='Dummy'))
     return subckt.constraints
+
 
 def test_Order_input_sanitation(db):
     with set_context(db):
@@ -34,10 +36,12 @@ def test_Order_input_sanitation(db):
         with pytest.raises(Exception):
             x = constraint.Order(direction='lefta_to_rightb', instances=['M1', 'M2', 'M3'])
 
+
 def test_Order_constraintname(db):
     with set_context(db):
         x = constraint.Order(direction='left_to_right', instances=['M1', 'M2'])
     assert x.constraint == 'order'
+
 
 def test_Order_nblock_checking(db):
     with set_context(db):
@@ -46,6 +50,7 @@ def test_Order_nblock_checking(db):
         with pytest.raises(Exception):
             x = constraint.Order(direction='left_to_right', instances=['M1'])
 
+
 @pytest.mark.skip(reason='Cannot activate this yet because of ALIGN1.0 annotation issues')
 def test_Order_validate_instances(db):
     with set_context(db):
@@ -53,27 +58,32 @@ def test_Order_validate_instances(db):
             x = constraint.Order(direction='left_to_right', instances=['undefined', 'M2'])
         x = constraint.Order(direction='left_to_right', instances=['M1', 'M2'])
 
+
 def test_ConstraintDB_inputapi(db):
     class Garbage(constraint.HardConstraint):
         test: str = 'hello'
-        def check(self):
+
+        def translate(self):
             pass
     with pytest.raises(Exception):
         db.append(Garbage())
+
 
 def test_Order_smt_checking(db):
     with set_context(db):
         db.append(constraint.Order(direction='left_to_right', instances=['M1', 'M2', 'M3']))
         db.append(constraint.Order(direction='left_to_right', instances=['M4', 'M5']))
-        with pytest.raises(CheckerError):
-                db.append(constraint.Order(direction='left_to_right', instances=['M3', 'M2']))
+        with pytest.raises(SolutionNotFoundError):
+            db.append(constraint.Order(direction='left_to_right', instances=['M3', 'M2']))
+
 
 def test_Order_db_append(db):
     with set_context(db):
         db.append(constraint.Order(direction='left_to_right', instances=['M1', 'M2', 'M3']))
         db.append(constraint.Order(direction='left_to_right', instances=['M4', 'M5']))
-        with pytest.raises(CheckerError):
+        with pytest.raises(SolutionNotFoundError):
             db.append(constraint.Order(direction='left_to_right', instances=['M3', 'M2']))
+
 
 def test_AlignInOrder_input_sanitation():
     with set_context(db):
@@ -82,11 +92,12 @@ def test_AlignInOrder_input_sanitation():
         with pytest.raises(Exception):
             x = constraint.AlignInOrder(instances=['M1', 'M2', 'M3'], line='garbage')
 
+
 def test_AlignInOrder_smt_checking(db):
     with set_context(db):
         db.append(constraint.AlignInOrder(instances=['M1', 'M2', 'M3'], direction='horizontal'))
         db.append(constraint.AlignInOrder(instances=['M4', 'M5'], line='bottom'))
-        with pytest.raises(CheckerError):
+        with pytest.raises(SolutionNotFoundError):
             db.append(constraint.AlignInOrder(instances=['M3', 'M2'], line='bottom'))
 
 
@@ -96,10 +107,11 @@ def test_AspectRatio_input_sanitation(db):
         with pytest.raises(Exception):
             x = constraint.AspectRatio(subcircuit="amplifier", ratio_low=0.6, ratio_high=0.5)
 
+
 def test_AspectRatio_smt_checking(db):
     with set_context(db):
         db.append(constraint.AspectRatio(subcircuit="amplifier", ratio_low=0.1, ratio_high=0.5))
-        with pytest.raises(CheckerError):
+        with pytest.raises(SolutionNotFoundError):
             db.append(constraint.AspectRatio(subcircuit="amplifier", ratio_low=0.6, ratio_high=1.0))
 
 
@@ -114,7 +126,7 @@ def test_ConstraintDB_incremental_checking(db):
         db.append(constraint.Order(direction='left_to_right', instances=['M1', 'M2', 'M3']))
     db.checkpoint()
     # Experiment 2 : Failure
-    with pytest.raises(CheckerError):
+    with pytest.raises(SolutionNotFoundError):
         with set_context(db):
             db.append(constraint.Order(direction='left_to_right', instances=['M3', 'M2']))
     db.revert()
@@ -123,7 +135,7 @@ def test_ConstraintDB_incremental_checking(db):
         db.append(constraint.Order(direction='left_to_right', instances=['M4', 'M5']))
     db.checkpoint()
     # Experiment 4: Failure
-    with pytest.raises(CheckerError):
+    with pytest.raises(SolutionNotFoundError):
         with set_context(db):
             db.append(constraint.Order(direction='left_to_right', instances=['M3', 'M2']))
     db.revert()
@@ -134,6 +146,7 @@ def test_ConstraintDB_incremental_checking(db):
     # constraint.Order(direction='left_to_right', instances=['M1', 'M2', 'M3'])
     # constraint.Order(direction='left_to_right', instances=['M4', 'M5'])
     # constraint.Order(direction='left_to_right', instances=['M2', 'M5'])
+
 
 def test_ConstraintDB_nonincremental_revert(db):
     '''
@@ -156,6 +169,7 @@ def test_ConstraintDB_nonincremental_revert(db):
     if db._checker:
         assert 'M3' not in str(db._checker._solver)
 
+
 def test_ConstraintDB_json(db):
     with set_context(db):
         db.append(constraint.Order(direction='left_to_right', instances=['M1', 'M2']))
@@ -165,6 +179,7 @@ def test_ConstraintDB_json(db):
     with set_context(db.parent):
         newdb = constraint.ConstraintDB.parse_file(fp)
     assert db == newdb
+
 
 def test_ConstraintDB_parent_relationship(db):
     with set_context(db):


### PR DESCRIPTION
This PR takes care of several important upgrades:

- [x] Constraint.check() has been refactored to Constraint.translate() seeing how it yields a list of formulae
- [x] All subcircuit elements are now part of the z3 problem (We previously translated only those bboxes required to explain the constraints)
- [x] SubCircuit.verify() has been implemented to do the actual checking (ConstraintDB has been maintained for backwards compatibility)
- [x] SubCircuit.verify() supports both incremental and non-incremental checking
- [x] Show instance details in error-report upon encountering unsat
- [x] AbstractChecker is now AbstractSolver. translate() must support any AbstractSolver
- [x] Harden GroupBlocks constraint
- [ ] Implement new placement engine using z3 / Scipy