### PR TITLE
Allow PDK to define base models

### DIFF
--- a/align/compiler/compiler.py
+++ b/align/compiler/compiler.py
@@ -2,10 +2,8 @@ import pathlib
 import pprint
 import json
 
-from align.schema import library
-
+from align.primitive.main import get_generator
 from ..schema.subcircuit import SubCircuit
-from ..schema.parser import SpiceParser
 from ..schema import constraint
 from .preprocess import preprocess_stack_parallel
 from .create_database import CreateDatabase
@@ -14,7 +12,6 @@ from .match_graph import Annotate
 from .write_verilog_lef import WriteVerilog
 from .find_constraint import FindConst
 from .user_const import ConstraintParser
-from ..schema import constraint
 from ..primitive import generate_primitive_lef
 import logging
 
@@ -124,7 +121,7 @@ def compiler_input(
             ), f"duplicate pins found in module {ckt.name}, {ckt.pins}"
             for ele in ckt.elements:
                 if isinstance(ckt_data.find(ele.model), SubCircuit):
-                    assert len(ele.pins) == len(ckt_data.find(ele.model).pins), f"incorrect subckt instantiation"
+                    assert len(ele.pins) == len(ckt_data.find(ele.model).pins), "incorrect subckt instantiation"
     return ckt_data
 
 
@@ -171,7 +168,7 @@ def call_primitive_generator(
 
         for ele in ckt.elements:
             primitive_generator = ele.generator
-            if primitive_generator in generators:
+            if primitive_generator in generators or get_generator(primitive_generator.lower(), pdk_dir):
                 assert generate_primitive_lef(
                     ele,
                     primitive_generator,

--- a/align/compiler/preprocess.py
+++ b/align/compiler/preprocess.py
@@ -292,6 +292,8 @@ def add_parallel_devices(ckt, update=True):
         G = Graph(ckt)
         for node in G.neighbors(net):
             ele = ckt.get_element(node)
+            if 'PARALLEL' not in ele.parameters:
+                continue  # this element does not support multiplicity
             p = {**ele.pins, **ele.parameters}
             p["model"] = ele.model
             if p in pp_list:

--- a/align/compiler/preprocess.py
+++ b/align/compiler/preprocess.py
@@ -305,7 +305,7 @@ def add_parallel_devices(ckt, update=True):
             if len(pd) > 1:
                 pd0 = sorted(pd, key=lambda x: x.name)[0]
                 logger.info(f"removing parallel instances {[x.name for x in pd[1:]]} and updating {pd0.name} parameters")
-                pd0.parameters["PARALLEL"] = sum([getattr(x.parameters, "PARALLEL", 1) for x in pd])
+                pd0.parameters["PARALLEL"] = str(sum([int(getattr(x.parameters, "PARALLEL", "1")) for x in pd]))
                 for rn in pd[1:]:
                     G.remove(rn)
 
@@ -370,7 +370,7 @@ def add_series_devices(ckt, update=True):
                 set(["PLUS", "MINUS"]),
             ]:
                 logger.info(f"stacking {nbrs} {stack1 + stack2}")
-                nbr1.parameters["STACK"] = stack1 + stack2
+                nbr1.parameters["STACK"] = str(stack1 + stack2)
                 for p, n in nbr1.pins.items():
                     if net == n:
                         nbr1.pins[p] = nbr2.pins[p]

--- a/align/compiler/preprocess.py
+++ b/align/compiler/preprocess.py
@@ -332,6 +332,8 @@ def add_series_devices(ckt, update=True):
         nbrs = sorted(list(G.neighbors(net)))
         if len(nbrs) == 2 and net not in remove_nodes:
             nbr1, nbr2 = [ckt.get_element(nbr) for nbr in nbrs]
+            if 'STACK' not in nbr1.parameters:
+                continue  # this element does not support stacking
             # Same instance type
             if nbr1.model != nbr2.model:
                 continue

--- a/align/compiler/read_library.py
+++ b/align/compiler/read_library.py
@@ -2,13 +2,22 @@ import pathlib
 from ..schema.parser import SpiceParser
 from ..schema.subcircuit import SubCircuit
 import logging
+from ..schema.library import Library
+from align.primitive.main import get_generator
 
 
 logger = logging.getLogger(__name__)
 
 
 def read_models(pdk_dir: pathlib.Path, config_path=None):
-    ckt_parser = SpiceParser()
+
+    PDK_MODELS = get_generator('PDK_MODELS', pdk_dir)
+    if PDK_MODELS:
+        library = Library(loadbuiltins=False, pdk_models=PDK_MODELS)
+    else:
+        library = Library(loadbuiltins=True)
+
+    ckt_parser = SpiceParser(library=library)
     # Read model file to map devices
     if config_path is None:
         config_path = pathlib.Path(__file__).resolve().parent.parent / "config"

--- a/align/compiler/read_library.py
+++ b/align/compiler/read_library.py
@@ -11,12 +11,8 @@ logger = logging.getLogger(__name__)
 
 def read_models(pdk_dir: pathlib.Path, config_path=None):
 
-    PDK_MODELS = get_generator('PDK_MODELS', pdk_dir)
-    if PDK_MODELS:
-        library = Library(loadbuiltins=False, pdk_models=PDK_MODELS)
-    else:
-        library = Library(loadbuiltins=True)
-
+    pdk_models = get_generator('pdk_models', pdk_dir)
+    library = Library(loadbuiltins=True, pdk_models=pdk_models)
     ckt_parser = SpiceParser(library=library)
     # Read model file to map devices
     if config_path is None:

--- a/align/pdk/finfet/__init__.py
+++ b/align/pdk/finfet/__init__.py
@@ -3,4 +3,4 @@ from .transistor import MOS
 from .transistor_array import MOSGenerator
 from .resistor import *
 from .digital import *
-from .models import PDK_MODELS
+from .models import *

--- a/align/pdk/finfet/__init__.py
+++ b/align/pdk/finfet/__init__.py
@@ -1,5 +1,6 @@
 from .canvas import CanvasPDK
 from .transistor import MOS
 from .transistor_array import MOSGenerator
-from .resistor import tfr_prim
+from .resistor import *
 from .digital import *
+from .models import PDK_MODELS

--- a/align/pdk/finfet/models.py
+++ b/align/pdk/finfet/models.py
@@ -1,42 +1,45 @@
 from align.schema.model import Model
 
-PDK_MODELS = list()
 
-PDK_MODELS.append(
-    Model(
-        name='NMOS',
-        pins=['D', 'G', 'S', 'B'],
-        prefix='',
-        parameters={
-            'W': 0,
-            'L': 0,
-            'NFIN': 1,
-            'NF': 2,
-            'M': 1
-            }
+def pdk_models():
+    models = list()
+    models.append(
+        Model(
+            name='NMOS',
+            pins=['D', 'G', 'S', 'B'],
+            prefix='',
+            parameters={
+                'W': 0,
+                'L': 0,
+                'NFIN': 1,
+                'NF': 2,
+                'M': 1,
+                'STACK': 1
+                }
+        )
     )
-)
+    models.append(
+        Model(
+            name='PMOS',
+            pins=['D', 'G', 'S', 'B'],
+            prefix='',
+            parameters={
+                'W': 0,
+                'L': 0,
+                'NFIN': 1,
+                'NF': 2,
+                'M': 1,
+                'STACK': 1
+                }
+        )
+    )
 
-PDK_MODELS.append(
-    Model(
-        name='PMOS',
-        pins=['D', 'G', 'S', 'B'],
-        prefix='',
-        parameters={
-            'W': 0,
-            'L': 0,
-            'NFIN': 1,
-            'NF': 2,
-            'M': 1
-            }
+    models.append(
+        Model(
+            name='TFR',
+            pins=['A', 'B'],
+            prefix='',
+            parameters={'W': 0, 'L': 0},
+        )
     )
-)
-
-PDK_MODELS.append(
-    Model(
-        name='TFR',
-        pins=['A', 'B'],
-        prefix='',
-        parameters={'W': 0, 'L': 0},
-    )
-)
+    return models

--- a/align/pdk/finfet/models.py
+++ b/align/pdk/finfet/models.py
@@ -12,9 +12,7 @@ PDK_MODELS.append(
             'L': 0,
             'NFIN': 1,
             'NF': 2,
-            'M': 1,
-            'PARALLEL': 1,  # Get rid of this hack
-            'STACK': 1  # Get rid of this hack
+            'M': 1
             }
     )
 )
@@ -29,9 +27,7 @@ PDK_MODELS.append(
             'L': 0,
             'NFIN': 1,
             'NF': 2,
-            'M': 1,
-            'PARALLEL': 1,  # Get rid of this hack
-            'STACK': 1  # Get rid of this hack
+            'M': 1
             }
     )
 )

