### PR TITLE
Rename MatchBlocks to PlaceCloser

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,7 +25,7 @@ jobs:
     environment:
       ALIGN_HOME: /root/ALIGN-public
       ALIGN_WORK_DIR: /root/ALIGN-public/work
-      MAX_JOBS: 2 # number of vCPUs (2)
+      MAX_JOBS: 4 # number of vCPUs (2)
 
     steps:
       - run:
@@ -95,7 +95,7 @@ jobs:
     environment:
       ALIGN_HOME: /root/ALIGN-public
       ALIGN_WORK_DIR: /root/ALIGN-public/work
-      MAX_JOBS: 2
+      MAX_JOBS: 4
 
     steps:
       - run:
@@ -154,7 +154,7 @@ jobs:
     environment:
       ALIGN_HOME: /root/ALIGN-public
       ALIGN_WORK_DIR: /root/ALIGN-public/work
-      MAX_JOBS: 2
+      MAX_JOBS: 4
 
     steps:
       - run:

--- a/PlaceRouteHierFlow/placer/ILP_solver.cpp
+++ b/PlaceRouteHierFlow/placer/ILP_solver.cpp
@@ -1980,6 +1980,35 @@ bool ILP_solver::FrameSolveILPSymphony(const design& mydesign, const SeqPair& cu
     }
   }
 
+  // matchblock
+  for(auto pair:mydesign.Match_blocks){
+    int i_pos_index = find(curr_sp.posPair.begin(), curr_sp.posPair.end(), pair.blockid1) - curr_sp.posPair.begin();
+    int i_neg_index = find(curr_sp.negPair.begin(), curr_sp.negPair.end(), pair.blockid1) - curr_sp.negPair.begin();
+    int j_pos_index = find(curr_sp.posPair.begin(), curr_sp.posPair.end(), pair.blockid2) - curr_sp.posPair.begin();
+    int j_neg_index = find(curr_sp.negPair.begin(), curr_sp.negPair.end(), pair.blockid2) - curr_sp.negPair.begin();
+    if (i_pos_index < j_pos_index) {
+      if (i_neg_index < j_neg_index) {
+        // i is left of j
+        objective.at(pair.blockid1 * 4) += -1;
+        objective.at(pair.blockid2 * 4) += 1;
+      } else {
+        // i is above j
+        objective.at(pair.blockid1 * 4 + 1) += 1;
+        objective.at(pair.blockid2 * 4 + 1) += -1;
+      }
+    } else {
+      if (i_neg_index < j_neg_index) {
+        // i is below j
+        objective.at(pair.blockid1 * 4 + 1) += -1;
+        objective.at(pair.blockid2 * 4 + 1) += 1;
+      } else {
+        // i is right of j
+        objective.at(pair.blockid1 * 4) += 1;
+        objective.at(pair.blockid2 * 4) += -1;
+      }
+    }
+  }
+  
   // overlap constraint
   for (unsigned int i = 0; i < mydesign.Blocks.size(); i++) {
     int i_pos_index = find(curr_sp.posPair.begin(), curr_sp.posPair.end(), i) - curr_sp.posPair.begin();

--- a/PlaceRouteHierFlow/placer/PlacerIfc.cpp
+++ b/PlaceRouteHierFlow/placer/PlacerIfc.cpp
@@ -8,7 +8,7 @@
 
 double Pdatatype::LAMBDA=1.;
 double Pdatatype::GAMAR=30;
-double Pdatatype::BETA=0.1;
+double Pdatatype::BETA=0.5;
 double Pdatatype::SIGMA=1000;
 double Pdatatype::PHI=0.05;
 double Pdatatype::PI=0.05;

--- a/align/schema/constraint.py
+++ b/align/schema/constraint.py
@@ -725,11 +725,12 @@ class CreateAlias(SoftConstraint):
     name: str
 
 
-class MatchBlocks(SoftConstraint):
+class PlaceCloser(SoftConstraint):
     '''
-    TODO: Can be replicated by Enclose??
+        `instances` are preferred to be placed closer.
     '''
     instances: List[str]
+    _inst_validator = types.validator('instances', allow_reuse=True)(validate_instances)
 
 
 class PowerPorts(SoftConstraint):
@@ -1232,7 +1233,7 @@ ConstraintType = Union[
     SameTemplate,
     CreateAlias,
     GroupBlocks,
-    MatchBlocks,
+    PlaceCloser,
     DoNotIdentify,
     PlaceOnGrid,
     BlockDistance,

--- a/tests/constraints/test_constraint.py
+++ b/tests/constraints/test_constraint.py
@@ -223,8 +223,7 @@ def test_netpriority():
     shutil.rmtree(ckt_dir)
 
 
-@pytest.mark.skip(reason='Failing test to be enabled in a follow up next PR')
-def test_matchblocks():
+def test_placecloser():
     name = f'ckt_{get_test_id()}'
     netlist = textwrap.dedent(f"""\
         .subckt inv vi vo vccx vssx
@@ -248,7 +247,7 @@ def test_matchblocks():
         {"constraint": "DoNotRoute", "nets": ["vccx", "vssx"]},
         {"constraint": "SameTemplate", "instances": ["xi1", "xi2"]},
         {"constraint": "Align", "line": "h_bottom", "instances": ["xi0", "xi1", "xi2"]},
-        {"constraint": "MatchBlocks", "instances": ["xi1", "xi2"]}
+        {"constraint": "PlaceCloser", "instances": ["xi1", "xi2"]}
         ]
     example = build_example(name, netlist, constraints)
     ckt_dir, run_dir = run_example(example, cleanup=False)


### PR DESCRIPTION
This PR:
- Renames MatchBlocks for user to PlaceCloser (still translated to MatchBlocks for pnr)
- PlaceCloser supports multiple instances
- Add a test for functionality

Failing test: `tests/constraints/test_constraint.py::test_placecloser`