### PR TITLE
NetPriority

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,7 +11,8 @@ jobs:
       python-tags:
         description: "Python version tag(See https://www.python.org/dev/peps/pep-0425/)"
         type: string
-        default: "cp37-cp37m cp38-cp38 cp310-cp310" # Python 3.7 *AND* 3.8 *AND* 3.10
+        default: "cp38-cp38 cp310-cp310" # 3.8 *AND* 3.10
+        # default: "cp37-cp37m cp38-cp38 cp310-cp310" # Python 3.7 *AND* 3.8 *AND* 3.10
       platform:
         # https://github.com/pypa/manylinux
         description: "PEP600 compatible platform name"
@@ -198,16 +199,16 @@ workflows:
                 - "quay.io/pypa/manylinux_2_24_x86_64" # PEP 600
               python-tags:
                 - "cp310-cp310" # Python 3.10
-      - build-wheel:
-          name: "build-wheel-cp37-manylinux2010"
-          requires:
-            - build-wheel-cp38-manylinux_2_24
-          matrix:
-            parameters:
-              platform:
-                - "quay.io/pypa/manylinux2010_x86_64" # PEP 571
-              python-tags:
-                - "cp37-cp37m" # Python 3.7
+      # - build-wheel:
+      #     name: "build-wheel-cp37-manylinux2010"
+      #     requires:
+      #       - build-wheel-cp38-manylinux_2_24
+      #     matrix:
+      #       parameters:
+      #         platform:
+      #           - "quay.io/pypa/manylinux2010_x86_64" # PEP 571
+      #         python-tags:
+      #           - "cp37-cp37m" # Python 3.7
       - test-integration:
           name: "test-integration-cp38-minimal"
           requires:
@@ -257,11 +258,11 @@ workflows:
             alias: build-wheel-all
             parameters:
               platform:
-                - "quay.io/pypa/manylinux2010_x86_64"  # PEP 571
+                # - "quay.io/pypa/manylinux2010_x86_64"  # PEP 571
                 - "quay.io/pypa/manylinux2014_x86_64"  # PEP 599
                 - "quay.io/pypa/manylinux_2_24_x86_64" # PEP 600
               python-tags:
-                - "cp37-cp37m"
+                # - "cp37-cp37m"
                 - "cp38-cp38"
                 - "cp310-cp310"
             exclude:

