### PR TITLE
Fix PlaceOnGrid constraint generation in align/pdk/finfet

### DIFF
--- a/align/pdk/finfet/transistor_array.py
+++ b/align/pdk/finfet/transistor_array.py
@@ -21,16 +21,20 @@ class MOSGenerator(CanvasPDK):
 
     def addPMOSArray(self, x_cells, y_cells, pattern, vt_type, ports, **parameters):
         self.mos_array_temporary_wrapper(x_cells, y_cells, pattern, vt_type, ports, **parameters)
-        if os.getenv('PLACE_ON_GRID', False):
-            rh = 7*self.pdk['M2']['Pitch']
-            if parameters['real_inst_type'].lower().startswith('n'):
-                o = 0
-            else:
-                o = rh
-            self.metadata = {'constraints': [PlaceOnGrid(direction='H', pitch=2*rh,
-                                                         ored_terms=[OffsetsScalings(offsets=[o], scalings=[1, -1])]).dict()]}
 
     def mos_array_temporary_wrapper(self, x_cells, y_cells, pattern, vt_type, ports, **parameters):
+
+        if os.getenv('PLACE_ON_GRID', False):
+            rh = 7*self.pdk['M2']['Pitch']
+            if False:
+                if parameters['real_inst_type'].lower().startswith('n'):
+                    o = 0
+                else:
+                    o = rh
+            else:
+                o = 0
+            self.metadata = {'constraints': [PlaceOnGrid(direction='H', pitch=2*rh,
+                                                         ored_terms=[OffsetsScalings(offsets=[o], scalings=[1, -1])]).dict()]}
 
         logger_func(f'x_cells={x_cells}, y_cells={y_cells}, pattern={pattern}, ports={ports}, parameters={parameters}')
 

--- a/tests/pdk/finfet_pdk/test_placement_grid.py
+++ b/tests/pdk/finfet_pdk/test_placement_grid.py
@@ -1,5 +1,6 @@
 import os
 import json
+import shutil
 import textwrap
 from .utils import get_test_id, build_example, run_example
 from . import circuits
@@ -68,3 +69,28 @@ def test_hierarchy():
     ]
     example = build_example(name, netlist, constraints)
     run_example(example, cleanup=False)
+
+
+def test_check_constraints():
+    os.environ['PLACE_ON_GRID'] = 't'
+    name = f'ckt_{get_test_id()}'
+    netlist = textwrap.dedent(f"""\
+        .subckt {name} vi vo vbp vccx vssx
+        mp0 vo vbp vccx vccx p w=720e-9 nf=4 m=4
+        mn0 vo vi vssx vssx n w=720e-9 nf=4 m=4
+        .ends {name}
+    """)
+    constraints = []
+    example = build_example(name, netlist, constraints)
+    ckt_dir, run_dir = run_example(example, n=1, cleanup=False, additional_args=['--flow_stop', '2_primitives'])
+    name = name.upper()
+    primitives_folder = run_dir / '2_primitives'
+    for dev in ['NMOS', 'PMOS']:
+        mos = [f for f in primitives_folder.glob(f'{dev}*[0-9].json')][0]
+        with (mos).open('rt') as fp:
+            data = json.load(fp)
+            assert "metadata" in data
+            assert "constraints" in data["metadata"]
+            assert data["metadata"]["constraints"][0]["constraint"] == "place_on_grid"
+    shutil.rmtree(run_dir)
+    shutil.rmtree(ckt_dir)

--- a/tests/pdk/finfet_pdk/test_placement_grid.py
+++ b/tests/pdk/finfet_pdk/test_placement_grid.py
@@ -1,9 +1,10 @@
 import os
 import json
-import shutil
+import pytest
 import textwrap
 from .utils import get_test_id, build_example, run_example
 from . import circuits
+from align.pdk.finfet import MOSGenerator
 
 
 def test_place_on_grid():
@@ -71,26 +72,11 @@ def test_hierarchy():
     run_example(example, cleanup=False)
 
 
-def test_check_constraints():
+@pytest.mark.parametrize('vt', ['NMOS', 'PMOS'])
+def test_check_constraints(vt):
     os.environ['PLACE_ON_GRID'] = 't'
