### PR TITLE
Query PDK to Find Generator Class

### DIFF
--- a/align/compiler/gen_abstract_name.py
+++ b/align/compiler/gen_abstract_name.py
@@ -4,21 +4,20 @@ Created on Wed Feb 2 13:12:15 2022
 
 @author: kunal
 """
-from statistics import mode
 from align.schema.types import set_context
 import logging
 import pathlib
 
 
 from align.schema import SubCircuit, constraint, Library, Instance
-from align.primitive.main import get_generator
-from .util import gen_key
+from .util import gen_key, get_generator
 
 logger = logging.getLogger(__name__)
 
+
 class PrimitiveLibrary():
 
-    def __init__(self, ckt_lib:Library, pdk_dir: pathlib.Path):
+    def __init__(self, ckt_lib: Library, pdk_dir: pathlib.Path):
         pdk_models = get_generator('pdk_models', pdk_dir)
         self.pdk_dir = pdk_dir
         self.plib = Library(loadbuiltins=False, pdk_models=pdk_models)
@@ -55,7 +54,7 @@ class PrimitiveLibrary():
         return self.plib
 
     def group_cap_subcircuit(self, unit_cap):
-        #TODO hack for group cap, need to be fixed
+        # TODO hack for group cap, need to be fixed
         """create subckt corresponding to unit cap
         Args:
             name (str): unique cap name in constraint
@@ -87,7 +86,7 @@ class PrimitiveLibrary():
         if not self.plib.find(name):
             logger.debug(f"creating subcircuit for {element}")
             with set_context(self.plib):