--- a/align/pdk/finfet/models.py
+++ b/align/pdk/finfet/models.py
@@ -33,13 +33,15 @@ def pdk_models():
                 }
         )
     )
-
     models.append(
         Model(
             name='TFR',
             pins=['A', 'B'],
             prefix='',
-            parameters={'W': 0, 'L': 0},
+            parameters={
+                'W': 0,
+                'L': 0
+                }
         )
     )
     return models

--- a/align/pdk/finfet/models.py
+++ b/align/pdk/finfet/models.py
@@ -1,0 +1,46 @@
+from align.schema.model import Model
+
+PDK_MODELS = list()
+
+PDK_MODELS.append(
+    Model(
+        name='NMOS',
+        pins=['D', 'G', 'S', 'B'],
+        prefix='',
+        parameters={
+            'W': 0,
+            'L': 0,
+            'NFIN': 1,
+            'NF': 2,
+            'M': 1,
+            'PARALLEL': 1,  # Get rid of this hack
+            'STACK': 1  # Get rid of this hack
+            }
+    )
+)
+
+PDK_MODELS.append(
+    Model(
+        name='PMOS',
+        pins=['D', 'G', 'S', 'B'],
+        prefix='',
+        parameters={
+            'W': 0,
+            'L': 0,
+            'NFIN': 1,
+            'NF': 2,
+            'M': 1,
+            'PARALLEL': 1,  # Get rid of this hack
+            'STACK': 1  # Get rid of this hack
+            }
+    )
+)
+
+PDK_MODELS.append(
+    Model(
+        name='TFR',
+        pins=['A', 'B'],
+        prefix='',
+        parameters={'W': 0, 'L': 0},
+    )
+)

