### PR TITLE
modifying primitive names in tests/pdks/test_mos.py

### DIFF
--- a/align/primitive/main.py
+++ b/align/primitive/main.py
@@ -17,17 +17,12 @@ logger = logging.getLogger(__name__)
 
 
 def get_xcells_pattern(primitive, pattern, x_cells):
-    if any(primitive.startswith(f'{x}_') for x in ["CM", "CMFB"]):
-        # Dual transistor (current mirror) primitives
-        # TODO: Generalize this (pattern is ignored)
-        x_cells = 2*x_cells + 2
-    elif any(primitive.startswith(f'{x}_') for x in ["SCM", "CMC", "DP", "CCP", "LS"]):
+    if any(primitive.startswith(f'{x}_') for x in ["SCM", "CMC", "DP", "CCP", "LS"]):
         # Dual transistor primitives
         x_cells = 2*x_cells
         # TODO: Fix difficulties associated with CC patterns matching this condition
         pattern = 2 if x_cells % 4 != 0 else pattern  # CC is not possible; default is interdigitated
     return x_cells, pattern
-
 
 def get_parameters(primitive, parameters, nfin):
     if parameters is None:

--- a/tests/pdks/test_mos.py
+++ b/tests/pdks/test_mos.py
@@ -46,10 +46,8 @@ def test_mos_smoke(pdk):
 @pytest.mark.parametrize("nfins", [12], ids=lambda x: f'n{x}')
 @pytest.mark.parametrize("typ", ["NMOS", "PMOS"])
 @pytest.mark.parametrize("pstr", [
-    "Switch_{}",
+    "{}",
     "DCL_{}",
-    "CM_{}",
-    "CMFB_{}",
     "SCM_{}",
     "CMC_{}",
     "DP_{}"],


### PR DESCRIPTION
Primitives CM and CMFB were redundant; we have replaced these with SCM. In this branch we have modified/removed tests related to CM and CMFB