### PR TITLE
Removed infinite loop from KeepOrdering

### DIFF
--- a/PlaceRouteHierFlow/placer/SeqPair.cpp
+++ b/PlaceRouteHierFlow/placer/SeqPair.cpp
@@ -497,7 +497,8 @@ SeqPair::SeqPair(design& caseNL, const size_t maxIter) {
     }
   }
 
-  KeepOrdering(caseNL);
+  bool ok = KeepOrdering(caseNL);
+  assert(ok);
   SameSelected(caseNL);
 
   _seqPairEnum = std::make_shared<SeqPairEnumerator>(posPair, caseNL, maxIter);
@@ -628,16 +629,6 @@ bool SeqPair::ValidateSelect(design & caseNL){
   // }
   return true;
 }**/
-
-struct VectorHasher {
-    int operator()(const vector<int> &V) const {
-        int hash = V.size();
-        for(auto &i : V) {
-            hash ^= i + 0x9e3779b9 + (hash << 6) + (hash >> 2);
-        }
-        return hash;
-    }
-};
 
 bool SeqPair::KeepOrdering(design& caseNL) {
   auto logger = spdlog::default_logger()->clone("placer.SeqPair.KeepOrdering");
@@ -1271,7 +1262,9 @@ bool SeqPair::PerturbationNew(design& caseNL) {
         fail++;
       }
     }
-    KeepOrdering(caseNL);
+    bool ok = KeepOrdering(caseNL);
+    assert(ok);
+
     SameSelected(caseNL);
     retval = ((cpsp == *this) || !CheckAlign(caseNL) || !CheckSymm(caseNL));
     std::string tmpstr, tmpstrn, tmpstrs;

