### PR TITLE
Constraints generated despite AutoConst

### DIFF
--- a/tests/pdk/finfet_pdk/test_circuits.py
+++ b/tests/pdk/finfet_pdk/test_circuits.py
@@ -42,7 +42,7 @@ def test_cmp_vanilla_pg():
     run_example(example, cleanup=cleanup)
 
 
-@pytest.mark.skip(reason='This test is failing. Enable in a future PR after refactoring')
+# @pytest.mark.skip(reason='This test is failing. Enable in a future PR after refactoring')
 def test_cmp_noconst():
     name = f'ckt_{get_test_id()}'
     netlist = circuits.comparator(name)
@@ -58,7 +58,7 @@ def test_cmp_noconst():
         modules = {module['name']: module for module in verilog_json['modules']}
         assert name in modules, f'Module {name} not found in verilog.json'
         for module in modules.values():
-            assert len(module['constraints']) == 1, "Constraints generated despise AutoConstraint"
+            assert len(module['constraints']) <= 1, "Constraints generated despise AutoConstraint"
 
     if cleanup:
         shutil.rmtree(run_dir)


### PR DESCRIPTION
To reproduce: `pytest -k cmp_noconst -v -s`

Although this test has the following constraint at top level:
```java
{"constraint": "AutoConstraint", "isTrue": False, "propagate": True}
```

The virtual hierarchy still has constraints:
```java
    {
      "name": "CMC_PMOS_I1",
      "parameters": [
        "DA",
        "DB",
        "G",
        "S"
      ],
      "constraints": [
        {
          "constraint": "symmetric_blocks",
          "pairs": [
            [
              "M1",
              "M2"
            ]
          ],
          "direction": "V"
        },
        {
          "constraint": "symmetric_nets",
          "net1": "DA",
          "net2": "DB",
          "pins1": [
            "M1/D",
            "DA"
          ],
          "pins2": [
            "M2/D",
            "DB"
          ],
          "direction": "V"
        }
      ],

```