### PR TITLE
DoNotRoute constraint

### DIFF
--- a/align/pnr/checkers.py
+++ b/align/pnr/checkers.py
@@ -297,7 +297,18 @@ def gen_viewer_json( hN, *, pdkdir, draw_grid=False, global_route_json=None, jso
     for inst, parameters in subinsts.items():
         cnv.subinsts[inst].parameters.update(parameters)
 
-    nets_allowed_to_be_open = [] if toplevel else global_power_names
+    nets_dnr = []
+    pnr_const_file = input_dir / 'inputs' / f'{hN.name}.pnr.const.json'
+    if pnr_const_file.is_file():
+        with open(pnr_const_file, 'r') as fp:
+            constraints = json.load(fp)
+            for const in constraints['constraints']:
+                if const['const_name'] == 'DoNotRoute':
+                    nets_dnr.extend(const['nets'])
+
+    nets_allowed_to_be_open = set(nets_dnr)
+    if not toplevel:
+        nets_allowed_to_be_open = set.union(nets_allowed_to_be_open, global_power_names)
 
     new_d = cnv.gen_data(run_drc=True, run_pex=extract,nets_allowed_to_be_open=nets_allowed_to_be_open,postprocess=toplevel)
 

--- a/align/schema/constraint.py
+++ b/align/schema/constraint.py
@@ -33,6 +33,10 @@ def validate_instances(cls, value):
     return [x.upper() for x in value]
 
 
+def upper_case(cls, value):
+    return [v.upper() for v in value]
+
+
 class SoftConstraint(types.BaseModel):
 
     constraint: str
@@ -586,12 +590,16 @@ class PowerPorts(SoftConstraint):
     '''
     ports: List[str]
 
+    _upper_case = types.validator('ports', allow_reuse=True)(upper_case)
+
 
 class GroundPorts(SoftConstraint):
     '''
     Ground port for each hieararchy
     '''
     ports: List[str]
+
+    _upper_case = types.validator('ports', allow_reuse=True)(upper_case)
 
 
 class ClockPorts(SoftConstraint):
@@ -789,6 +797,12 @@ class MultiConnection(SoftConstraint):
     multiplier: int
 
 
+class DoNotRoute(SoftConstraint):
+    nets: List[str]
+
+    _upper_case = types.validator('nets', allow_reuse=True)(upper_case)
+
+
 ConstraintType = Union[
     # ALIGN Internal DSL
     Order, Align,
@@ -816,6 +830,7 @@ ConstraintType = Union[
     PortLocation,
     SymmetricNets,
     MultiConnection,
+    DoNotRoute,
     # Setup constraints
     PowerPorts,
     GroundPorts,

--- a/tests/constraints/test_constraint.py
+++ b/tests/constraints/test_constraint.py
@@ -122,7 +122,7 @@ def test_donotroute():
         {"constraint": "AutoConstraint", "isTrue": False},
         {"constraint": "PowerPorts", "ports": ["vccx"]},
         {"constraint": "GroundPorts", "ports": ["vssx"]},
-        {"constraint": "DoNotRoute", "nets": ["v1", "vccx"]}
+        {"constraint": "DoNotRoute", "nets": ["v1", "vccx", "vssx"]}
         ]
     example = build_example(name, netlist, constraints)
     _, run_dir = run_example(example, cleanup=False)


### PR DESCRIPTION
New constraint to exclude signal, ground and/or power nets from routing:
```python
class DoNotRoute(SoftConstraint):
    nets: List[str]
```
If a power or ground net is not to be routed, router should not construct a grid. 
The constraint is included in *.pnr.const.json file as-is. Please see the test below:
```bash
cd tests/constraints
pytest -k donotroute 
find run_ckt_donotroute/
```