--- a/align/pdk/finfet/models.sp
+++ b/align/pdk/finfet/models.sp
@@ -2,3 +2,4 @@
 .model p pmos nfin=1 w=1 nf=1 l=1 m=1
 .model npv nmos nfin=1 w=1 nf=1 l=1 m=1 source=sig drain=sig dv=0
 .model ppv pmos nfin=1 w=1 nf=1 l=1 m=1 source=sig drain=sig dv=0
+.model tfr_flat tfr w=1 l=1

--- a/align/pdk/finfet/resistor.py
+++ b/align/pdk/finfet/resistor.py
@@ -42,3 +42,11 @@ class tfr_prim(CanvasPDK):
             PlaceOnGrid(direction='V', pitch=5*poly_pitch, ored_terms=[OffsetsScalings(offsets=[1*poly_pitch], scalings=[1])]).dict()
         ]
         return {"bbox": bbox, "instance": {}, "terminals": self.terminals, "metadata": self.metadata}
+
+
+class tfr(tfr_prim):
+    pass
+
+
+class tfr_flat(tfr_prim):
+    pass

--- a/align/primitive/main.py
+++ b/align/primitive/main.py
@@ -210,11 +210,10 @@ def generate_primitive_lef(element, model, all_lef, primitives, design_config: d
         return True
 
     elif name == 'generic' or get_generator(name.lower(), pdk_dir):
-        # TODO: how about hashing for unique names?
         value_str = ''
         if values:
             for key in sorted(values):
-                val = values[key].replace('-', '')
+                val = str(values[key]).replace('-', '')
                 value_str += f'_{key}_{val}'
         attr = {'ports': list(element.pins.keys()),
                 'values': values if values else None,
@@ -337,12 +336,12 @@ def generate_primitive_lef(element, model, all_lef, primitives, design_config: d
             elif design_config["pdk_type"] == "Bulk":
                 # Bulk design
                 for key in values:
-                   assert values[key]["W"] != str, f"unrecognized size of device {key}:{values[key]['W']} in {name}"
-                   assert int(
-                       float(values[key]["W"])*1E+9) % design_config["Fin_pitch"] == 0, \
-                       f"Width of device {key} in {name} should be multiple of fin pitch:{design_config['Fin_pitch']}" 
-                   size = int(float(values[key]["W"])*1E+9/design_config["Fin_pitch"])
-                   values[key]["NFIN"] = size
+                    assert values[key]["W"] != str, f"unrecognized size of device {key}:{values[key]['W']} in {name}"
+                    assert int(
+                        float(values[key]["W"])*1E+9) % design_config["Fin_pitch"] == 0, \
+                        f"Width of device {key} in {name} should be multiple of fin pitch:{design_config['Fin_pitch']}"
+                    size = int(float(values[key]["W"])*1E+9/design_config["Fin_pitch"])
+                    values[key]["NFIN"] = size
                 name_arg = 'NFIN'+str(size)
             else:
                 print(design_config["pdk_type"] + " pdk not supported")

--- a/align/schema/library.py
+++ b/align/schema/library.py
@@ -38,14 +38,14 @@ class Library(List[Union[Model, SubCircuit]]):
             )
         )
         models.append(
-        Model(
-            name='PMOS',
-            pins=['D', 'G', 'S', 'B'],
-            parameters={
-                'W': 0,
-                'L': 0,
-                'NFIN': 1,
-                'NF': 2,
+            Model(
+                name='PMOS',
+                pins=['D', 'G', 'S', 'B'],
+                parameters={
+                    'W': 0,
+                    'L': 0,
+                    'NFIN': 1,
+                    'NF': 2,
                     'M': 1,
                     'PARALLEL': 1,  # Internal attribute used for parallel and stacked devices
                     'STACK': 1},

--- a/align/schema/library.py
+++ b/align/schema/library.py
@@ -68,7 +68,9 @@ def load_builtins(default):
                 name='CAP',
                 pins=['PLUS', 'MINUS'],
                 parameters={
-                    'VALUE': 0
+                    'VALUE': 0,
+                    'PARALLEL': 1,
+                    'STACK': 1
                 },
                 prefix='C'
             )
@@ -78,7 +80,9 @@ def load_builtins(default):
                 name='RES',
                 pins=['PLUS', 'MINUS'],
                 parameters={
-                    'VALUE': 0
+                    'VALUE': 0,
+                    'PARALLEL': 1,
+                    'STACK': 1
                 },
                 prefix='R'
             )
@@ -88,7 +92,9 @@ def load_builtins(default):
                 name='IND',
                 pins=['PLUS', 'MINUS'],
                 parameters={
-                    'VALUE': 0
+                    'VALUE': 0,
+                    'PARALLEL': 1,
+                    'STACK': 1
                 },
                 prefix='L'
             )

--- a/align/schema/library.py
+++ b/align/schema/library.py
@@ -1,8 +1,5 @@
 from .model import Model
 from .subcircuit import SubCircuit
-import inspect
-import random
-import string
 from .types import List, Union, set_context
 
 libraries = {}
@@ -10,86 +7,89 @@ libraries = {}
 
 class Library(List[Union[Model, SubCircuit]]):
 
-    def __init__(self, name=None, loadbuiltins=True):
+    def __init__(self, name=None, loadbuiltins=False, pdk_models=None):
         if name:
             assert name not in libraries
             libraries.update({name: self})
         super().__init__()
         if loadbuiltins:
+            load_builtins(default)
+            self.extend(libraries['default'])
+        if pdk_models:
+            with set_context(default):
+                for m in pdk_models:
+                    default.append(m)
             self.extend(libraries['default'])
 
     def find(self, name):
         return next((x for x in self if x.name == name.upper()), None)
 
+
 #
 # Create default library
 #
-
-
 default = Library('default')
 
 
-with set_context(default):
-    default.append(
-        Model(
-            name='NMOS',
-            pins=['D', 'G', 'S', 'B'],
-            parameters={
-                'W': 0,
-                'L': 0,
-                'NFIN': 1,
-                'NF': 2,
-                'M': 1,
-                'PARALLEL': 1,  # Internal attribute used for parallel and stacked devices
-                'STACK': 1},
-            prefix=''
+def load_builtins(default):
+    with set_context(default):
+        default.append(
+            Model(
+                name='NMOS',
+                pins=['D', 'G', 'S', 'B'],
+                parameters={
+                    'W': 0,
+                    'L': 0,
+                    'NFIN': 1,
+                    'NF': 2,
+                    'M': 1,
+                    'PARALLEL': 1,  # Internal attribute used for parallel and stacked devices
+                    'STACK': 1},
+                prefix=''
+            )
         )
-    )
-
-    default.append(
-        Model(
-            name='PMOS',
-            pins=['D', 'G', 'S', 'B'],
-            parameters={
-                'W': 0,
-                'L': 0,
-                'NFIN': 1,
-                'NF': 2,
-                'M': 1,
-                'PARALLEL': 1,  # Internal attribute used for parallel and stacked devices
-                'STACK': 1},
-            prefix=''
+        default.append(
+            Model(
+                name='PMOS',
+                pins=['D', 'G', 'S', 'B'],
+                parameters={
+                    'W': 0,
+                    'L': 0,
+                    'NFIN': 1,
+                    'NF': 2,
+                    'M': 1,
+                    'PARALLEL': 1,  # Internal attribute used for parallel and stacked devices
+                    'STACK': 1},
+                prefix=''
+            )
         )
-    )
-
-    default.append(
-        Model(
-            name='CAP',
-            pins=['PLUS', 'MINUS'],
-            parameters={
-                'VALUE': 0
-            },
-            prefix='C'
+        default.append(
+            Model(
+                name='CAP',
+                pins=['PLUS', 'MINUS'],
+                parameters={
+                    'VALUE': 0
+                },
+                prefix='C'
+            )
         )
-    )
-
-    default.append(
-        Model(
-            name='RES',
-            pins=['PLUS', 'MINUS'],
-            parameters={
-                'VALUE': 0
-            },
-            prefix='R'
+        default.append(
+            Model(
+                name='RES',
+                pins=['PLUS', 'MINUS'],
+                parameters={
+                    'VALUE': 0
+                },
+                prefix='R'
+            )
         )
-    )
-    default.append(
-        Model(
-            name='IND',
-            pins=['PLUS', 'MINUS'],
-            parameters={
-                'VALUE': 0
-            },
-            prefix='L'
+        default.append(
+            Model(
+                name='IND',
+                pins=['PLUS', 'MINUS'],
+                parameters={
+                    'VALUE': 0
+                },
+                prefix='L'
+            )
         )
-    )

--- a/align/schema/library.py
+++ b/align/schema/library.py
@@ -2,38 +2,27 @@ from .model import Model
 from .subcircuit import SubCircuit
 from .types import List, Union, set_context
 
-libraries = {}
-
 
 class Library(List[Union[Model, SubCircuit]]):
 
-    def __init__(self, name=None, loadbuiltins=False, pdk_models=None):
-        if name:
-            assert name not in libraries
-            libraries.update({name: self})
+    def __init__(self, loadbuiltins=False, pdk_models=None):
         super().__init__()
-        if loadbuiltins:
-            load_builtins(default)
-            self.extend(libraries['default'])
+        models = None
         if pdk_models:
-            with set_context(default):
-                for m in pdk_models:
-                    default.append(m)
-            self.extend(libraries['default'])
+            models = pdk_models()
+        elif loadbuiltins:
+            models = self.default_models()
+        if models:
+            with set_context(self):
+                for m in models:
+                    self.append(m)
 
     def find(self, name):
         return next((x for x in self if x.name == name.upper()), None)
 
-
-#
-# Create default library
-#
-default = Library('default')
-
-
-def load_builtins(default):
-    with set_context(default):
-        default.append(
+    def default_models(self):
+        models = list()
+        models.append(
             Model(
                 name='NMOS',
                 pins=['D', 'G', 'S', 'B'],
@@ -48,22 +37,22 @@ def load_builtins(default):
                 prefix=''
             )
         )
-        default.append(
-            Model(
-                name='PMOS',
-                pins=['D', 'G', 'S', 'B'],
-                parameters={
-                    'W': 0,
-                    'L': 0,
-                    'NFIN': 1,
-                    'NF': 2,
+        models.append(
+        Model(
+            name='PMOS',
+            pins=['D', 'G', 'S', 'B'],
+            parameters={
+                'W': 0,
+                'L': 0,
+                'NFIN': 1,
+                'NF': 2,
                     'M': 1,
                     'PARALLEL': 1,  # Internal attribute used for parallel and stacked devices
                     'STACK': 1},
                 prefix=''
             )
         )
-        default.append(
+        models.append(
             Model(
                 name='CAP',
                 pins=['PLUS', 'MINUS'],
@@ -75,7 +64,7 @@ def load_builtins(default):
                 prefix='C'
             )
         )
-        default.append(
+        models.append(
             Model(
                 name='RES',
                 pins=['PLUS', 'MINUS'],
@@ -87,7 +76,7 @@ def load_builtins(default):
                 prefix='R'
             )
         )
-        default.append(
+        models.append(
             Model(
                 name='IND',
                 pins=['PLUS', 'MINUS'],
@@ -99,3 +88,4 @@ def load_builtins(default):
                 prefix='L'
             )
         )
+        return models

--- a/align/schema/parser.py
+++ b/align/schema/parser.py
@@ -189,8 +189,8 @@ class SpiceParser:
 
     def _process_constraints(self):
         with set_context(self._scope[-1].constraints):
-            for constraint in self._constraints:
-                self._scope[-1].constraints.append(eval(constraint, {}, constraint_dict))
+            for const in self._constraints:
+                self._scope[-1].constraints.append(eval(const, {}, constraint_dict))
         self._constraints = None
 
     def _process_declaration(self, decl, args, kwargs):
@@ -216,6 +216,4 @@ class SpiceParser:
             assert self.library.find(name) is None, f"User is attempting to redeclare {name}"
             assert self.library.find(base) is not None, f"Base model {base} not found for model {name}"
             with set_context(self.library):
-                self.library.append(
-                    Model(name=name, base=base, parameters=kwargs)
-                )
+                self.library.append(Model(name=name, base=base, parameters=kwargs))

--- a/tests/compiler/test_compiler_parser.py
+++ b/tests/compiler/test_compiler_parser.py
@@ -5,8 +5,8 @@ from align.compiler.compiler import compiler_input
 
 def test_simple_circuit():
     test_home = pathlib.Path(__file__).resolve().parent.parent
-    test_path = test_home / "files"/ "test_circuits"/ "test2.sp"
-    pdk_dir = test_home.parent / "pdks"/ "FinFET14nm_Mock_PDK"
+    test_path = test_home / "files" / "test_circuits" / "test2.sp"
+    pdk_dir = test_home.parent / "pdks" / "FinFET14nm_Mock_PDK"
     config_path = pathlib.Path(__file__).resolve().parent.parent / "files"
     lib = compiler_input(test_path, "test2", pdk_dir, config_path)
     circuit = lib.find("TEST2")
@@ -91,10 +91,10 @@ def test_simple_circuit():
     model = lib.find(circuit.elements[3].model)
     assert model.base == None  # Using base model
     assert model.pins == ["PLUS", "MINUS"]
-    assert model.parameters == {"VALUE": "0"}
+    assert model.parameters == {"VALUE": "0", 'PARALLEL': '1', 'STACK': '1'}
     assert model.prefix == "R"
     assert circuit.elements[3].pins == {"PLUS": "VBIAS", "MINUS": "NET5"}
-    assert circuit.elements[3].parameters == {"VALUE": "5000"}
+    assert circuit.elements[3].parameters == {"VALUE": "5000", 'PARALLEL': '1', 'STACK': '1'}
 
     assert circuit.elements[4].name == "CC0"
     model = lib.find(circuit.elements[4].model)
@@ -102,7 +102,7 @@ def test_simple_circuit():
     assert model.base == None
     assert circuit.elements[4].pins == {"PLUS": "VIN", "MINUS": "NET5"}
     assert circuit.elements[4].parameters == {
-        "VALUE": "1.0000000000000002E-14"
+        "VALUE": "1.0000000000000002E-14", 'PARALLEL': '1', 'STACK': '1'
     }  # TBF: remove multiple zeros
 
     assert circuit.elements[5].name == "LL0"
@@ -111,7 +111,7 @@ def test_simple_circuit():
     assert model.base == None
     assert circuit.elements[5].pins == {"PLUS": "VDD!", "MINUS": "VOUT"}
     assert circuit.elements[5].parameters == {
-        "VALUE": "0.002"
+        "VALUE": "0.002", 'PARALLEL': '1', 'STACK': '1'
     }  # TBF: change to scientific nomenclature?
 
     assert circuit.elements[6].name == "RR1"
@@ -119,20 +119,20 @@ def test_simple_circuit():
     model = lib.find(circuit.elements[6].model)
     assert model.name == "RESISTOR"
     assert model.pins == ["PLUS", "MINUS"]
-    assert model.parameters == {"R": "1", "VALUE": "0"}
+    assert model.parameters == {"R": "1", "VALUE": "0", 'PARALLEL': '1', 'STACK': '1'}
     assert circuit.elements[6].pins == {"PLUS": "VBIAS", "MINUS": "NET6"}
-    assert circuit.elements[6].parameters == {"R": "5000", "VALUE": "0"}
+    assert circuit.elements[6].parameters == {"R": "5000", "VALUE": "0", 'PARALLEL': '1', 'STACK': '1'}
 
     assert circuit.elements[7].name == "CC1"
     assert circuit.elements[7].model == "CAPACITOR"
     model = lib.find(circuit.elements[7].model)
     assert model.name == "CAPACITOR"
     assert model.pins == ["PLUS", "MINUS"]
-    assert model.parameters == {"C": "1", "VALUE": "0"}
+    assert model.parameters == {"C": "1", "VALUE": "0", 'PARALLEL': '1', 'STACK': '1'}
     assert circuit.elements[7].pins == {"PLUS": "VIN", "MINUS": "NET6"}
     assert circuit.elements[7].parameters == {
         "C": "1.0000000000000002E-14",
-        "VALUE": "0",
+        "VALUE": "0", 'PARALLEL': '1', 'STACK': '1'
     }
 
     assert circuit.elements[8].name == "LL1"
@@ -140,6 +140,6 @@ def test_simple_circuit():
     model = lib.find(circuit.elements[8].model)
     assert model.name == "INDUCTOR"
     assert model.pins == ["PLUS", "MINUS"]
-    assert model.parameters == {"IND": "1", "VALUE": "0"}
+    assert model.parameters == {"IND": "1", "VALUE": "0", 'PARALLEL': '1', 'STACK': '1'}
     assert circuit.elements[8].pins == {"PLUS": "VDD!", "MINUS": "NET6"}
-    assert circuit.elements[8].parameters == {"IND": "0.002", "VALUE": "0"}
+    assert circuit.elements[8].parameters == {"IND": "0.002", "VALUE": "0", 'PARALLEL': '1', 'STACK': '1'}

--- a/tests/compiler/test_library_parsing.py
+++ b/tests/compiler/test_library_parsing.py
@@ -1,12 +1,10 @@
-from align.schema.types import set_context
 import pathlib
-import pytest
+from align.schema.types import set_context
 from align.schema.parser import SpiceParser
 from align.schema import constraint
 
 
-@pytest.fixture
-def library():
+def test_basic_lib():
     parser = SpiceParser()
     align_home = pathlib.Path(__file__).resolve().parent.parent / "files"
     basic_lib_path = align_home / "basic_template.sp"
@@ -17,17 +15,13 @@ def library():
     with open(user_lib_path) as f:
         lines = f.read()
     parser.parse(lines)
-    return parser.library
+    library = parser.library
 
-
-def test_basic_lib(library):
     assert len(library.find("DP_PMOS_B").elements) == 2
     assert len(library.find("CASCODED_CMC_PMOS").elements) == 4
     assert len(library.find("INV_B").elements) == 2
     assert len(library) == 54
 
-
-def test_constraint(library):
     assert len(library.find("DP_PMOS_B").constraints) == 3
     dp_const = library.find("DP_PMOS_B").constraints
     with set_context(dp_const):

--- a/tests/compiler/test_preprocessing.py
+++ b/tests/compiler/test_preprocessing.py
@@ -11,16 +11,16 @@ from align.compiler.preprocess import (
 
 @pytest.fixture
 def db():
-    library = Library()
+    library = Library(loadbuiltins=False)
     with set_context(library):
-        cmodel = Model(name="CAP", pins=["PLUS", "MINUS"], parameters={"VALUE": "5.0"})
-        rmodel = Model(name="RES", pins=["PLUS", "MINUS"], parameters={"VALUE": "5.0"})
+        cmodel = Model(name="CAP", pins=["PLUS", "MINUS"], parameters={"VALUE": "5.0", "PARALLEL": 1})
+        rmodel = Model(name="RES", pins=["PLUS", "MINUS"], parameters={"VALUE": "5.0", "PARALLEL": 1})
         library.append(cmodel)
         library.append(rmodel)
         model_nmos = Model(
             name="TESTMOS",
             pins=["D", "G", "S", "B"],
-            parameters={"PARAM1": "1.0", "M": 1, "PARAM2": "2"},
+            parameters={"PARAM1": "1.0", "M": 1, "PARAM2": "2", "PARALLEL": 1},
         )
         library.append(model_nmos)
         subckt = SubCircuit(
@@ -33,7 +33,7 @@ def db():
                 name="C1",
                 model="CAP",
                 pins={"PLUS": "PLUS", "MINUS": "MINUS"},
-                parameters={"VALUE": "2"},
+                parameters={"VALUE": "2", "PARALLEL": "1"},
                 generator="CAP",
             )
         )
@@ -42,7 +42,7 @@ def db():
                 name="C2",
                 model="CAP",
                 pins={"PLUS": "PLUS", "MINUS": "MINUS"},
-                parameters={"VALUE": "2"},
+                parameters={"VALUE": "2", "PARALLEL": 1},
                 generator="CAP",
             )
         )
@@ -51,7 +51,7 @@ def db():
                 name="R1",
                 model="RES",
                 pins={"PLUS": "PLUS", "MINUS": "MINUS"},
-                parameters={"VALUE": "10"},
+                parameters={"VALUE": "10", "PARALLEL": "1"},
                 generator="RES",
             )
         )
@@ -60,7 +60,7 @@ def db():
                 name="R2",
                 model="RES",
                 pins={"PLUS": "PLUS", "MINUS": "MINUS"},
-                parameters={"VALUE": "10"},
+                parameters={"VALUE": "10", "PARALLEL": "1"},
                 generator="RES",
             )
         )
@@ -79,6 +79,7 @@ def db():
                 model="TESTMOS",
                 pins={"D": "D", "G": "G", "S": "S", "B": "B"},
                 generator="TESTMOS",
+                parameters={"PARAM1": "1.0", "M": 1, "PARAM2": "2"}
             )
         )
         subckt.elements.append(
@@ -87,6 +88,7 @@ def db():
                 model="TESTMOS",
                 pins={"D": "D", "G": "G", "S": "S", "B": "B"},
                 generator="TESTMOS",
+                parameters={"PARAM1": "1.0", "M": 1, "PARAM2": "2"}
             )
         )
 
@@ -97,34 +99,34 @@ def test_parallel(db):
 
     assert db.get_element("C1").name == "C1"
     add_parallel_devices(db, update=False)
-    assert db.get_element("C1").parameters == {"VALUE": "2"}
+    assert db.get_element("C1").parameters == {"VALUE": "2", "PARALLEL": "1"}
     add_parallel_devices(db, update=True)
-    assert db.get_element("C1").parameters == {"VALUE": "2", "PARALLEL": 2}
+    assert db.get_element("C1").parameters == {"VALUE": "2", "PARALLEL": "2"}
     assert db.get_element("C2") is None, 'C2 should have been removed'
-    assert db.get_element("R1").parameters == {"VALUE": "10", "PARALLEL": 3}
+    assert db.get_element("R1").parameters == {"VALUE": "10", "PARALLEL": "3"}
     assert db.get_element("R2") is None, 'R2 should have been removed'
     assert db.get_element("R3") is None, 'R3 should have been removed'
     assert db.get_element("M1").parameters == {
         "PARAM1": "1.0",
         "M": "1",
         "PARAM2": "2",
-        "PARALLEL": 2,
+        "PARALLEL": "2",
     }
     assert db.get_element("M2") is None, 'Should M2 have been removed from the db as it has been merged to M1?'
 
 
 @pytest.fixture
 def dbs():
-    library = Library()
+    library = Library(loadbuiltins=False)
     with set_context(library):
-        cmodel = Model(name="CAP", pins=["PLUS", "MINUS"], parameters={"VALUE": "5.0"})
-        rmodel = Model(name="RES", pins=["PLUS", "MINUS"], parameters={"VALUE": "5.0"})
+        cmodel = Model(name="CAP", pins=["PLUS", "MINUS"], parameters={"VALUE": "5.0", "STACK": 1})
+        rmodel = Model(name="RES", pins=["PLUS", "MINUS"], parameters={"VALUE": "5.0", "STACK": 1})
         library.append(cmodel)
         library.append(rmodel)
         model_nmos = Model(
             name="TESTMOS",
             pins=["D", "G", "S", "B"],
-            parameters={"PARAM1": "1.0", "M": 1, "PARAM2": "2"},
+            parameters={"PARAM1": "1.0", "M": 1, "PARAM2": "2", "STACK": 1},
         )
         library.append(model_nmos)
         subckt = SubCircuit(
@@ -137,7 +139,7 @@ def dbs():
                 name="C1",
                 model="CAP",
                 pins={"PLUS": "PLUS", "MINUS": "netc1"},
-                parameters={"VALUE": "2"},
+                parameters={"VALUE": "2", "STACK": "1"},
                 generator="CAP",
             )
         )
@@ -146,7 +148,7 @@ def dbs():
                 name="C2",
                 model="CAP",
                 pins={"PLUS": "netc1", "MINUS": "MINUS"},
-                parameters={"VALUE": "2"},
+                parameters={"VALUE": "2", "STACK": "1"},
                 generator="CAP",
             )
         )
@@ -155,7 +157,7 @@ def dbs():
                 name="R1",
                 model="RES",
                 pins={"PLUS": "PLUS", "MINUS": "netr1"},
-                parameters={"VALUE": "10"},
+                parameters={"VALUE": "10", "STACK": "1"},
                 generator="RES",
             )
         )