-                new_subckt = SubCircuit(name=name, pins=list(element.pins.keys()), generator={"name":element.model})
+                new_subckt = SubCircuit(name=name, pins=list(element.pins.keys()), generator={"name": element.model})
             with set_context(new_subckt.elements):
                 new_ele = Instance(name=element.name,
                                    model=element.model,
@@ -125,7 +124,7 @@ class PrimitiveLibrary():
     def add_primitve(self, primitive_name):
         if not self.plib.find(primitive_name):
             primitive = self.ckt_lib.find(primitive_name)
-            #add model for instances in the primitive first
+            # add model for instances in the primitive first
             if isinstance(primitive, SubCircuit):
                 with set_context(self.plib):
                     for e in primitive.elements:
@@ -133,6 +132,3 @@ class PrimitiveLibrary():
                             self.plib.append(self.ckt_lib.find(e.model))
             with set_context(self.plib):
                 self.plib.append(primitive)
-
-
-

--- a/align/compiler/read_library.py
+++ b/align/compiler/read_library.py
@@ -1,7 +1,4 @@
-from operator import sub
 import pathlib
-
-from align.schema.types import set_context
 from ..schema.parser import SpiceParser
 from ..schema.subcircuit import SubCircuit
 from ..schema import constraint

--- a/align/compiler/read_library.py
+++ b/align/compiler/read_library.py
@@ -6,7 +6,7 @@ from ..primitive import main
 
 import logging
 from ..schema.library import Library
-from align.primitive.main import get_generator
+from .util import get_generator
 
 
 logger = logging.getLogger(__name__)

--- a/align/compiler/util.py
+++ b/align/compiler/util.py
@@ -220,10 +220,10 @@ def get_generator(name, pdkdir):
 
     def _find_generator_class(module, name):
         generator_class = getattr(module, "generator_class", False)
-        if generator_class:
+        if generator_class and generator_class(name):
             return generator_class(name)
         else:
-            return getattr(module, name.lower(), False)
+            return getattr(module, name, False) or getattr(module, name.lower(), False)
 
     try:  # is pdk an installed module
         module = importlib.import_module(pdk_dir_stem)

--- a/align/compiler/util.py
+++ b/align/compiler/util.py
@@ -9,6 +9,8 @@ from ..schema import SubCircuit, Model
 import logging
 import pathlib
 import hashlib
+import importlib
+import sys
 
 logger = logging.getLogger(__name__)
 
@@ -144,6 +146,7 @@ def get_ports_weight(G):
             ports_weight[port] = {}
     return ports_weight
 
+
 def gen_key(param):
     """_gen_key
     Creates a hex key for combined transistor params
@@ -157,12 +160,11 @@ def gen_key(param):
     key = f"_{str(int(hashlib.sha256(arg_str.encode('utf-8')).hexdigest(), 16) % 10**8)}"
     return key
 
+
 def create_node_id(G, node1, ports_weight=None):
     in1 = G.nodes[node1].get("instance")
     if in1:
-        properties = {'model':in1.model,
-                      'n_pins':len(set(in1.pins.values()))
-        }
+        properties = {'model': in1.model, 'n_pins': len(set(in1.pins.values()))}
         if in1.parameters:
             properties.update(in1.parameters)
         return gen_key(properties)
@@ -199,10 +201,34 @@ def compare_two_nodes(G, node1: str, node2: str, ports_weight=None):
         DESCRIPTION. True for matching node
 
     """
-    id1 = create_node_id(G,node1, ports_weight=ports_weight)
+    id1 = create_node_id(G, node1, ports_weight=ports_weight)
     id2 = create_node_id(G, node2, ports_weight=ports_weight)
-    return id1 ==id2
+    return id1 == id2
 
 
 def get_primitive_spice():
     return pathlib.Path(__file__).resolve().parent.parent / "config" / "basic_template.sp"
+
+
+def get_generator(name, pdkdir):
+    if pdkdir is None:
+        return False
+    pdk_dir_path = pdkdir
+    if isinstance(pdkdir, str):
+        pdk_dir_path = pathlib.Path(pdkdir)
+    pdk_dir_stem = pdk_dir_path.stem
+
+    try:  # is pdk an installed module
+        module = importlib.import_module(pdk_dir_stem)
+    except ImportError:
+        init_file = pdk_dir_path / '__init__.py'
+        if init_file.is_file():  # is pdk a package
+            spec = importlib.util.spec_from_file_location(pdk_dir_stem, pdk_dir_path / '__init__.py')
+            module = importlib.util.module_from_spec(spec)
+            sys.modules[pdk_dir_stem] = module
+            spec.loader.exec_module(module)
+        else:  # is pdk old school (backward compatibility)
+            spec = importlib.util.spec_from_file_location("primitive", pdkdir / 'primitive.py')
+            module = importlib.util.module_from_spec(spec)
+            spec.loader.exec_module(module)
+    return getattr(module, name, False) or getattr(module, name.lower(), False)

--- a/align/pdk/finfet/__init__.py
+++ b/align/pdk/finfet/__init__.py
@@ -4,3 +4,4 @@ from .transistor_array import MOSGenerator
 from .resistor import *
 from .digital import *
 from .models import *
+from .generators import generator_class

--- a/align/pdk/finfet/digital.py
+++ b/align/pdk/finfet/digital.py
@@ -2,7 +2,7 @@ from .canvas import CanvasPDK
 from align.schema.constraint import PlaceOnGrid, OffsetsScalings
 
 
-class dig22inv(CanvasPDK):
+class StandardCells(CanvasPDK):
 
     def __init__(self, *args, **kwargs):
         super().__init__()

--- a/align/pdk/finfet/gen_param.py
+++ b/align/pdk/finfet/gen_param.py
@@ -1,35 +1,9 @@
-import sys
-import pathlib
 import logging
-import importlib.util
 from copy import deepcopy
 from math import sqrt, floor, log10
+from align.compiler.util import get_generator
 
 logger = logging.getLogger(__name__)
-
-
-def get_generator(name, pdkdir):
-    if pdkdir is None:
-        return False
-    pdk_dir_path = pdkdir
-    if isinstance(pdkdir, str):
-        pdk_dir_path = pathlib.Path(pdkdir)
-    pdk_dir_stem = pdk_dir_path.stem
-
-    try:  # is pdk an installed module
-        module = importlib.import_module(pdk_dir_stem)
-    except ImportError:
-        init_file = pdk_dir_path / '__init__.py'
-        if init_file.is_file():  # is pdk a package
-            spec = importlib.util.spec_from_file_location(pdk_dir_stem, pdk_dir_path / '__init__.py')
-            module = importlib.util.module_from_spec(spec)
-            sys.modules[pdk_dir_stem] = module
-            spec.loader.exec_module(module)
-        else:  # is pdk old school (backward compatibility)
-            spec = importlib.util.spec_from_file_location("primitive", pdkdir / 'primitive.py')
-            module = importlib.util.module_from_spec(spec)
-            spec.loader.exec_module(module)
-    return getattr(module, name, False) or getattr(module, name.lower(), False)
 
 
 def generate_generic(pdkdir, parameters, netlistdir=None):

--- a/align/pdk/finfet/generators.py
+++ b/align/pdk/finfet/generators.py
@@ -1,0 +1,8 @@
+from .digital import StandardCells
+
+
+def generator_class(name):
+    if name.lower().startswith("dig22"):
+        return StandardCells
+    else:
+        return False

--- a/align/pnr/checkers.py
+++ b/align/pnr/checkers.py
@@ -1,9 +1,7 @@
 from ..cell_fabric import transformation, pdk
-from .. import primitive
+from ..compiler.util import get_generator
 import itertools
 import json
-import importlib
-import sys
 import pathlib
 import re
 from .router import NType
@@ -33,7 +31,7 @@ def gen_viewer_json(hN, *, pdkdir, draw_grid=False, global_route_json=None, json
 
     global_power_names = set( [ n.name for n in hN.PowerNets])
 
-    generator = primitive.get_generator('MOSGenerator', pdkdir)
+    generator = get_generator('MOSGenerator', pdkdir)
     # TODO: Remove these hardcoded widths & heights from __init__()
     #       (Height may be okay since it defines UnitCellHeight)
     cnv = generator(pdk.Pdk().load(pdkdir / 'layers.json'),28,12,2,3,1,1,1)

--- a/align/primitive/__init__.py
+++ b/align/primitive/__init__.py
@@ -1,1 +1,1 @@
-from .main import generate_primitives, get_generator, generate_primitive
+from .main import generate_primitives, generate_primitive

--- a/align/primitive/default/canvas.py
+++ b/align/primitive/default/canvas.py
@@ -1,8 +1,6 @@
-import math
 import functools
 
-from ..main import get_generator
-
+from ...compiler.util import get_generator
 from ...cell_fabric.canvas import Canvas
 from ...cell_fabric.generators import *
 from ...cell_fabric.grid import *

--- a/align/primitive/main.py
+++ b/align/primitive/main.py
@@ -3,8 +3,8 @@ from ..cell_fabric import gen_gds_json
 from ..cell_fabric import positive_coord
 from ..cell_fabric import gen_lef
 from ..schema.subcircuit import SubCircuit
+from ..compiler.util import get_generator
 import copy
-import sys
 import datetime
 import pathlib
 import logging
@@ -102,31 +102,6 @@ def generate_Ring(pdkdir, block_name, x_cells, y_cells):
     uc.addRing(x_cells, y_cells)
 
     return uc, ['Body']
-
-
-def get_generator(name, pdkdir):
-    if pdkdir is None:
-        return False
-    pdk_dir_path = pdkdir
-    if isinstance(pdkdir, str):
-        pdk_dir_path = pathlib.Path(pdkdir)
-    pdk_dir_stem = pdk_dir_path.stem
-
-    try:  # is pdk an installed module
-        module = importlib.import_module(pdk_dir_stem)
-    except ImportError:
-        init_file = pdk_dir_path / '__init__.py'
-        if init_file.is_file():  # is pdk a package
-            spec = importlib.util.spec_from_file_location(pdk_dir_stem, pdk_dir_path / '__init__.py')
-            module = importlib.util.module_from_spec(spec)
-            sys.modules[pdk_dir_stem] = module
-            spec.loader.exec_module(module)
-        else:  # is pdk old school (backward compatibility)
-            print(f"check {pdkdir/'primitive.py'}")
-            spec = importlib.util.spec_from_file_location("primitive", pdkdir / 'primitive.py')
-            module = importlib.util.module_from_spec(spec)
-            spec.loader.exec_module(module)
-    return getattr(module, name, False) or getattr(module, name.lower(), False)
 
 
 def generate_generic(pdkdir, parameters, netlistdir=None):

--- a/align/primitive/main.py
+++ b/align/primitive/main.py
@@ -106,6 +106,9 @@ def generate_Ring(pdkdir, block_name, x_cells, y_cells):
 
 def generate_generic(pdkdir, parameters, netlistdir=None):
     primitive1 = get_generator(parameters["real_inst_type"], pdkdir)
+    if "values" not in parameters:
+        parameters["values"] = dict()
+    parameters["values"]["model"] = "real_inst_type"
     uc = primitive1()
     uc.generate(
         ports=parameters["ports"],

--- a/tests/compiler/test_get_generator.py
+++ b/tests/compiler/test_get_generator.py
@@ -1,25 +1,31 @@
 import os
-import json
 import pathlib
-from align.primitive import main
+from align.compiler.util import get_generator
 
 my_dir = pathlib.Path(__file__).resolve().parent
 
 
-def test_one(): # backward compatibility
+def test_one():  # backward compatibility
     name = "return_from_pdk"
     pdk_dir = pathlib.Path(os.getenv('ALIGN_HOME'))/'tests/primitive_pdks'/'sample_pdk'
-    func = main.get_generator(name, pdk_dir)
+    func = get_generator(name, pdk_dir)
     assert func()
 
-def test_two(): # import from package
-    name = "return_from_package"
+
+def test_two():  # import from package
     pdk_dir = pathlib.Path(os.getenv('ALIGN_HOME'))/'tests/primitive_pdks'/'sample_package'
-    func = main.get_generator(name, pdk_dir)
-    assert func()
+
+    name = "abc"
+    func = get_generator(name, pdk_dir)
+    assert func
+
+    name = "no_such_class"
+    func = get_generator(name, pdk_dir)
+    assert not func
+
 
 def test_three():  # import from installed package
     name = "import_module"
     pdk_dir = "importlib"
-    func = main.get_generator(name, pdk_dir)
+    func = get_generator(name, pdk_dir)
     assert func is not None

--- a/tests/compiler/test_get_generator.py
+++ b/tests/compiler/test_get_generator.py
@@ -2,6 +2,7 @@ import os
 import pathlib
 from align.compiler.util import get_generator
 
+
 my_dir = pathlib.Path(__file__).resolve().parent
 
 
@@ -15,11 +16,15 @@ def test_one():  # backward compatibility
 def test_two():  # import from package
     pdk_dir = pathlib.Path(os.getenv('ALIGN_HOME'))/'tests/primitive_pdks'/'sample_package'
 
-    name = "abc"
+    name = "a_class"
     func = get_generator(name, pdk_dir)
     assert func
 
-    name = "no_such_class"
+    name = "a_method"
+    func = get_generator(name, pdk_dir)
+    assert func
+
+    name = "no_such_thing"
     func = get_generator(name, pdk_dir)
     assert not func
 

--- a/tests/pdk/finfet_pdk/test_circuits.py
+++ b/tests/pdk/finfet_pdk/test_circuits.py
@@ -269,7 +269,7 @@ def test_cs_1():
         """)
     constraints = []
     example = build_example(name, netlist, constraints)
-    run_example(example, cleanup=False, log_level=LOG_LEVEL)
+    run_example(example, cleanup=CLEANUP, log_level=LOG_LEVEL)
 
 
 def test_cs_2():
@@ -282,7 +282,7 @@ def test_cs_2():
         """)
     constraints = [{"constraint": "MultiConnection", "nets": ["vop"], "multiplier": 2}]
     example = build_example(name, netlist, constraints)
-    run_example(example, cleanup=False, log_level=LOG_LEVEL)
+    run_example(example, cleanup=CLEANUP, log_level=LOG_LEVEL)
 
 
 def test_charge_pump_switch():

--- a/tests/pdk/finfet_pdk/test_circuits_partial_routing.py
+++ b/tests/pdk/finfet_pdk/test_circuits_partial_routing.py
@@ -3,7 +3,7 @@ import textwrap
 from .utils import get_test_id, build_example, run_example
 from . import circuits
 
-CLEANUP = False
+CLEANUP = True
 BYPASS_ERRORS = True
 
 

--- a/tests/pdk/finfet_pdk/test_generator.py
+++ b/tests/pdk/finfet_pdk/test_generator.py
@@ -1,11 +1,11 @@
-from align.primitive import main
+from align.compiler.util import get_generator
 from .utils import pdk_dir, export_to_viewer
 
 
 def test_example():
     name = "tfr_prim"
     try:
-        primitive_generator = main.get_generator(name, pdk_dir)
+        primitive_generator = get_generator(name, pdk_dir)
         data = primitive_generator().generate(
             ports=['p', 'n'],
             netlist_parameters={'w': '1e-6', 'l': '1e-6'},

--- a/tests/pdk/finfet_pdk/test_identification.py
+++ b/tests/pdk/finfet_pdk/test_identification.py
@@ -1,7 +1,11 @@
 import json
 import pytest
 import textwrap
+import shutil
 from .utils import get_test_id, build_example, run_example
+
+
+CLEANUP = True
 
 
 def dump_simplified_json(modules, filename):
@@ -47,7 +51,7 @@ def test_collisions():
     """)
     constraints = [{"constraint": "ConfigureCompiler", "auto_constraint": False, "propagate": True}]
     example = build_example(name, netlist, constraints)
-    _, run_dir = run_example(example, cleanup=False, n=1, additional_args=['--flow_stop', '2_primitives'])
+    ckt_dir, run_dir = run_example(example, cleanup=False, n=1, additional_args=['--flow_stop', '2_primitives'])
 
     name = name.upper()
     filename = run_dir / '1_topology' / f'{name}.verilog.json'
@@ -73,6 +77,10 @@ def test_collisions():
         mn02 = find_instance(instances, ['MN02'])
         assert mn01[atn] != mn02[atn], 'Collision of mn01 and mn02'
 
+    if CLEANUP:
+        shutil.rmtree(run_dir)
+        shutil.rmtree(ckt_dir)
+
 
 def test_disable_fix_merge():
     name = f'ckt_{get_test_id()}'
@@ -95,7 +103,7 @@ def test_disable_fix_merge():
          }
     ]
     example = build_example(name, netlist, constraints)
-    _, run_dir = run_example(example, cleanup=False, n=1, additional_args=['--flow_stop', '2_primitives'])
+    ckt_dir, run_dir = run_example(example, cleanup=False, n=1, additional_args=['--flow_stop', '2_primitives'])
 
     name = name.upper()
     filename = run_dir / '1_topology' / f'{name}.verilog.json'
@@ -107,6 +115,10 @@ def test_disable_fix_merge():
         filename = run_dir / '1_topology' / f'{name}_simple.verilog.json'
         _ = dump_simplified_json(modules, filename)
         assert all([k in instances for k in ['X_MN01', 'X_MN02', 'X_MN03', 'X_MN04']]), 'Incorrect annotation'
+
+    if CLEANUP:
+        shutil.rmtree(run_dir)
+        shutil.rmtree(ckt_dir)
 
 
 def test_illegal():

--- a/tests/pdk/finfet_pdk/test_miscellaneous.py
+++ b/tests/pdk/finfet_pdk/test_miscellaneous.py
@@ -3,7 +3,9 @@ from .utils import get_test_id, build_example, run_example
 import align.pdk.finfet
 import pathlib
 from align.compiler.read_library import read_lib
-import pytest
+
+
+CLEANUP = True
 
 
 def test_read_lib():
@@ -29,7 +31,7 @@ def test_floating_pin():
         {"constraint": "DoNotRoute", "nets": ["vccx", "vssx"]}
     ]
     example = build_example(name, netlist, constraints)
-    run_example(example, cleanup=False, n=1)
+    run_example(example, cleanup=CLEANUP, n=1)
 
 
 def test_floating_power_pin():
@@ -55,4 +57,4 @@ def test_floating_power_pin():
         {"constraint": "AlignInOrder", "direction": "horizontal", "instances": [f"xi<{i}>" for i in range(5)]}
     ]
     example = build_example(name, netlist, constraints)
-    run_example(example, cleanup=False, n=1)
+    run_example(example, cleanup=CLEANUP, n=1)

--- a/tests/pdk/finfet_pdk/test_pinless.py
+++ b/tests/pdk/finfet_pdk/test_pinless.py
@@ -2,7 +2,7 @@ import pytest
 import textwrap
 from .utils import get_test_id, build_example, run_example
 
-cleanup = False
+CLEANUP = True
 
 
 @pytest.mark.skip(reason="this test is failing in CircleCI")
@@ -22,4 +22,4 @@ def test_pinless():
         {"constraint": "DoNotRoute", "nets": ["vccx", "vssx"]}
         ]
     example = build_example(name, netlist, setup, constraints)
-    run_example(example, cleanup=cleanup)
+    run_example(example, cleanup=CLEANUP)

--- a/tests/pdk/finfet_pdk/test_placement_grid.py
+++ b/tests/pdk/finfet_pdk/test_placement_grid.py
@@ -12,6 +12,8 @@ import align
 monkeypatch.setattr on MOSGenerator does not work probably due to reloading the module in get_generator
 """
 
+CLEANUP = True
+
 
 @pytest.fixture
 def placer_max_iter(monkeypatch):
@@ -117,7 +119,7 @@ def test_ota_on_grid_h(place_on_grid_h):
         {"constraint": "Order", "direction": "top_to_bottom", "instances": ["g3", "g2", "g1"]}
     ]
     example = build_example(name, netlist, constraints)
-    run_example(example, cleanup=False)
+    run_example(example, cleanup=CLEANUP)
 
 
 def test_ota_on_grid_v(place_on_grid_v):
@@ -133,7 +135,7 @@ def test_ota_on_grid_v(place_on_grid_v):
         {"constraint": "Order", "direction": "top_to_bottom", "instances": ["g3", "g2", "g1"]}
     ]
     example = build_example(name, netlist, constraints)
-    run_example(example, cleanup=False)
+    run_example(example, cleanup=CLEANUP)
 
 
 def cmp_constraints(name):
@@ -165,7 +167,8 @@ def test_cmp_on_grid(place_on_grid_h, placer_max_iter):
     netlist = circuits.comparator(name)
     constraints = cmp_constraints(name)
     example = build_example(name, netlist, constraints)
-    run_example(example, cleanup=False)
+    run_example(example, cleanup=CLEANUP)
+
 
 def test_cmp_on_grid_ilp(place_on_grid_h, placer_max_iter):
     print(f'PLACE_ON_GRID={os.environ["PLACE_ON_GRID"]}')
@@ -173,4 +176,4 @@ def test_cmp_on_grid_ilp(place_on_grid_h, placer_max_iter):
     netlist = circuits.comparator(name)
     constraints = cmp_constraints(name)
     example = build_example(name, netlist, constraints)
-    run_example(example, cleanup=False, additional_args=['--place_using_ILP'])
+    run_example(example, cleanup=CLEANUP, additional_args=['--place_using_ILP'])

--- a/tests/pdk/finfet_pdk/test_placer.py
+++ b/tests/pdk/finfet_pdk/test_placer.py
@@ -9,7 +9,7 @@ from . import circuits
 import time
 
 
-CLEANUP = False
+CLEANUP = True
 LOG_LEVEL = 'INFO'
 
 
@@ -393,7 +393,7 @@ def test_sub_1():
         {"constraint": "AspectRatio", "subcircuit": name, "ratio_low": 0.1, "ratio_high": 1}
     ]
     example = build_example(name, netlist, constraints)
