### PR TITLE
Move block restrictions out of .circleci/config.yml

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -131,8 +131,8 @@ jobs:
       pdk:
         description: "Choose PDK (Can be substring as it gets fed to pytest -k argument)"
         type: string
-      design:
-        description: "Choose Design (Can be substring as it gets fed to pytest -k argument)"
+      ci-level:
+        description: "Choose CI level (can be 'checkin', 'merge', and 'all')"
         type: string
       timeout:
         description: "Integer representing pytest --timeout argument"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -226,7 +226,7 @@ workflows:
               ci-level:
                 - "checkin"
               max-errors:
-                - "0"
+                - "3"
       - test-integration:
           name: "test-integration-cp38-<<matrix.pdk>>"
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -141,7 +141,7 @@ jobs:
       nightly-dirs:
         description: "Space separated list of test directories or files"
         type: string
-        default: "test/integration"
+        default: "tests/integration"
       max-errors:
         description: "Maximum allowable errors"
         type: string

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -144,8 +144,8 @@ jobs:
         default: "test/integration"
       max-errors:
         description: "Maximum allowable errors"
-        type: int
-        default: 20
+        type: string
+        default: "20"
 
     docker:
       - image: <<parameters.platform>>
@@ -226,7 +226,7 @@ workflows:
               ci-level:
                 - "checkin"
               max-errors:
-                - 0
+                - "0"
       - test-integration:
           name: "test-integration-cp38-<<matrix.pdk>>"
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -155,14 +155,13 @@ jobs:
       - attach_workspace:
           at: .
       - run:
-          name: "test-integration-<<parameters.platform>>-<<parameters.pdk>>(<<parameters.design>>)"
+          name: "test-integration-<<parameters.platform>>-<<parameters.pdk>>(<<parameters.ci-level>>)"
           no_output_timeout: "<<parameters.timeout>>s"
           command: |
             rm -fr align setup.py
             pip install align[test] -f ./wheelhouse
-            filter="<<parameters.design>>"
-            filter="<<parameters.pdk>>${filter:+ and $filter}"
-            pytest -vv --runnightly --maxerrors=20 --timeout=<<parameters.timeout>> --durations=0 -k "$filter" -- tests/integration tests/pdks
+            filter="<<parameters.pdk>>"
+            CI_LEVEL="<<parameters.ci-level>>" pytest -vv --runnightly --maxerrors=20 --timeout=<<parameters.timeout>> --durations=0 -k "$filter" -- tests/integration tests/pdks
             mkdir -p test-reports/${CIRCLE_BUILD_NUM} && cp -r junit.xml LOG test-reports/${CIRCLE_BUILD_NUM}
       - store_test_results:
           path: test-reports
@@ -216,8 +215,8 @@ workflows:
                 - "python:3.8"
               pdk:
                 - "Finfet"
-              design:
-                - "adder or switched_capacitor_filter or high_speed_comparator"
+              ci-level:
+                - "checkin"
       - test-integration:
           name: "test-integration-cp38-<<matrix.pdk>>"
           requires:
@@ -233,8 +232,8 @@ workflows:
                 - "python:3.8"
               pdk:
                 - "Finfet"
-              design:
-                - "not SAR and not Sanitized_EdgeComparator and not DLL and not single_to_differential_converter and not COMPARATOR_2LEVEL_BIDIRECTIONAL_MAC_SKEW and not CTD and not BUFFER_VREFP and not BUFFER_VREFP2 and not CTDSM_CORE_NEW and not BUFFER_VCM and not vco_dtype_12_hierarchical and not Sanitized_Coarse_Comp_CK and not COMP_GM_STAGE_0415 and not linear_equalizer and not test_vga and not Gm1_v5_Practice and not powertrain_binary and not SW_Cres_v3_5 and not ldo_error_amp and not telescopic_ota_guard_ring"
+              ci-level:
+                - "merge"
       - build-wheel:
           name: "build-wheel-<<matrix.python-tags>>-<<matrix.platform>>"
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -138,6 +138,14 @@ jobs:
         description: "Integer representing pytest --timeout argument"
         type: string
         default: "1800"
