### PR TITLE
Open and Design Rule Violation in Comparator

### DIFF
--- a/tests/pdk/finfet_pdk/test_circuits_partial_routing.py
+++ b/tests/pdk/finfet_pdk/test_circuits_partial_routing.py
@@ -47,6 +47,7 @@ def test_cmp_fp1_pr(partial_routing):
         {"constraint": "Order", "direction": "top_to_bottom", "instances": ["mn0", "dp"]},
         {"constraint": "AlignInOrder", "line": "bottom", "instances": ["dp", "ccn"]},
         {"constraint": "MultiConnection", "nets": ["vcom"], "multiplier": 6},
+        {"constraint": "AspectRatio", "subcircuit": name, "ratio_low": 1, "ratio_high": 2}
     ]
     example = build_example(name, netlist, constraints)
     run_example(example, cleanup=CLEANUP, max_errors=0)


### PR DESCRIPTION
To reproduce: `pytest -v tests/pdk/finfet_pdk/test_circuits_partial_routing.py::test_cmp_vanilla_pr`

Power router leaves an open and design rule violations:
![image](https://user-images.githubusercontent.com/56893713/165166199-7e2a4e52-e204-4dcb-9346-b8955cb0f1a6.png)