-    _, run_dir = run_example(example, cleanup=False)
+    ckt_dir, run_dir = run_example(example, cleanup=False)
 
     with (run_dir / '3_pnr' / 'Results' / f'{name.upper()}_0.scaled_placement_verilog.json').open('rt') as fp:
         placement = json.load(fp)
@@ -401,4 +401,6 @@ def test_sub_1():
         instances = {i['instance_name']: i['transformation'] for i in placement['modules'][0]['instances']}
         assert instances['X_MP0']['oY'] > 0, 'Suboptimal placement: MP0 should be just below MN0'
         assert instances['X_MP1']['oY'] > 0, 'Suboptimal placement: MP1 should be just below MN1'
-    shutil.rmtree(run_dir)
+    if CLEANUP:
+        shutil.rmtree(ckt_dir)
+        shutil.rmtree(run_dir)

--- a/tests/pdk/finfet_pdk/test_resistor.py
+++ b/tests/pdk/finfet_pdk/test_resistor.py
@@ -8,6 +8,9 @@ from .utils import get_test_id, build_example, run_example
 from . import circuits
 
 
+CLEANUP = True
+
+
 def test_zero():
     pg = tfr_prim()
     data = pg.generate(ports=['a', 'b'])
@@ -19,7 +22,7 @@ def test_res_hier():
     netlist = circuits.tia(name)
     constraints = [{"constraint": "ConfigureCompiler", "auto_constraint": False, "propagate": True}]
     example = build_example(name, netlist, constraints)