@@ -164,7 +166,7 @@ def dbs():
                 name="R2",
                 model="RES",
                 pins={"PLUS": "netr1", "MINUS": "netr2"},
-                parameters={"VALUE": "10"},
+                parameters={"VALUE": "10", "STACK": "1"},
                 generator="RES",
             )
         )
@@ -173,7 +175,7 @@ def dbs():
                 name="R3",
                 model="RES",
                 pins={"PLUS": "netr2", "MINUS": "MINUS"},
-                parameters={"VALUE": "10"},
+                parameters={"VALUE": "10", "STACK": "1"},
                 generator="RES",
             )
         )
@@ -228,21 +230,22 @@ def test_series(dbs):
         "PARAM1": "1.0",
         "M": "1",
         "PARAM2": "2",
+        "STACK": "1"
     }
     add_series_devices(dbs, update=True)
-    assert dbs.get_element("C1").parameters == {"VALUE": "2", "STACK": 2}
-    assert dbs.get_element("R1").parameters == {"VALUE": "10", "STACK": 3}
+    assert dbs.get_element("C1").parameters == {"VALUE": "2", "STACK": "2"}
+    assert dbs.get_element("R1").parameters == {"VALUE": "10", "STACK": "3"}
     assert dbs.get_element("M1").parameters == {
         "PARAM1": "1.0",
         "M": "1",
         "PARAM2": "2",
-        "STACK": 2,
+        "STACK": "2",
     }
     assert dbs.get_element("M3").parameters == {
         "PARAM1": "1.0",
         "M": "1",
         "PARAM2": "2",
-        "STACK": 3,
+        "STACK": "3",
     }
     assert len(dbs.elements) == 4
     assert dbs.get_element("M2") is None, 'Should M2 have been removed from the db as it has been merged to M1?'

