### PR TITLE
AlignInOrder and SameTemplate for detected arrays

### DIFF
--- a/align/compiler/create_array_hierarchy.py
+++ b/align/compiler/create_array_hierarchy.py
@@ -220,7 +220,8 @@ class process_arrays:
                         if inst in self.graph]
             if len(h_blocks) > 0:
                 with set_context(self.iconst):
-                    self.iconst.append(constraint.Align(line="h_center", instances=h_blocks))
+                    self.iconst.append(constraint.AlignInOrder(line="bottom", direction="horizontal", instances=h_blocks))
+                    self.iconst.append(constraint.SameTemplate(instances=h_blocks))
             # del self.match_pairs[key]
         logger.debug(f"AlignBlock const update {self.iconst}")
         # hier_keys = [key for key, value in self.match_pairs.items() if "name" in value.keys()]

--- a/tests/pdk/finfet_pdk/circuits.py
+++ b/tests/pdk/finfet_pdk/circuits.py
@@ -241,3 +241,20 @@ def two_stage_ota_differential(name):
         .END
     """)
     return netlist
+
+
+def charge_pump_switch(name):
+    netlist = textwrap.dedent(f"""\
+    .subckt switch ng pg t1 t2 vccx vssx
+    qp0 t1 pg t2 vccx p m=1 nf=2 w=90e-9
+    qn0 t1 ng t2 vssx n m=1 nf=2 w=90e-9
+    .ends
+    .subckt {name} en enb in out vccx vssx
+    """)
+    for i in range(16):
+        netlist += f"isw<{i}> en enb in out vccx vssx switch\n"
+    netlist += textwrap.dedent(f"""\
+    .ends {name}
+    .END
+    """)
+    return netlist


### PR DESCRIPTION
To reduce the placement dimensionality, this PR uses:
- Generates AlignInOrder instead of Align for large arrays
- Generates SameTemplate