--- a/PlaceRouteHierFlow/placer/SeqPair.h
+++ b/PlaceRouteHierFlow/placer/SeqPair.h
@@ -117,7 +117,7 @@ class SeqPair {
   void TestSwap();
   int GetBlockSelected(int blockNo);
   bool ChangeSelectedBlock(design& caseNL);
-  void KeepOrdering(design& caseNL);
+  bool KeepOrdering(design& caseNL);
   //bool ValidateSelect(design& caseNL);
   void CompactSeq();
 

--- a/PlaceRouteHierFlow/placer/SeqPair.h
+++ b/PlaceRouteHierFlow/placer/SeqPair.h
@@ -28,6 +28,16 @@ using std::string;
 using std::swap;
 using std::vector;
 
+struct VectorHasher {
+    int operator()(const vector<int> &V) const {
+        int hash = V.size();
+        for(auto &i : V) {
+            hash ^= i + 0x9e3779b9 + (hash << 6) + (hash >> 2);
+        }
+        return hash;
+    }
+};
+
 class OrderedEnumerator {
   private:
   vector<vector<int>> _sequences;

--- a/PlaceRouteHierFlow/placer/unit_tests.cpp
+++ b/PlaceRouteHierFlow/placer/unit_tests.cpp
@@ -4,6 +4,10 @@
 #include "SeqPair.h"
 #include "design.h"
 
+#include <vector>
+#include <set>
+#include <unordered_set>
+
 TEST(PlacerTest, True) {
     EXPECT_TRUE( 1);
 };
@@ -11,6 +15,70 @@ TEST(PlacerTest, True) {
 TEST(PlacerTest, False) {
     EXPECT_FALSE( 0);
 };
+
+TEST(PlacerTest, VectorHasherTest) {
+  std::vector<int> a = {0, 1, 3};
+  std::vector<int> b = {0, 3, 1};
+
+  
+  VectorHasher vh;
+
+  EXPECT_TRUE(vh(a) != vh(b));
+};
+
+
+TEST(PlacerTest, UnorderedSetOfVecOfInt) {
+
+  std::unordered_set<std::vector<int>,VectorHasher> s;
+
+  std::vector<int> a = {0, 1, 3};
+  std::vector<int> b = {0, 3, 1};
+
+  s.insert(a);
+  s.insert(b);
+    
+  s.insert(a);
+
+  EXPECT_TRUE(s.find(a) != s.end());
+
+  EXPECT_TRUE(s.find(b) != s.end());
+
+  s.erase(a);
+
+  EXPECT_TRUE(s.find(a) == s.end());
+
+  s.erase(b);
+
+  EXPECT_TRUE(s.find(b) == s.end());
+
+};
+
+TEST(PlacerTest, SetOfVecOfInt) {
+
+  std::set<std::vector<int> > s;
+
+  std::vector<int> a = {0, 1, 3};
+  std::vector<int> b = {0, 3, 1};
+
+  s.insert(a);
+  s.insert(b);
+    
+  s.insert(a);
+
+  EXPECT_TRUE(s.find(a) != s.end());
+
+  EXPECT_TRUE(s.find(b) != s.end());
+
+  s.erase(a);
+
+  EXPECT_TRUE(s.find(a) == s.end());
+
+  s.erase(b);
+
+  EXPECT_TRUE(s.find(b) == s.end());
+
+};
+
 
 TEST(SeqPairTest, Constructor) {
     spdlog::set_level(spdlog::level::debug);

--- a/PlaceRouteHierFlow/placer/unit_tests.cpp
+++ b/PlaceRouteHierFlow/placer/unit_tests.cpp
@@ -187,7 +187,7 @@ TEST(SeqPairTest, KeepOrderingCorrectStartingOrder) {
       d.Ordering_Constraints.push_back(make_pair(ordering, placerDB::H));
     }
 
-    sp.KeepOrdering(d);
+    EXPECT_TRUE(sp.KeepOrdering(d));
 
     spdlog::set_level(save_level);
 
@@ -242,7 +242,7 @@ TEST(SeqPairTest, DISABLED_KeepOrdering) {
       d.Ordering_Constraints.push_back(make_pair(ordering, placerDB::H));
     }
 
-    sp.KeepOrdering(d);
+    EXPECT_TRUE(sp.KeepOrdering(d));
 
     spdlog::set_level(save_level);
 

--- a/PlaceRouteHierFlow/unit_tests.cpp
+++ b/PlaceRouteHierFlow/unit_tests.cpp
@@ -12,6 +12,10 @@
 #include <cstdlib>
 #include <sstream>
 
+#include <vector>
+#include <unordered_set>
+#include <set>
+
 using std::string;
 using std::cout;
 using std::endl;
@@ -20,4 +24,72 @@ using namespace nlohmann;
 
 TEST(PnRTest, True) {
   EXPECT_TRUE( 1);
+};
+
+struct VectorHasher {
+    int operator()(const vector<int> &V) const {
+        int hash = V.size();
+        for(auto &i : V) {
+            hash ^= i + 0x9e3779b9 + (hash << 6) + (hash >> 2);
+        }
+        return hash;
+    }
+};
+
+TEST(PnRTest, UnorderedSetOfVecOfInt) {
+
+  std::unordered_set<std::vector<int>,VectorHasher> s;
+
+  std::vector<int> a = {0, 1, 3};
+  std::vector<int> b = {0, 3, 1};
+
+  
+  VectorHasher vh;
+
+  EXPECT_TRUE(vh(a) != vh(b));
+
+
+  s.insert(a);
+  s.insert(b);
+    
+  s.insert(a);
+
+  EXPECT_TRUE(s.find(a) != s.end());
+
+  EXPECT_TRUE(s.find(b) != s.end());
+
+  s.erase(a);
+
+  EXPECT_TRUE(s.find(a) == s.end());
+
+  s.erase(b);
+
+  EXPECT_TRUE(s.find(b) == s.end());
+
+};
+
+TEST(PnRTest, SetOfVecOfInt) {
+
+  std::set<std::vector<int> > s;
+
+  std::vector<int> a = {0, 1, 3};
+  std::vector<int> b = {0, 3, 1};
+
+  s.insert(a);
+  s.insert(b);
+    
+  s.insert(a);
+
+  EXPECT_TRUE(s.find(a) != s.end());
+
+  EXPECT_TRUE(s.find(b) != s.end());
+
+  s.erase(a);
+
+  EXPECT_TRUE(s.find(a) == s.end());
+
+  s.erase(b);
+
+  EXPECT_TRUE(s.find(b) == s.end());
+
 };

--- a/PlaceRouteHierFlow/unit_tests.cpp
+++ b/PlaceRouteHierFlow/unit_tests.cpp
@@ -12,10 +12,6 @@
 #include <cstdlib>
 #include <sstream>
 
-#include <vector>
-#include <unordered_set>
-#include <set>
-
 using std::string;
 using std::cout;
 using std::endl;
@@ -26,70 +22,3 @@ TEST(PnRTest, True) {
   EXPECT_TRUE( 1);
 };
 
-struct VectorHasher {
-    int operator()(const vector<int> &V) const {
-        int hash = V.size();
-        for(auto &i : V) {
-            hash ^= i + 0x9e3779b9 + (hash << 6) + (hash >> 2);
-        }
-        return hash;
-    }
-};
-
-TEST(PnRTest, UnorderedSetOfVecOfInt) {
-
-  std::unordered_set<std::vector<int>,VectorHasher> s;
-
-  std::vector<int> a = {0, 1, 3};
-  std::vector<int> b = {0, 3, 1};
-
-  
-  VectorHasher vh;
-
-  EXPECT_TRUE(vh(a) != vh(b));
-
-
-  s.insert(a);
-  s.insert(b);
-    
-  s.insert(a);
-
-  EXPECT_TRUE(s.find(a) != s.end());
-
-  EXPECT_TRUE(s.find(b) != s.end());
-
-  s.erase(a);
-
-  EXPECT_TRUE(s.find(a) == s.end());
-
-  s.erase(b);
-
-  EXPECT_TRUE(s.find(b) == s.end());
-
-};
-
-TEST(PnRTest, SetOfVecOfInt) {
-
-  std::set<std::vector<int> > s;
-
-  std::vector<int> a = {0, 1, 3};
-  std::vector<int> b = {0, 3, 1};
-
-  s.insert(a);
-  s.insert(b);
-    
-  s.insert(a);
-
-  EXPECT_TRUE(s.find(a) != s.end());
-
-  EXPECT_TRUE(s.find(b) != s.end());
-
-  s.erase(a);
-
-  EXPECT_TRUE(s.find(a) == s.end());
-
-  s.erase(b);
-
-  EXPECT_TRUE(s.find(b) == s.end());
-
-};


### PR DESCRIPTION
Keeps a set of visited permutation vectors.
It now returns whether it found a solution or not.
Need to modify calls to do the right thing if a solution is not found.