-    _, run_dir = run_example(example, cleanup=False, n=1, additional_args=['--flow_stop', '2_primitives'])
+    run_example(example, cleanup=CLEANUP, n=1, additional_args=['--flow_stop', '2_primitives'])
 
 
 def test_res_flat():
@@ -35,7 +38,7 @@ def test_res_flat():
     """)
     constraints = [{"constraint": "ConfigureCompiler", "auto_constraint": False, "propagate": True}]
     example = build_example(name, netlist, constraints)
-    _, run_dir = run_example(example, cleanup=False, n=1, log_level='DEBUG', additional_args=['--flow_stop', '3_pnr:prep'])
+    ckt_dir, run_dir = run_example(example, cleanup=False, n=1, log_level='DEBUG', additional_args=['--flow_stop', '3_pnr:prep'])
 
     name = name.upper()
     with (run_dir / '1_topology' / '__primitives_library__.json').open('rt') as f1:
@@ -55,8 +58,9 @@ def test_res_flat():
 
             for k, v in instances.items():
                 assert v['abstract_template_name'] in atn, f"Abstract not found: {v['abstract_template_name']}"
-    shutil.rmtree(run_dir)
-    shutil.rmtree(example)
+    if CLEANUP:
+        shutil.rmtree(run_dir)
+        shutil.rmtree(ckt_dir)
 
 
 @pytest.mark.skip(reason="For a future PR")
@@ -74,7 +78,7 @@ def test_res_one():
     """)
     constraints = [{"constraint": "ConfigureCompiler", "auto_constraint": False, "propagate": True}]
     example = build_example(name, netlist, constraints)