--- a/tests/pdk/finfet_pdk/test_resistor.py
+++ b/tests/pdk/finfet_pdk/test_resistor.py
@@ -26,8 +26,8 @@ def test_res_flat():
     .subckt {name} v1 v2 v3 vssx
     xr1 v1 vssx tfr_flat w=1 l=1
     xr2 v2 vssx tfr_flat w=1 l=2
-    xr3 v3 vssx tfr_flat w=1 l=3
-    xr4 v3 vssx tfr_flat w=1 l=3
+    xr3 v3   vm tfr_flat w=1 l=3
+    xr4 vm vssx tfr_flat w=1 l=3
     .ends {name}
     .END
     """)

--- a/tests/pdk/finfet_pdk/test_resistor.py
+++ b/tests/pdk/finfet_pdk/test_resistor.py
@@ -1,8 +1,54 @@
 from align.pdk.finfet import tfr_prim
 from .utils import export_to_viewer
+import json
+import textwrap
+from .utils import get_test_id, build_example, run_example
+from . import circuits
 
 
 def test_zero():
     pg = tfr_prim()
     data = pg.generate(ports=['a', 'b'])
     export_to_viewer("test_tfr_0", data)
+
+
+def test_res_hier():
+    name = f'ckt_{get_test_id()}'
+    netlist = circuits.tia(name)
+    constraints = [{"constraint": "AutoConstraint", "isTrue": False, "propagate": True}]
+    example = build_example(name, netlist, constraints)
+    _, run_dir = run_example(example, cleanup=False, n=1, additional_args=['--flow_stop', '2_primitives'])
+
+
+def test_res_flat():
+    name = f'ckt_{get_test_id()}'
+    netlist = textwrap.dedent(f"""\
+    .subckt {name} v1 v2 v3 vssx
+    xr1 v1 vssx tfr_flat w=1 l=1
+    xr2 v2 vssx tfr_flat w=1 l=2
+    xr3 v3 vssx tfr_flat w=1 l=3
+    xr4 v3 vssx tfr_flat w=1 l=3
+    .ends {name}
+    .END
+    """)
+    constraints = [{"constraint": "AutoConstraint", "isTrue": False, "propagate": True}]
+    example = build_example(name, netlist, constraints)
+    _, run_dir = run_example(example, cleanup=False, n=1, log_level='DEBUG', additional_args=['--flow_stop', '3_pnr:prep'])
+
+    name = name.upper()
+    with (run_dir / '1_topology' / '__primitives__.json').open('rt') as f1:
+        primitives = json.load(f1)
+        with (run_dir / '1_topology' / f'{name}.verilog.json').open('rt') as f2:
+            hierarchy = json.load(f2)
+
+            atn = set()
+            for k, v in primitives.items():
+                atn.add(v['abstract_template_name'])
+
+            modules = {e['name']: e for e in hierarchy['modules']}
+            instances = {i['instance_name']: i for i in modules[name]['instances']}
+
+            assert instances['XR3']['abstract_template_name'] == instances['XR4']['abstract_template_name']
+
+            for k, v in instances.items():
+                assert v['abstract_template_name'] in atn, f"Abstract not found: {v['abstract_template_name']}"

--- a/tests/pnr/test_write_constraint.py
+++ b/tests/pnr/test_write_constraint.py
@@ -1,3 +1,4 @@
+from marshal import load
 import pathlib
 import pytest
 import json
@@ -8,7 +9,7 @@ from align.schema import types, Instance, Library, SubCircuit, constraint, Spice
 
 @pytest.fixture
 def mock_circuit():
-    library = Library()
+    library = Library(loadbuiltins=True)
     n = library.find('nmos')
     assert n is not None
     with types.set_context(library):


### PR DESCRIPTION
This PR allows a PDK module to define base models.
Merge parallel or stack only if the model supports this capability (model includes PARALLEL and STACK parameters).
Be consistent in handling PARALLEL and STACK parameters. 