### PR TITLE
Merging Series and Parallel Devices

### DIFF
--- a/align/compiler/preprocess.py
+++ b/align/compiler/preprocess.py
@@ -296,17 +296,17 @@ def add_parallel_devices(ckt, update=True):
             p = {**ele.pins, **ele.parameters}
             p["model"] = ele.model
             if p in pp_list:
-                parallel_devices[pp_list.index(p)].append(node)
+                parallel_devices[pp_list.index(p)].append(ele)
             else:
                 pp_list.append(p)
-                parallel_devices[pp_list.index(p)] = [node]
+                parallel_devices[pp_list.index(p)] = [ele]
         for pd in parallel_devices.values():
             if len(pd) > 1:
-                logger.info(f"removing parallel nodes {pd}")
-                pd0 = sorted(pd)[0]
-                ckt.get_element(pd0).parameters["PARALLEL"] = len(set(pd))
+                pd0 = sorted(pd, key=lambda x: x.name)[0]
+                logger.info(f"removing parallel instances {[x.name for x in pd[1:]]} and updating {pd0.name} parameters")
+                pd0.parameters["PARALLEL"] = sum([getattr(x.parameters, "PARALLEL", 1) for x in pd])
                 for rn in pd[1:]:
-                    G.remove_node(rn)
+                    G.remove(rn)
 
 
 def add_series_devices(ckt, update=True):

--- a/tests/compiler/test_preprocessing.py
+++ b/tests/compiler/test_preprocessing.py
@@ -100,7 +100,10 @@ def test_parallel(db):
     assert db.get_element("C1").parameters == {"VALUE": "2"}
     add_parallel_devices(db, update=True)
     assert db.get_element("C1").parameters == {"VALUE": "2", "PARALLEL": 2}
+    assert db.get_element("C2") is None, 'C2 should have been removed'
     assert db.get_element("R1").parameters == {"VALUE": "10", "PARALLEL": 3}
+    assert db.get_element("R2") is None, 'R2 should have been removed'
+    assert db.get_element("R3") is None, 'R3 should have been removed'
     assert db.get_element("M1").parameters == {
         "PARAM1": "1.0",
         "M": "1",

--- a/tests/compiler/test_preprocessing.py
+++ b/tests/compiler/test_preprocessing.py
@@ -107,6 +107,7 @@ def test_parallel(db):
         "PARAM2": "2",
         "PARALLEL": 2,
     }
+    assert db.get_element("M2") is None, 'Should M2 have been removed from the db as it has been merged to M1?'
 
 
 @pytest.fixture
@@ -241,6 +242,8 @@ def test_series(dbs):
         "STACK": 3,
     }
     assert len(dbs.elements) == 4
+    assert dbs.get_element("M2") is None, 'Should M2 have been removed from the db as it has been merged to M1?'
+    assert dbs.get_element("M5") is None, 'Should M5 have been removed from the db as it has been merged to M3?'
 
 
 @pytest.fixture


### PR DESCRIPTION
To reproduce: `pytest -v tests/compiler/test_preprocessing.py`

@kkunal1408 , should not the merge transistors have been removed from the database? The current implementation removes from the temporary graph but not the database. 