-    _, run_dir = run_example(example, cleanup=False, n=1, additional_args=['--flow_stop', '2_primitives'])
+    ckt_dir, run_dir = run_example(example, cleanup=False, n=1, additional_args=['--flow_stop', '2_primitives'])
 
     name = name.upper()
     with (run_dir / '1_topology' / '__primitives_library__.json').open('rt') as f1:
@@ -105,5 +109,6 @@ def test_res_one():
 
     assert primitives['TFR_PRIM']['base'] == 'TFR'
 
-    shutil.rmtree(run_dir)
-    shutil.rmtree(example)
+    if CLEANUP:
+        shutil.rmtree(run_dir)
+        shutil.rmtree(ckt_dir)

--- a/tests/pnr/test_cap_array.py
+++ b/tests/pnr/test_cap_array.py
@@ -3,7 +3,7 @@ import json
 
 from align.pnr import *
 from align.cell_fabric import transformation, pdk
-from align import primitive
+from align.compiler.util import get_generator
 from pprint import pformat
 
 import pytest
@@ -25,7 +25,7 @@ def test_remove_duplicates(fn):
         d = json.load( fp)
 
     pdkdir = pathlib.Path(__file__).parent.parent.parent / "pdks" / "FinFET14nm_Mock_PDK"
-    generator = primitive.get_generator('MOSGenerator', pdkdir)
+    generator = get_generator('MOSGenerator', pdkdir)
 
     # TODO: Remove these hardcoded widths & heights from __init__()
     #       (Height may be okay since it defines UnitCellHeight)