+      nightly-dirs:
+        description: "Space separated list of test directories or files"
+        type: string
+        default: "test/integration"
+      max-errors:
+        description: "Maximum allowable errors"
+        type: int
+        default: 20
 
     docker:
       - image: <<parameters.platform>>
@@ -161,7 +169,7 @@ jobs:
             rm -fr align setup.py
             pip install align[test] -f ./wheelhouse
             filter="<<parameters.pdk>>"
-            CI_LEVEL="<<parameters.ci-level>>" pytest -vv --runnightly --maxerrors=20 --timeout=<<parameters.timeout>> --durations=0 -k "$filter" -- tests/integration tests/pdks
+            CI_LEVEL="<<parameters.ci-level>>" pytest -vv --runnightly --maxerrors=<<parameters.max-errors>> --timeout=<<parameters.timeout>> --durations=0 -k "$filter" -- <<parameters.nightly-dirs>>
             mkdir -p test-reports/${CIRCLE_BUILD_NUM} && cp -r junit.xml LOG test-reports/${CIRCLE_BUILD_NUM}
       - store_test_results:
           path: test-reports
@@ -217,6 +225,8 @@ workflows:
                 - "Finfet"
               ci-level:
                 - "checkin"
+              max-errors:
+                - 0
       - test-integration:
           name: "test-integration-cp38-<<matrix.pdk>>"
           requires:
@@ -234,6 +244,8 @@ workflows:
                 - "Finfet"
               ci-level:
                 - "merge"
+              nightly-dirs:
+                - "tests/integration tests/pdks"
       - build-wheel:
           name: "build-wheel-<<matrix.python-tags>>-<<matrix.platform>>"
           requires:

--- a/conftest.py
+++ b/conftest.py
@@ -2,6 +2,7 @@ import pytest
 from align.utils import logmanager
 logmanager.reconfigure_loglevels(console_level='WARNING')
 
+
 def pytest_addoption(parser):
     parser.addoption(
         "--runnightly", action="store_true", default=False, help="run nightly tests"
@@ -19,6 +20,7 @@ def pytest_addoption(parser):
         "--skipGDS", action="store_true", default=False, help="Skip GDS for nightly run (Use with --runnightly)"
     )
 
+
 def pytest_collection_modifyitems(config, items):
     if not config.getoption("--runnightly"):
         skip_nightly = pytest.mark.skip(reason="need --runnightly option to run")
@@ -31,6 +33,7 @@ def pytest_collection_modifyitems(config, items):
             if "regression" in item.keywords:
                 item.add_marker(skip_regression)
 
+
 def pytest_generate_tests(metafunc):
     if "maxerrors" in metafunc.fixturenames:
         maxerrors = metafunc.config.getoption("--maxerrors")
@@ -40,3 +43,6 @@ def pytest_generate_tests(metafunc):
         metafunc.parametrize("router_mode", [router_mode])
     if "skipGDS" in metafunc.fixturenames:
         metafunc.parametrize("skipGDS", [True])
+    if "ci_level" in metafunc.fixturenames:
+        ci_level = metafunc.config.getoption("--ci_level")
+        metafunc.parametrize("ci_level", [ci_level])

--- a/conftest.py
+++ b/conftest.py
@@ -43,6 +43,4 @@ def pytest_generate_tests(metafunc):
         metafunc.parametrize("router_mode", [router_mode])
     if "skipGDS" in metafunc.fixturenames:
         metafunc.parametrize("skipGDS", [True])
-    if "ci_level" in metafunc.fixturenames:
-        ci_level = metafunc.config.getoption("--ci_level")
-        metafunc.parametrize("ci_level", [ci_level])
+

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -28,18 +28,60 @@ skip_dirs = {'Sanitized_model3x_MDLL_TOP',
              'Sanitized_CK_Divider8',
              'mimo_bulk'}
 
+
 ALIGN_HOME = pathlib.Path(__file__).parent.parent.parent
 