-    name = f'ckt_{get_test_id()}'
-    netlist = textwrap.dedent(f"""\
-        .subckt {name} vi vo vbp vccx vssx
-        mp0 vo vbp vccx vccx p w=720e-9 nf=4 m=4
-        mn0 vo vi vssx vssx n w=720e-9 nf=4 m=4
-        .ends {name}
-    """)
-    constraints = []
-    example = build_example(name, netlist, constraints)
-    ckt_dir, run_dir = run_example(example, n=1, cleanup=False, additional_args=['--flow_stop', '2_primitives'])
-    name = name.upper()
-    primitives_folder = run_dir / '2_primitives'
-    for dev in ['NMOS', 'PMOS']:
-        mos = [f for f in primitives_folder.glob(f'{dev}*[0-9].json')][0]
-        with (mos).open('rt') as fp:
-            data = json.load(fp)
-            assert "metadata" in data
-            assert "constraints" in data["metadata"]
-            assert data["metadata"]["constraints"][0]["constraint"] == "place_on_grid"
-    shutil.rmtree(run_dir)
-    shutil.rmtree(ckt_dir)
+    c = MOSGenerator()
+    ports = {'S': [('M1', 'S')], 'D': [('M1', 'D')], 'G': [('M1', 'G')]}
+    parameters = {'M': 1, 'NFIN': 4, 'real_inst_type': vt, 'NF': 2}
+    c.addNMOSArray(1, 1, 0, None, ports, **parameters)
+    assert c.metadata["constraints"][0]["constraint"] == "place_on_grid"

--- a/tests/pdk/finfet_pdk/test_placement_grid.py
+++ b/tests/pdk/finfet_pdk/test_placement_grid.py
@@ -1,10 +1,8 @@
 import os
 import json
-import pytest
 import textwrap
 from .utils import get_test_id, build_example, run_example
 from . import circuits
-from align.pdk.finfet import MOSGenerator
 
 
 def test_place_on_grid():
@@ -70,13 +68,3 @@ def test_hierarchy():
     ]
     example = build_example(name, netlist, constraints)
     run_example(example, cleanup=False)
-
-
-@pytest.mark.parametrize('vt', ['NMOS', 'PMOS'])
-def test_check_constraints(vt):
-    os.environ['PLACE_ON_GRID'] = 't'
-    c = MOSGenerator()
-    ports = {'S': [('M1', 'S')], 'D': [('M1', 'D')], 'G': [('M1', 'G')]}
-    parameters = {'M': 1, 'NFIN': 4, 'real_inst_type': vt, 'NF': 2}
-    c.addNMOSArray(1, 1, 0, None, ports, **parameters)
-    assert c.metadata["constraints"][0]["constraint"] == "place_on_grid"

--- a/tests/pdk/finfet_pdk/test_transistor_array.py
+++ b/tests/pdk/finfet_pdk/test_transistor_array.py
@@ -1,3 +1,4 @@
+import os
 import pytest
 from align.pdk.finfet import MOSGenerator
 from .utils import get_test_id, export_to_viewer
@@ -98,6 +99,16 @@ def test_duo_one():
     export_to_viewer(get_test_id(), c)
     if c.drc.num_errors > 0 or len(c.rd.opens) > 0 or len(c.rd.shorts) > 0:
         assert False, f'{get_test_id()}'
+
+
+@pytest.mark.parametrize('vt', ['NMOS', 'PMOS'])
+def test_check_constraints(vt):
+    os.environ['PLACE_ON_GRID'] = 't'
+    c = MOSGenerator()
+    ports = {'S': [('M1', 'S')], 'D': [('M1', 'D')], 'G': [('M1', 'G')]}
+    parameters = {'M': 1, 'NFIN': 4, 'real_inst_type': vt, 'NF': 2}
+    c.addNMOSArray(1, 1, 0, None, ports, **parameters)
+    assert c.metadata["constraints"][0]["constraint"] == "place_on_grid"
 
 
 # Unit tests ###


### PR DESCRIPTION
The constraint was only created for PMOS but not for NMOS devices.
Also, simplified the constraint so that both NMOS and PMOS can be placed on [0,0]. 