--- a/tests/pnr/test_check_adr.py
+++ b/tests/pnr/test_check_adr.py
@@ -6,9 +6,11 @@ from pprint import pformat
 
 from align.pnr import *
 from align.cell_fabric import transformation, pdk
-from align import primitive
+from align.compiler.util import get_generator
 
-mydir =  pathlib.Path(__file__).resolve().parent
+
+mydir = pathlib.Path(__file__).resolve().parent
+
 
 def get_fpath(fn):
     return mydir / f"{fn}_adr_dr_globalrouting.json"
@@ -19,7 +21,7 @@ def aux(fn):
         d = json.load( fp)
 
     pdkdir = mydir.parent.parent / "pdks" / "FinFET14nm_Mock_PDK"
-    generator = primitive.get_generator('MOSGenerator', pdkdir)
+    generator = get_generator('MOSGenerator', pdkdir)
     # TODO: Remove these hardcoded widths & heights from __init__()
     #       (Height may be okay since it defines UnitCellHeight)
     cnv = generator(pdk.Pdk().load(pdkdir / 'layers.json'),12, 4, 2, 3)

--- a/tests/primitive_pdks/sample_package/__init__.py
+++ b/tests/primitive_pdks/sample_package/__init__.py
@@ -1,1 +1,1 @@
-from .main import generator_class
+from .main import *

--- a/tests/primitive_pdks/sample_package/__init__.py
+++ b/tests/primitive_pdks/sample_package/__init__.py
@@ -1,2 +1,1 @@
-
-from .main import return_from_package
+from .main import generator_class

--- a/tests/primitive_pdks/sample_package/main.py
+++ b/tests/primitive_pdks/sample_package/main.py
@@ -1,3 +1,10 @@
 
-def return_from_package():
-    return True
+class abc():
+    pass
+
+
+def generator_class(name):
+    if name.startswith("abc"):
+        return abc
+    else:
+        return False

--- a/tests/primitive_pdks/sample_package/main.py
+++ b/tests/primitive_pdks/sample_package/main.py
@@ -1,10 +1,14 @@
 
-class abc():
+class a_class():
+    pass
+
+
+def a_method():
     pass
 
 
 def generator_class(name):
-    if name.startswith("abc"):
-        return abc
+    if name.startswith("a_"):
+        return a_class
     else:
         return False


### PR DESCRIPTION
This PR:

- refactors get_generator method
- for packaged or installed PDK's, calls generator_class method to identify the generator

This enhancement allows using a single generator class name for a large number of models. 