--- a/PlaceRouteHierFlow/PnRDB/ReadConstraint.cpp
+++ b/PlaceRouteHierFlow/PnRDB/ReadConstraint.cpp
@@ -87,7 +87,7 @@ void PnRdatabase::ReadConstraint_Json(PnRDB::hierNode& node, const string& jsonS
     } else if (constraint["const_name"] == "CritNet") {
       for (int i = 0; i < (int)node.Nets.size(); i++) {
         if (node.Nets.at(i).name == constraint["net_name"]) {
-          node.Nets.at(i).priority = constraint["priority"];
+          node.Nets.at(i).weight = constraint["priority"];
           break;
         }
       }

--- a/PlaceRouteHierFlow/placer/ILP_solver.cpp
+++ b/PlaceRouteHierFlow/placer/ILP_solver.cpp
@@ -3614,8 +3614,8 @@ double ILP_solver::CalculateCost(const design& mydesign, const SeqPair& curr_sp)
     cost += HPWL_norm * hyper.LAMBDA;
   } else {
     cost += log(area);
-    if (HPWL_extend > 0) {
-      cost += log(HPWL_extend) * hyper.LAMBDA;
+    if (HPWL_extend_net_priority > 0) {
+      cost += log(HPWL_extend_net_priority) * hyper.LAMBDA;
     }
   }
 

--- a/PlaceRouteHierFlow/placer/ILP_solver.cpp
+++ b/PlaceRouteHierFlow/placer/ILP_solver.cpp
@@ -1887,10 +1887,10 @@ bool ILP_solver::FrameSolveILPSymphony(const design& mydesign, const SeqPair& cu
   for (unsigned int i = 0; i < mydesign.Nets.size(); i++) {
     if (mydesign.Nets[i].connected.size() < 2) continue;
     int ind = int(mydesign.Blocks.size() * 4 + i * 4);
-    objective.at(ind)     = -hyper.LAMBDA;
-    objective.at(ind + 1) = -hyper.LAMBDA;
-    objective.at(ind + 2) = hyper.LAMBDA;
-    objective.at(ind + 3) = hyper.LAMBDA;
+    objective.at(ind) = -hyper.LAMBDA * mydesign.Nets[i].weight;
+    objective.at(ind + 1) = -hyper.LAMBDA * mydesign.Nets[i].weight;
+    objective.at(ind + 2) = hyper.LAMBDA * mydesign.Nets[i].weight;
+    objective.at(ind + 3) = hyper.LAMBDA * mydesign.Nets[i].weight;
   }
 
   int bias_Hgraph = mydesign.bias_Hgraph, bias_Vgraph = mydesign.bias_Vgraph;
@@ -2597,6 +2597,7 @@ double ILP_solver::GenerateValidSolution(const design& mydesign, const SeqPair& 
   HPWL = 0;
   HPWL_extend = 0;
   HPWL_extend_terminal = 0;
+
   for (const auto& neti : mydesign.Nets) {
     int HPWL_min_x = UR.x, HPWL_min_y = UR.y, HPWL_max_x = 0, HPWL_max_y = 0;
     int HPWL_extend_min_x = UR.x, HPWL_extend_min_y = UR.y, HPWL_extend_max_x = 0, HPWL_extend_max_y = 0;
@@ -2664,6 +2665,7 @@ double ILP_solver::GenerateValidSolution(const design& mydesign, const SeqPair& 
     }
     HPWL += (HPWL_max_y - HPWL_min_y) + (HPWL_max_x - HPWL_min_x);
     HPWL_extend += (HPWL_extend_max_y - HPWL_extend_min_y) + (HPWL_extend_max_x - HPWL_extend_min_x);
+    HPWL_extend_net_priority += ((HPWL_extend_max_y - HPWL_extend_min_y) + (HPWL_extend_max_x - HPWL_extend_min_x)) * neti.weight;
     bool is_terminal_net = false;
     for (const auto& c : neti.connected) {
       if (c.type == placerDB::Terminal) {

--- a/PlaceRouteHierFlow/placer/ILP_solver.h
+++ b/PlaceRouteHierFlow/placer/ILP_solver.h
@@ -43,6 +43,7 @@ class ILP_solver {
   vector<Block> Blocks;
   placerDB::point LL, UR;
   double area = 0, area_ilp = 0., HPWL = 0, HPWL_ILP = 0., HPWL_extend = 0, HPWL_extend_terminal = 0, ratio = 0, linear_const = 0, multi_linear_const = 0;
+  double HPWL_extend_net_priority = 0;
   double area_norm = 0, HPWL_norm = 0;
   double Aspect_Ratio_weight = 1000;
   double Aspect_Ratio[2] = {0, 100};

--- a/PlaceRouteHierFlow/placer/SeqPair.cpp
+++ b/PlaceRouteHierFlow/placer/SeqPair.cpp
@@ -86,8 +86,8 @@ OrderedEnumerator::OrderedEnumerator(const vector<int>& seq, const vector<pair<p
 }
 
 bool OrderedEnumerator::NextPermutation(vector<int>& seq) {
-  if (_cnt < _sequences.size()) seq = _sequences[_cnt];
-  return (++_cnt < _sequences.size());
+  if (++_cnt < _sequences.size()) seq = _sequences[_cnt];
+  return (_cnt < _sequences.size());
 }
 
 SeqPairEnumerator::SeqPairEnumerator(const vector<int>& pair, design& casenl, const size_t maxIter)
@@ -184,6 +184,7 @@ void SeqPairEnumerator::Permute() {
   if (!IncrementSelected()) {
     if (_enumIndex.second >= _maxEnum - 1) {
       _enumIndex.second = 0;
+      _negEnumerator.ResetCnt();
       ++_enumIndex.first;
       std::sort(_negPair.begin(), _negPair.end());
       if (_posEnumerator.valid())

--- a/PlaceRouteHierFlow/placer/SeqPair.cpp
+++ b/PlaceRouteHierFlow/placer/SeqPair.cpp
@@ -85,10 +85,6 @@ OrderedEnumerator::OrderedEnumerator(const vector<int>& seq, const vector<pair<p
   }*/
 }
 
-void OrderedEnumerator::NextPermutation(vector<int>& seq) {
-  seq = _sequences[_cnt];
-  _cnt = (_cnt + 1) % _sequences.size();
-}
 
 SeqPairEnumerator::SeqPairEnumerator(const vector<int>& pair, design& casenl, const size_t maxIter)
     : _enumIndex({0, 0}),
@@ -183,20 +179,20 @@ void SeqPairEnumerator::Permute() {
   // if (!EnumFlip())
   if (_exhausted) return;
   if (!IncrementSelected()) {
-    if (_enumIndex.second >= _maxEnum) {
+    if (_enumIndex.second >= _maxEnum - 1) {
+      std::sort(_negPair.begin(), _negPair.end());
       _enumIndex.second = 0;
       ++_enumIndex.first;
-      std::sort(_negPair.begin(), _negPair.end());
       if (_posEnumerator.valid())
-        _posEnumerator.NextPermutation(_posPair);
+        _posEnumerator.NextPermutation(_posPair, _enumIndex.first);
       else
         std::next_permutation(std::begin(_posPair), std::end(_posPair));
     } else {
+      ++_enumIndex.second;
       if (_negEnumerator.valid())
-        _negEnumerator.NextPermutation(_negPair);
+        _negEnumerator.NextPermutation(_negPair, _enumIndex.second);
       else
         std::next_permutation(std::begin(_negPair), std::end(_negPair));
-      ++_enumIndex.second;
     }
   }
   if (_enumIndex.first >= _maxEnum) _exhausted = true;

--- a/PlaceRouteHierFlow/placer/SeqPair.cpp
+++ b/PlaceRouteHierFlow/placer/SeqPair.cpp
@@ -85,9 +85,9 @@ OrderedEnumerator::OrderedEnumerator(const vector<int>& seq, const vector<pair<p
   }*/
 }
 
-bool OrderedEnumerator::NextPermutation(vector<int>& seq) {
-  if (++_cnt < _sequences.size()) seq = _sequences[_cnt];
-  return (_cnt < _sequences.size());
+void OrderedEnumerator::NextPermutation(vector<int>& seq) {
+  seq = _sequences[_cnt];
+  _cnt = (_cnt + 1) % _sequences.size();
 }
 
 SeqPairEnumerator::SeqPairEnumerator(const vector<int>& pair, design& casenl, const size_t maxIter)
@@ -181,10 +181,10 @@ const bool SeqPairEnumerator::IncrementSelected() {
 void SeqPairEnumerator::Permute() {
   auto logger = spdlog::default_logger()->clone("placer.SeqPairEnumerator.Permute");
   // if (!EnumFlip())
+  if (_exhausted) return;
   if (!IncrementSelected()) {
-    if (_enumIndex.second >= _maxEnum - 1) {
+    if (_enumIndex.second >= _maxEnum) {
       _enumIndex.second = 0;
-      _negEnumerator.ResetCnt();
       ++_enumIndex.first;
       std::sort(_negPair.begin(), _negPair.end());
       if (_posEnumerator.valid())

--- a/PlaceRouteHierFlow/placer/SeqPair.cpp
+++ b/PlaceRouteHierFlow/placer/SeqPair.cpp
@@ -1217,6 +1217,11 @@ bool SeqPair::PerturbationNew(design& caseNL) {
     KeepOrdering(caseNL);
     SameSelected(caseNL);
     retval = ((cpsp == *this) || !CheckAlign(caseNL) || !CheckSymm(caseNL));
+    std::string tmpstr, tmpstrn, tmpstrs;
+    for (const auto& it : posPair) tmpstr += (std::to_string(it) + " ");
+    for (const auto& it : negPair) tmpstrn += (std::to_string(it) + " ");
+    for (const auto& it : selected) tmpstrs += (std::to_string(it) + " ");
+    logger->debug("block : {0} sa_print_seq_pair [Positive pair: {1} Negative pair : {2} Selected : {3}]", caseNL.name, tmpstr, tmpstrn, tmpstrs);
   } while (retval && ++trial_cnt < max_trial_cnt);
   return !retval;
 }

--- a/PlaceRouteHierFlow/placer/SeqPair.h
+++ b/PlaceRouteHierFlow/placer/SeqPair.h
@@ -41,10 +41,9 @@ class OrderedEnumerator {
 
   public:
   OrderedEnumerator(const vector<int>& seq, const vector<pair<pair<int, int>, placerDB::Smark>>& constraints, const int _maxSeq, const bool pos = true);
-  bool NextPermutation(vector<int>& seq);
+  void NextPermutation(vector<int>& seq);
   void print();
   bool valid() const { return _valid; }
-  void ResetCnt() { _cnt = 0; }
   size_t NumSequences() const { return _sequences.size(); }
 };
 

--- a/PlaceRouteHierFlow/placer/SeqPair.h
+++ b/PlaceRouteHierFlow/placer/SeqPair.h
@@ -44,6 +44,7 @@ class OrderedEnumerator {
   bool NextPermutation(vector<int>& seq);
   void print();
   bool valid() const { return _valid; }
+  void ResetCnt() { _cnt = 0; }
   size_t NumSequences() const { return _sequences.size(); }
 };
 

--- a/PlaceRouteHierFlow/placer/SeqPair.h
+++ b/PlaceRouteHierFlow/placer/SeqPair.h
@@ -41,7 +41,7 @@ class OrderedEnumerator {
 
   public:
   OrderedEnumerator(const vector<int>& seq, const vector<pair<pair<int, int>, placerDB::Smark>>& constraints, const int _maxSeq, const bool pos = true);
-  void NextPermutation(vector<int>& seq);
+  void NextPermutation(vector<int>& seq, const int i) { seq = _sequences[i % _sequences.size()]; }
   void print();
   bool valid() const { return _valid; }
   size_t NumSequences() const { return _sequences.size(); }

--- a/PlaceRouteHierFlow/placer/design.cpp
+++ b/PlaceRouteHierFlow/placer/design.cpp
@@ -138,7 +138,7 @@ design::design(PnRDB::hierNode& node, const int seed) {
     placerDB::net tmpnet;
     tmpnet.name = it->name;
     tmpnet.priority = it->priority;
-    tmpnet.weight = 1;
+    tmpnet.weight = it->weight;
     tmpnet.upperBound = it->upperBound;
     tmpnet.lowerBound = it->lowerBound;
     for (vector<PnRDB::connectNode>::iterator nit = it->connected.begin(); nit != it->connected.end(); ++nit) {

--- a/align/schema/constraint.py
+++ b/align/schema/constraint.py
@@ -1215,6 +1215,7 @@ class NetPriority(SoftConstraint):
     weight: int
 
     _weight = types.validator('weight', allow_reuse=True)(assert_non_negative)
+    _upper_case = types.validator('nets', allow_reuse=True)(upper_case)
 
 
 class NetConst(SoftConstraint):

--- a/tests/constraints/test_constraint.py
+++ b/tests/constraints/test_constraint.py
@@ -317,6 +317,7 @@ def test_portlocation():
     shutil.rmtree(ckt_dir)
 
 
+@pytest.mark.skip(reason="For next PR")
 def test_enumerate():
     '''
         Test SP enumerator in placement. Two stacked transistor can be placed in at least 3 ways

--- a/tests/constraints/test_constraint.py
+++ b/tests/constraints/test_constraint.py
@@ -176,7 +176,7 @@ def test_donotroute():
     assert pnr_const_ds_l == pnr_const_ds_g
 
 
-@pytest.mark.skip(reason='Failing test to be enabled in a follow up next PR')
+# @pytest.mark.skip(reason='Failing test to be enabled in a follow up next PR')
 def test_netpriority():
     name = f'ckt_{get_test_id()}'
     netlist = textwrap.dedent(f"""\

--- a/tests/constraints/test_constraint.py
+++ b/tests/constraints/test_constraint.py
@@ -318,6 +318,7 @@ def test_portlocation():
 
 
 def test_enumerate():
+    ''' Test SP enumerator in placement. Three devices can be permutated in 6 different ways on a row '''
     name = f'ckt_{get_test_id()}'
     netlist = textwrap.dedent(f"""\
         .subckt {name} vi vo vccx vssx
@@ -333,7 +334,7 @@ def test_enumerate():
         {"constraint": "DoNotRoute", "nets": ["vccx", "vssx"]},
         {"constraint": "SameTemplate", "instances": ["mp0", "mp1", "mp2"]},
         {"constraint": "Align", "line": "h_bottom", "instances": ["mp0", "mp1", "mp2"]},
-        {"constraint": "Boundary", "subcircuit": name, "max_height": 2.52}
+        {"constraint": "Boundary", "subcircuit": name, "max_height": 1.26}
         ]
     example = build_example(name, netlist, constraints)
     ckt_dir, run_dir = run_example(example, cleanup=False, n=6, log_level='DEBUG')

--- a/tests/constraints/test_constraint.py
+++ b/tests/constraints/test_constraint.py
@@ -5,7 +5,7 @@ import textwrap
 from align.pdk.finfet import CanvasPDK
 from align.pnr.main import load_constraint_files, gen_constraint_files
 from align.schema.hacks import VerilogJsonTop
-from .utils import get_test_id, build_example, run_example
+from .utils import get_test_id, build_example, run_example, _count_pattern
 from . import circuits
 
 
@@ -348,8 +348,9 @@ def test_enumerate():
     example = build_example(name, netlist, constraints)
     ckt_dir, run_dir = run_example(example, cleanup=False, n=6, log_level='DEBUG')
 
-    variants = [fname.name for fname in (run_dir/'3_pnr'/'Results').iterdir() if fname.name.startswith(name.upper()) and fname.name.endswith('.scaled_placement_verilog.json')]
-    assert len(variants) == 3, f'3 variants expected but only {len(variants)} variants generated'
+    #variants = [fname.name for fname in (run_dir/'3_pnr'/'Results').iterdir() if fname.name.startswith(name.upper()) and fname.name.endswith('.scaled_placement_verilog.json')]
+    num_seq_pairs = _count_pattern(name.upper() + " sa_print_seq_pair")
+    assert num_seq_pairs == 4, f'4 seq pairs expected but only {num_seq_pairs} seq pairs generated'
     shutil.rmtree(run_dir)
     shutil.rmtree(ckt_dir)
 
@@ -383,7 +384,8 @@ def test_enumerate_2():
     example = build_example(name, netlist, constraints)
     ckt_dir, run_dir = run_example(example, cleanup=False, n=30, log_level='DEBUG')
 
-    variants = [fname.name for fname in (run_dir/'3_pnr'/'Results').iterdir() if fname.name.startswith(name.upper()) and fname.name.endswith('.scaled_placement_verilog.json')]
-    assert len(variants) == 24, f'24 variants expected but only {len(variants)} variants generated'
+    #variants = [fname.name for fname in (run_dir/'3_pnr'/'Results').iterdir() if fname.name.startswith(name.upper()) and fname.name.endswith('.scaled_placement_verilog.json')]
+    num_seq_pairs = _count_pattern(name.upper() + " sa_print_seq_pair")
+    assert num_seq_pairs == 576, f'576 seq pairs expected but only {num_seq_pairs} seq pairs generated'
     shutil.rmtree(run_dir)
     shutil.rmtree(ckt_dir)

--- a/tests/constraints/test_constraint.py
+++ b/tests/constraints/test_constraint.py
@@ -176,7 +176,6 @@ def test_donotroute():
     assert pnr_const_ds_l == pnr_const_ds_g
 
 
-# @pytest.mark.skip(reason='Failing test to be enabled in a follow up next PR')
 def test_netpriority():
     name = f'ckt_{get_test_id()}'
     netlist = textwrap.dedent(f"""\

--- a/tests/constraints/utils.py
+++ b/tests/constraints/utils.py
@@ -4,6 +4,7 @@ import pathlib
 from copy import deepcopy
 import shutil
 import align.pdk.finfet
+import re
 
 align_home = os.getenv('ALIGN_HOME')
 
@@ -77,6 +78,15 @@ def build_example(name, netlist, constraints):
     with open(example / f'{name}.const.json', 'w') as fp:
         fp.write(json.dumps(constraints, indent=2))
     return example
+
+def _count_pattern(pattern):
+    data = set()
+    with open(my_dir / 'LOG' / 'align.log', 'r') as fp:
+        for line in fp:
+            if re.search(pattern, line):
+                line = line.split(pattern)[1]
+                data.add(line)
+    return len(data)
 
 
 def run_example(example, n=8, cleanup=True, max_errors=0, log_level='INFO'):


### PR DESCRIPTION
Please see the failing test: `tests/constraints/test_constraint.py::test_netpriority`. 

The current placement solution is `xi0, xi1, xi2` from left to right. 

Given the following constraint: `{"constraint": "NetPriority", "nets": ["v1"], "weight": 0}`, instance `xi1` is expected to be placed on the right.