-examples_dir = ALIGN_HOME / 'examples'
-examples = [p.parents[0] for p in examples_dir.rglob('*.sp') if all(x not in skip_dirs for x in p.relative_to(examples_dir).parts)]
 pdks = [pdk for pdk in (ALIGN_HOME / 'pdks').iterdir() if pdk.is_dir() and pdk.name not in skip_pdks]
 
 
+def gen_examples():
+    ci_level = os.environ.get('CI_LEVEL', 'all')
+
+    examples_dir = ALIGN_HOME / 'examples'
+    examples = [p.parents[0] for p in examples_dir.rglob('*.sp') if all(x not in skip_dirs for x in p.relative_to(examples_dir).parts)]
+
+    if ci_level == 'merge':
+        circle_ci_skip = "not SAR and not Sanitized_EdgeComparator and not DLL and not single_to_differential_converter and not COMPARATOR_2LEVEL_BIDIRECTIONAL_MAC_SKEW and not CTD and not BUFFER_VREFP and not BUFFER_VREFP2 and not CTDSM_CORE_NEW and not BUFFER_VCM and not vco_dtype_12_hierarchical and not Sanitized_Coarse_Comp_CK and not COMP_GM_STAGE_0415 and not linear_equalizer and not test_vga and not Gm1_v5_Practice and not powertrain_binary and not SW_Cres_v3_5 and not ldo_error_amp and not telescopic_ota_guard_ring"
+        exclude_strings = [nm for nm in circle_ci_skip.split(' ') if nm not in ["and", "or", "not"]]
+
+        additional_skip_dirs = set()
+        for p in examples:
+            s = str(p)
+            if any(x in s for x in exclude_strings):
+                additional_skip_dirs.add(p.stem)
+        print(additional_skip_dirs)
+
+        examples = [p.parents[0]
+            for p in examples_dir.rglob('*.sp')
+                if all(x not in skip_dirs and x not in additional_skip_dirs
+                    for x in p.relative_to(examples_dir).parts)]
+    elif ci_level == 'checkin':
+        circle_ci_dont_skip = "adder or switched_capacitor_filter or high_speed_comparator"
+        include_strings = [nm for nm in circle_ci_dont_skip.split(' ') if nm not in ["or"]]
+        restricted_directories = set()
+        for p in examples:
+            s = str(p)
+            if any(x in s for x in include_strings):
+                restricted_directories.add(p.stem)
+
+        print(restricted_directories)
+        examples = [p.parents[0]
+            for p in examples_dir.rglob('*.sp')
+                if all(x not in skip_dirs for x in p.relative_to(examples_dir).parts)
+                    and any(x in restricted_directories for x in p.relative_to(examples_dir).parts)]
+    elif ci_level == 'all':
+        pass
+    else:
+        assert False, ci_level
+
+    print(examples)
+    return examples
+
+
 @pytest.mark.nightly
-@pytest.mark.parametrize("design_dir", examples, ids=lambda x: x.name)
+@pytest.mark.parametrize("design_dir", gen_examples(), ids=lambda x: x.name)
 @pytest.mark.parametrize("pdk_dir", pdks, ids=lambda x: x.name)
 def test_integration(pdk_dir, design_dir, maxerrors, router_mode, skipGDS):
-
     uid = os.environ.get('PYTEST_CURRENT_TEST')
     uid = uid.split(' ')[0].split(':')[-1].replace('[', '_').replace(']', '').replace('-', '_')
     run_dir = pathlib.Path(os.environ['ALIGN_WORK_DIR']).resolve() / uid


### PR DESCRIPTION
Added an environment variable to set the CI_LEVEL ('checkin', 'merge', 'all')
To run merge level CI from the command line, run:
```
CI_LEVEL=merge pytest --maxerrors 10 -vv --runnightly -- tests/integration tests/pdks
```
This is the checkin level CI command:
```
CI_LEVEL=checkin pytest --maxerrors 10 -vv --runnightly -- tests/integration tests/pdks
```

