### PR TITLE
Open in Unit Test 

### DIFF
--- a/PlaceRouteHierFlow/router/A_star.cpp
+++ b/PlaceRouteHierFlow/router/A_star.cpp
@@ -1249,7 +1249,7 @@ void A_star::erase_candidate_node(std::set<int> &Close_set, std::vector<int> &ca
 std::vector<std::vector<int>> A_star::A_star_algorithm_Sym(Grid &grid, int left_up, int right_down, vector<RouterDB::Metal> &sym_path) {
   auto logger = spdlog::default_logger()->clone("router.A_star.A_star_algorithm_Sym");
 
-  int via_expand_effort = 100;
+  int via_expand_effort = 0;
   std::set<std::pair<int, int>, RouterDB::pairComp> L_list;
   std::set<int> close_set;
   std::pair<int, int> temp_pair;
@@ -1293,12 +1293,26 @@ std::vector<std::vector<int>> A_star::A_star_algorithm_Sym(Grid &grid, int left_
       continue;
     }
 
-    close_set.insert(current_node);
+    //close_set.insert(current_node);
 
     // found the candidates nodes
     std::vector<int> candidate_node;
     bool near_node_exist = found_near_node(current_node, grid, candidate_node);
+
+    if(current_node==248){
+       for(auto it: candidate_node){
+          std::cout<<"expanded node "<<current_node<<" parents "<<grid.vertices_total[current_node].parent<<" "<<it<<" "<<grid.vertices_total[it].metal<<" "<<grid.vertices_total[it].x<<" "<<grid.vertices_total[it].y<<std::endl;
+       }
+    }
+
     erase_candidate_node(close_set, candidate_node);
+
+    if(current_node==248){
+       for(auto it: candidate_node){
+          std::cout<<"nodes after erase "<<current_node<<" parents "<<grid.vertices_total[current_node].parent<<" "<<it<<" "<<grid.vertices_total[it].metal<<" "<<grid.vertices_total[it].x<<" "<<grid.vertices_total[it].y<<std::endl;
+       }
+    }
+
     if (!near_node_exist) {
       continue;
     }
@@ -1319,6 +1333,12 @@ std::vector<std::vector<int>> A_star::A_star_algorithm_Sym(Grid &grid, int left_
 
     candidate_node = temp_candidate_node;
 
+    if(current_node==248){
+       for(auto it: candidate_node){
+          std::cout<<"nodes after parallel "<<current_node<<" parents "<<grid.vertices_total[current_node].parent<<" "<<it<<" "<<grid.vertices_total[it].metal<<" "<<grid.vertices_total[it].x<<" "<<grid.vertices_total[it].y<<std::endl;
+       }
+    }
+
     if (candidate_node.size() == 0) {
       // grid.vertices_total[current_node].Cost = INT_MAX;
       continue;
@@ -1333,7 +1353,8 @@ std::vector<std::vector<int>> A_star::A_star_algorithm_Sym(Grid &grid, int left_
       int temp_cost = grid.vertices_total[current_node].Cost + abs(grid.vertices_total[current_node].x - grid.vertices_total[candidate_node[i]].x) +
                       abs(grid.vertices_total[current_node].y - grid.vertices_total[candidate_node[i]].y) +
                       via_expand_effort * abs(grid.vertices_total[candidate_node[i]].metal - grid.vertices_total[current_node].metal) + temp_candidate_cost[i];
-      if (temp_cost < grid.vertices_total[candidate_node[i]].Cost) {
+      //if (temp_cost < grid.vertices_total[candidate_node[i]].Cost) {
+      if (1) {
         int sym_cost = Find_Symmetry_Cost(grid, candidate_node[i], sym_path);
         // std::cout<<"sym cost "<<sym_cost<<" sym path size "<<sym_path.size()<<std::endl;
         int sym_factor = 0;

--- a/PlaceRouteHierFlow/router/A_star.cpp
+++ b/PlaceRouteHierFlow/router/A_star.cpp
@@ -1325,7 +1325,10 @@ std::vector<std::vector<int>> A_star::A_star_algorithm_Sym(Grid &grid, int left_
     }
 
     // std::vector<int> expand_candidate_node;
+    std::cout<<"current node "<<current_node<<" "<<grid.vertices_total[current_node].metal<<" "<<grid.vertices_total[current_node].x<<" "<<grid.vertices_total[current_node].y<<std::endl;
+
     for (int i = 0; i < (int)candidate_node.size(); i++) {
+      std::cout<<"expand node "<<candidate_node[i]<<" "<<grid.vertices_total[candidate_node[i]].metal<<" "<<grid.vertices_total[candidate_node[i]].x<<" "<<grid.vertices_total[candidate_node[i]].y<<std::endl;
       int M_dis = Manhattan_distan(candidate_node[i], grid);
       int temp_cost = grid.vertices_total[current_node].Cost + abs(grid.vertices_total[current_node].x - grid.vertices_total[candidate_node[i]].x) +
                       abs(grid.vertices_total[current_node].y - grid.vertices_total[candidate_node[i]].y) +

--- a/PlaceRouteHierFlow/router/A_star.h
+++ b/PlaceRouteHierFlow/router/A_star.h
@@ -64,7 +64,7 @@ class A_star {
   int trace_back_node_parent(int current_node, Grid &grid, std::set<int> &source_index);
   std::vector<std::vector<int>> GetPath();
   bool expand_node_ud(int direction, std::vector<int> &temp_node, Grid &grid);
-  void erase_candidate_node(std::set<int> &Close_set, std::vector<int> &candidate);
+  void erase_candidate_node(std::set<int> &Close_set, std::vector<int> &candidate, Grid &grid);
   bool Pre_trace_back(Grid &grid, int current_node, int left, int right, std::set<int> &src_index, std::set<int> &dest_index);
   void rm_cycle_path(std::vector<std::vector<int>> &Node_Path);
   void lable_father(Grid &grid, std::vector<std::vector<int>> &Node_Path);

--- a/PlaceRouteHierFlow/router/GcellDetailRouter.cpp
+++ b/PlaceRouteHierFlow/router/GcellDetailRouter.cpp
@@ -400,7 +400,7 @@ void GcellDetailRouter::create_detailrouter_new() {
           //grid.CreateGridData_new();
           get_internal_metal_via();
           generate_set_data(Set_x);
-          assert(0);
+          //assert(0);
          }
         
         std::vector<std::vector<RouterDB::Metal>> physical_path;

--- a/PlaceRouteHierFlow/router/GcellDetailRouter.cpp
+++ b/PlaceRouteHierFlow/router/GcellDetailRouter.cpp
@@ -394,7 +394,7 @@ void GcellDetailRouter::create_detailrouter_new() {
         // bool pathMark = a_star.FindFeasiblePath(grid, this->path_number, 0, 0);
         bool pathMark = a_star.FindFeasiblePath_sym(grid, this->path_number, 0, 0, symmetry_path);
         // std::cout<<"performing detailed router on debug 1"<<std::endl;
-        /*
+        
         if(pathMark==0){
           grid.CreateGridData();
           //grid.CreateGridData_new();
@@ -402,7 +402,7 @@ void GcellDetailRouter::create_detailrouter_new() {
           generate_set_data(Set_x);
           assert(0);
          }
-        */
+        
         std::vector<std::vector<RouterDB::Metal>> physical_path;
         std::vector<std::vector<int>> extend_labels;
         Update_rouer_report_info(temp_routing_net, i, j, pathMark);

--- a/PlaceRouteHierFlow/router/Rdatatype.h
+++ b/PlaceRouteHierFlow/router/Rdatatype.h
@@ -91,6 +91,7 @@ struct vertex {
   int y = -1;
   int metal = -1;
   int Cost = INT_MAX;
+  int reopen = 1;
   // int Cost = -1;
   bool active = false;
   bool via_active_down = true;

--- a/tests/pnr/test_router.py
+++ b/tests/pnr/test_router.py
@@ -13,7 +13,6 @@ def test_ru_zero():
     run_postamble(name, cv, max_errors=0)
 
 
-@pytest.mark.skip(reason='This test is failing. Enable in a future PR after refactoring')
 def test_ru_1():
     name = get_test_id()
     cv = CanvasPDK()


### PR DESCRIPTION
`test_router.py::test_ru_1` fails due to an open. This scenario happens when tracks of primitives do not align after placement. A feasible route, annotated below, exists by going up from M1 to M3 and down to M1:

![image](https://user-images.githubusercontent.com/56893713/157551146-73b1f5b3-43ac-4d51-8d55-0b3a612e80cb.png)
