### PR TITLE
Primitive with a missing pin

### DIFF
--- a/align/cell_fabric/gen_lef.py
+++ b/align/cell_fabric/gen_lef.py
@@ -21,6 +21,17 @@ def lef_from_layout_d(layout_d, fp, out_lef, cell_pin, bodyswitch, blockM, *, ex
 
     for i in cell_pin:
         if i == 'B' and bodyswitch==0:continue
+
+        # # Check if there are any rectangles for this pin
+        # pin_found = False
+        # for obj in layout_d['terminals']:
+        #     if obj['netType'] == 'pin' and obj['netName'] == i:
+        #         pin_found = True
+        #         break
+
+        # if not pin_found:
+        #     continue
+
         fp.write("  PIN %s\n" % i)
         #fp.write( "    DIRECTION %s ;\n" % obj[ported'])
         fp.write("    DIRECTION INOUT ;\n")

--- a/align/pdk/finfet/resistor.py
+++ b/align/pdk/finfet/resistor.py
@@ -7,7 +7,6 @@ class tfr_prim(CanvasPDK):
         super().__init__()
         self.metadata = {'instances': []}
 
-
     def generate(self, ports, netlist_parameters=None, layout_parameters=None, *args, **kwargs):
 
         assert len(ports) == 2
@@ -15,8 +14,12 @@ class tfr_prim(CanvasPDK):
         b_idx = (4, -1)
         e_idx = (7, -1)
 
-        self.addWire(self.m2, ports[0], 12, b_idx, e_idx, netType = "pin")
-        self.addWire(self.m2, ports[1], 2, b_idx, e_idx, netType = "pin")
+        p1 = netlist_parameters.get('P1', 'SIG')
+        if p1 == 'SIG':
+            self.addWire(self.m2, ports[0], 12, b_idx, e_idx, netType="pin")
+        p2 = netlist_parameters.get('P2', 'SIG')
+        if p2 == 'SIG':
+            self.addWire(self.m2, ports[1], 2, b_idx, e_idx, netType="pin")
 
         x1 = self.pdk['Poly']['Pitch']*(10)
         y1 = self.pdk['M2']['Pitch']*(14)

--- a/tests/pdk/finfet/test_pinless.py
+++ b/tests/pdk/finfet/test_pinless.py
@@ -22,6 +22,7 @@ def test_pinless():
         .ends {name}
     """)
     constraints = [
+        {"constraint": "AutoConstraint", "isTrue": False},
         {"constraint": "PowerPorts", "ports": ["VCCX"]},
         {"constraint": "GroundPorts", "ports": ["VSSX"]}
         ]

--- a/tests/pdk/finfet/test_pinless.py
+++ b/tests/pdk/finfet/test_pinless.py
@@ -1,0 +1,29 @@
+import pytest
+import textwrap
+import json
+import shutil
+try:
+    from .utils import get_test_id, build_example, run_example, plot_sa_cost, plot_sa_seq
+    from . import circuits
+except BaseException:
+    from utils import get_test_id, build_example, run_example, plot_sa_cost, plot_sa_seq
+    import circuits
+
+cleanup = False
+
+
+def test_pinless():
+    name = f'ckt_{get_test_id()}'
+    setup = textwrap.dedent("""""")
+    netlist = textwrap.dedent(f"""\
+        .subckt {name} vin vop vccx vssx
+        xi0 vccx vop tfr_prim w=1e-6 l=1e-6 p1=pwr
+        mn0 vo vin vssx vssx n w=720e-9 nf=4 m=4
+        .ends {name}
+    """)
+    constraints = [
+        {"constraint": "PowerPorts", "ports": ["VCCX"]},
+        {"constraint": "GroundPorts", "ports": ["VSSX"]}
+        ]
+    example = build_example(name, netlist, setup, constraints)
+    run_example(example, cleanup=cleanup)


### PR DESCRIPTION
If a primitive terminal is connected to backside for power routing, the generated primitive will not have a pin. For example, the first pin of the resistor below is connected to power and the primitive will not have a terminal/rectangle for this pin:
`        xi0 vccx vop tfr_prim w=1e-6 l=1e-6 p1=pwr`

A missing pin throws `MemoryError: std::bad_alloc` error during RouteWork. To reproduce:
```bash
cd tests/pdk/finfet
pytest test_pinless.py -v -s
```