### PR TITLE
modifying layers.json to recreate the issue

### DIFF
--- a/PlaceRouteHierFlow/PnRDB/WriteJSON.cpp
+++ b/PlaceRouteHierFlow/PnRDB/WriteJSON.cpp
@@ -13,6 +13,10 @@ static int via2int(const PnRDB::Drc_info& drc_info, const string& via) { return 
 
 static int metal2int(const PnRDB::Drc_info& drc_info, const string& metal) { return stoi(drc_info.MaskID_Metal.at(drc_info.Metalmap.at(metal))); }
 
+static int via2index(const PnRDB::Drc_info& drc_info, const string& via) { return drc_info.Viamap.at(via); }
+
+static int metal2index(const PnRDB::Drc_info& drc_info, const string& metal) { return drc_info.Metalmap.at(metal); }
+
 unsigned short JSON_Presentation(int font, int vp, int hp) {
   if (font < 0 || font > 3) font = 0;
   if (vp < 0 || vp > 2) vp = 0;
@@ -240,7 +244,7 @@ static bool addMetalBoundaries(json& jsonElements, struct PnRDB::Metal& metal, c
     json bound0;
     bound0["type"] = "boundary";
     bound0["layer"] = metal2int(drc_info, metal.MetalRect.metal);
-    bound0["datatype"] = 0;
+    bound0["datatype"] = drc_info.Metal_info.at(metal2index(drc_info, metal.MetalRect.metal)).gds_datatype.Draw;
     json xy = json::array();
     for (size_t i = 0; i < 5; i++) {
       xy.push_back(x[i]);
@@ -259,7 +263,7 @@ static void addContactBoundaries(json& jsonElements, struct PnRDB::contact& Cont
   json bound0;
   bound0["type"] = "boundary";
   bound0["layer"] = metal2int(drc_info, Contact.metal);
-  bound0["datatype"] = 0;
+  bound0["datatype"] = drc_info.Metal_info.at(metal2index(drc_info, Contact.metal)).gds_datatype.Draw;
   json xy = json::array();
   for (size_t i = 0; i < 5; i++) {
     xy.push_back(x[i]);
@@ -333,6 +337,7 @@ static void addViaBoundaries(json& jsonElements, struct PnRDB::Via& via, const P
   json bound0;
   bound0["type"] = "boundary";
   bound0["layer"] = via2int(drc_info, via.ViaRect.metal);
+  bound0["datatype"] = drc_info.Via_info.at(via2index(drc_info, via.ViaRect.metal)).gds_datatype.Draw; 
   bound0["datatype"] = 0;
   json xy = json::array();
   for (size_t i = 0; i < 5; i++) {
@@ -348,7 +353,7 @@ static void addViaBoundaries(json& jsonElements, struct PnRDB::Via& via, const P
   json bound1;
   bound1["type"] = "boundary";
   bound1["layer"] = metal2int(drc_info, via.LowerMetalRect.metal);
-  bound1["datatype"] = 0;
+  bound1["datatype"] = drc_info.Metal_info.at(metal2index(drc_info, via.LowerMetalRect.metal)).gds_datatype.Draw;
   xy = json::array();
   for (size_t i = 0; i < 5; i++) {
     xy.push_back(x[i]);
@@ -363,7 +368,7 @@ static void addViaBoundaries(json& jsonElements, struct PnRDB::Via& via, const P
   json bound2;
   bound2["type"] = "boundary";
   bound2["layer"] = metal2int(drc_info, via.UpperMetalRect.metal);
-  bound2["datatype"] = 0;
+  bound2["datatype"] = drc_info.Metal_info.at(metal2index(drc_info, via.UpperMetalRect.metal)).gds_datatype.Draw;
   xy = json::array();
   for (size_t i = 0; i < 5; i++) {
     xy.push_back(x[i]);

--- a/PlaceRouteHierFlow/PnRDB/WriteJSON.cpp
+++ b/PlaceRouteHierFlow/PnRDB/WriteJSON.cpp
@@ -337,7 +337,7 @@ static void addViaBoundaries(json& jsonElements, struct PnRDB::Via& via, const P
   json bound0;
   bound0["type"] = "boundary";
   bound0["layer"] = via2int(drc_info, via.ViaRect.metal);
-  bound0["datatype"] = drc_info.Via_info.at(via2index(drc_info, via.ViaRect.metal)).gds_datatype.Draw;
+  bound0["datatype"] = drc_info.Via_info.at(via2index(drc_info, via.ViaRect.metal)).gds_datatype.Draw;  
   json xy = json::array();
   for (size_t i = 0; i < 5; i++) {
     xy.push_back(x[i]);

--- a/PlaceRouteHierFlow/PnRDB/WriteJSON.cpp
+++ b/PlaceRouteHierFlow/PnRDB/WriteJSON.cpp
@@ -337,7 +337,8 @@ static void addViaBoundaries(json& jsonElements, struct PnRDB::Via& via, const P
   json bound0;
   bound0["type"] = "boundary";
   bound0["layer"] = via2int(drc_info, via.ViaRect.metal);
-  bound0["datatype"] = drc_info.Via_info.at(via2index(drc_info, via.ViaRect.metal)).gds_datatype.Draw;  
+  //bound0["datatype"] = drc_info.Via_info.at(via2index(drc_info, via.ViaRect.metal)).gds_datatype.Draw;
+  bound0["datatype"] = 0;  
   json xy = json::array();
   for (size_t i = 0; i < 5; i++) {
     xy.push_back(x[i]);
@@ -352,7 +353,8 @@ static void addViaBoundaries(json& jsonElements, struct PnRDB::Via& via, const P
   json bound1;
   bound1["type"] = "boundary";
   bound1["layer"] = metal2int(drc_info, via.LowerMetalRect.metal);
-  bound1["datatype"] = drc_info.Metal_info.at(metal2index(drc_info, via.LowerMetalRect.metal)).gds_datatype.Draw;
+  //bound1["datatype"] = drc_info.Metal_info.at(metal2index(drc_info, via.LowerMetalRect.metal)).gds_datatype.Draw;
+  bound1["datatype"] = 0;
   xy = json::array();
   for (size_t i = 0; i < 5; i++) {
     xy.push_back(x[i]);
@@ -367,7 +369,8 @@ static void addViaBoundaries(json& jsonElements, struct PnRDB::Via& via, const P
   json bound2;
   bound2["type"] = "boundary";
   bound2["layer"] = metal2int(drc_info, via.UpperMetalRect.metal);
-  bound2["datatype"] = drc_info.Metal_info.at(metal2index(drc_info, via.UpperMetalRect.metal)).gds_datatype.Draw;
+  //bound2["datatype"] = drc_info.Metal_info.at(metal2index(drc_info, via.UpperMetalRect.metal)).gds_datatype.Draw;
+  bound2["datatype"] = 0;
   xy = json::array();
   for (size_t i = 0; i < 5; i++) {
     xy.push_back(x[i]);

--- a/PlaceRouteHierFlow/PnRDB/WriteJSON.cpp
+++ b/PlaceRouteHierFlow/PnRDB/WriteJSON.cpp
@@ -337,8 +337,8 @@ static void addViaBoundaries(json& jsonElements, struct PnRDB::Via& via, const P
   json bound0;
   bound0["type"] = "boundary";
   bound0["layer"] = via2int(drc_info, via.ViaRect.metal);
-  //bound0["datatype"] = drc_info.Via_info.at(via2index(drc_info, via.ViaRect.metal)).gds_datatype.Draw;
-  bound0["datatype"] = 0;  
+  bound0["datatype"] = drc_info.Via_info.at(via2index(drc_info, via.ViaRect.metal)).gds_datatype.Draw; 
+  bound0["datatype"] = 0;
   json xy = json::array();
   for (size_t i = 0; i < 5; i++) {
     xy.push_back(x[i]);
@@ -353,8 +353,7 @@ static void addViaBoundaries(json& jsonElements, struct PnRDB::Via& via, const P
   json bound1;
   bound1["type"] = "boundary";
   bound1["layer"] = metal2int(drc_info, via.LowerMetalRect.metal);
-  //bound1["datatype"] = drc_info.Metal_info.at(metal2index(drc_info, via.LowerMetalRect.metal)).gds_datatype.Draw;
-  bound1["datatype"] = 0;
+  bound1["datatype"] = drc_info.Metal_info.at(metal2index(drc_info, via.LowerMetalRect.metal)).gds_datatype.Draw;
   xy = json::array();
   for (size_t i = 0; i < 5; i++) {
     xy.push_back(x[i]);
@@ -369,8 +368,7 @@ static void addViaBoundaries(json& jsonElements, struct PnRDB::Via& via, const P
   json bound2;
   bound2["type"] = "boundary";
   bound2["layer"] = metal2int(drc_info, via.UpperMetalRect.metal);
-  //bound2["datatype"] = drc_info.Metal_info.at(metal2index(drc_info, via.UpperMetalRect.metal)).gds_datatype.Draw;
-  bound2["datatype"] = 0;
+  bound2["datatype"] = drc_info.Metal_info.at(metal2index(drc_info, via.UpperMetalRect.metal)).gds_datatype.Draw;
   xy = json::array();
   for (size_t i = 0; i < 5; i++) {
     xy.push_back(x[i]);

--- a/PlaceRouteHierFlow/PnRDB/WriteJSON.cpp
+++ b/PlaceRouteHierFlow/PnRDB/WriteJSON.cpp
@@ -338,7 +338,6 @@ static void addViaBoundaries(json& jsonElements, struct PnRDB::Via& via, const P
   bound0["type"] = "boundary";
   bound0["layer"] = via2int(drc_info, via.ViaRect.metal);
   bound0["datatype"] = drc_info.Via_info.at(via2index(drc_info, via.ViaRect.metal)).gds_datatype.Draw; 
-  bound0["datatype"] = 0;
   json xy = json::array();
   for (size_t i = 0; i < 5; i++) {
     xy.push_back(x[i]);

--- a/PlaceRouteHierFlow/PnRDB/WriteJSON.cpp
+++ b/PlaceRouteHierFlow/PnRDB/WriteJSON.cpp
@@ -337,8 +337,7 @@ static void addViaBoundaries(json& jsonElements, struct PnRDB::Via& via, const P
   json bound0;
   bound0["type"] = "boundary";
   bound0["layer"] = via2int(drc_info, via.ViaRect.metal);
-  bound0["datatype"] = drc_info.Via_info.at(via2index(drc_info, via.ViaRect.metal)).gds_datatype.Draw; 
-  bound0["datatype"] = 0;
+  bound0["datatype"] = drc_info.Via_info.at(via2index(drc_info, via.ViaRect.metal)).gds_datatype.Draw;
   json xy = json::array();
   for (size_t i = 0; i < 5; i++) {
     xy.push_back(x[i]);

--- a/pdks/FinFET14nm_Mock_PDK/layers.json
+++ b/pdks/FinFET14nm_Mock_PDK/layers.json
@@ -203,7 +203,7 @@
             "Layer": "M3",
             "GdsLayerNo": 19,
             "GdsDatatype": {
-                "Draw": 0,
+                "Draw": 20,
                 "c1": 1,
                 "c2": 2,
                 "Pin": 3,
@@ -241,7 +241,7 @@
             "Layer": "V2",
             "GdsLayerNo": 16,
             "GdsDatatype": {
-                "Draw": 0
+                "Draw": 20
             },
             "Stack": [
                 "M2",


### PR DESCRIPTION
PnR assumes "GdsDatatype" equal to 0 for drawing metal layers and Vias (PnR does not take the values for layers.json). This result in missing layer issues when we import the layouts in Virtuoso.