### PR TITLE
Allow MOSGenerator styles

### DIFF
--- a/align/compiler/match_graph.py
+++ b/align/compiler/match_graph.py
@@ -175,6 +175,11 @@ class Annotate:
             # Create a subckt and add to library
             with set_context(self.ckt_data):
                 new_subckt = SubCircuit(name=const.name.upper(), pins=ac_nets)
+                if getattr(const, 'generator', None):
+                    new_subckt.generator["name"] = const.generator["name"]
+                    gen_const = constraint.Generator(**const.generator)
+                    with set_context(subckt.constraints):
+                         new_subckt.constraints.append(gen_const)
                 self.ckt_data.append(new_subckt)
             # Add all instances of groupblock to new subckt
             with set_context(new_subckt.elements):
@@ -191,6 +196,7 @@ class Annotate:
                     pins={x: x for x in ac_nets},
                 )
                 subckt.elements.append(X1)
+
             # Translate any constraints defined on the groupblock elements to subckt
             tr._top_to_bottom_translation(
                 name, {inst: inst for inst in const_inst}, const.name

--- a/align/compiler/util.py
+++ b/align/compiler/util.py
@@ -223,7 +223,8 @@ def get_generator(name, pdkdir):
         if generator_class and generator_class(name):
             return generator_class(name)
         else:
-            return getattr(module, name, False) or getattr(module, name.lower(), False)
+            res = getattr(module, name, False) or getattr(module, name.lower(), False)
+            return res
 
     try:  # is pdk an installed module
         module = importlib.import_module(pdk_dir_stem)

--- a/align/pdk/finfet/gen_param.py
+++ b/align/pdk/finfet/gen_param.py
@@ -68,7 +68,7 @@ def add_primitive(primitives, block_name, block_args):
 def gen_param(subckt, primitives, pdk_dir):
     block_name = subckt.name
     vt = subckt.elements[0].model
-    values = subckt.elements[0].parameters
+    values = deepcopy(subckt.elements[0].parameters)
     generator_name = subckt.generator["name"]
     logger.debug(f"Getting generator parameters for: {block_name}")
     if get_generator(block_name.lower(), pdk_dir):

--- a/align/primitive/main.py
+++ b/align/primitive/main.py
@@ -33,11 +33,17 @@ def generate_MOS_primitive(pdkdir, block_name, primitive, height, nfin, x_cells,
 
     pdk = Pdk().load(pdkdir / 'layers.json')
 
-    # if style is not None and style != '':
-    #     generator = get_generator(f'MOSGenerator_{style}', pdkdir)
-    # else:
-    #
-    generator = get_generator('MOSGenerator', pdkdir)
+    style = None
+    for const in primitive.constraints:
+        if const.constraint == 'generator':
+            p = const.parameters
+            if const.parameters is not None:
+                style = const.parameters.get('style')
+
+    if style is not None and style != '':
+        generator = get_generator(f'MOSGenerator_{style}', pdkdir)
+    else:
+        generator = get_generator('MOSGenerator', pdkdir)
 
     # TODO: THIS SHOULD NOT BE NEEDED !!!
     fin = int(nfin)

--- a/align/primitive/main.py
+++ b/align/primitive/main.py
@@ -13,13 +13,17 @@ import importlib.util
 logger = logging.getLogger(__name__)
 
 
-# def get_xcells_pattern(primitive, pattern, x_cells):
-#     if any(primitive.startswith(f'{x}_') for x in ["SCM", "CMC", "DP", "CCP", "LS"]):
-#         # Dual transistor primitives
-#         x_cells = 2*x_cells
-#         # TODO: Fix difficulties associated with CC patterns matching this condition
-#         pattern = 2 if x_cells % 4 != 0 else pattern  # CC is not possible; default is interdigitated
-#     return x_cells, pattern
+def get_xcells_pattern(primitive, pattern, x_cells):
+    # TODO: no need for this name based pattern mapping in the flow
+    if any(primitive.startswith(f'{x}_') for x in ["CM", "CMFB"]):
+        # TODO: Generalize this (pattern is ignored)
+        x_cells = 2*x_cells + 2
+    elif any(primitive.startswith(f'{x}_') for x in ["SCM", "CMC", "DP", "CCP", "LS"]):
+        # Dual transistor primitives
+        x_cells = 2*x_cells
+        # TODO: Fix difficulties associated with CC patterns matching this condition
+        pattern = 2 if x_cells % 4 != 0 else pattern  # CC is not possible; default is interdigitated
+    return x_cells, pattern
 
 
 # TODO: Pass cell_pin and pattern to this function to begin with

--- a/align/primitive/main.py
+++ b/align/primitive/main.py
@@ -61,9 +61,9 @@ def generate_MOS_primitive(pdkdir, block_name, primitive, height, nfin, x_cells,
         parameters['model'] = 'NMOS' if 'NMOS' in primitive.name else 'PMOS'
     def gen(pattern, routing):
         if 'NMOS' in primitive.name:
-            uc.addNMOSArray(x_cells, y_cells, pattern, vt_type, routing, **parameters)
+            uc.addNMOSArray(2*x_cells, y_cells, pattern, vt_type, routing, **parameters)
         else:
-            uc.addPMOSArray(x_cells, y_cells, pattern, vt_type, routing, **parameters)
+            uc.addPMOSArray(2*x_cells, y_cells, pattern, vt_type, routing, **parameters)
         return routing.keys()
 
     connections = {pin: [] for pin in primitive.pins}

--- a/align/primitive/main.py
+++ b/align/primitive/main.py
@@ -36,14 +36,15 @@ def get_parameters(primitive, parameters, nfin):
 # TODO: Pass cell_pin and pattern to this function to begin with
 
 
-def generate_MOS_primitive(pdkdir, block_name, primitive, height, nfin, x_cells, y_cells, pattern, vt_type, stack, parameters, pinswitch, bodyswitch, style=None):
-    
+def generate_MOS_primitive(pdkdir, block_name, primitive, height, nfin, x_cells, y_cells, pattern, vt_type, stack, parameters, pinswitch, bodyswitch):
+
     pdk = Pdk().load(pdkdir / 'layers.json')
 
-    if style is not None and style != '':
-        generator = get_generator(f'MOSGenerator_{style}', pdkdir)
-    else:
-        generator = get_generator('MOSGenerator', pdkdir)
+    # if style is not None and style != '':
+    #     generator = get_generator(f'MOSGenerator_{style}', pdkdir)
+    # else:
+    #
+    generator = get_generator('MOSGenerator', pdkdir)
 
     # TODO: THIS SHOULD NOT BE NEEDED !!!
     fin = int(nfin)
@@ -170,14 +171,15 @@ def generate_primitive(block_name, primitive, height=28, x_cells=1, y_cells=1, p
     elif 'ring' in primitive:
         uc, _ = generate_Ring(pdkdir, block_name, x_cells, y_cells)
     elif 'MOS' == primitive.generator['name']:
-        style = None
-        if 'style' in primitive.generator:
-            style = primitive.generator['style']
+        #Instead of hacking here as a style, please use a one one mapping with generator["name"]. The groupblock constraint can add generator names to the subcircuit now"
+        # style = None
+        # if 'style' in primitive.generator:
+        #     style = primitive.generator['style']
 
         uc, _ = generate_MOS_primitive(pdkdir, block_name, primitive, height, value, x_cells, y_cells,
-                                       pattern, vt_type, stack, parameters, pinswitch, bodyswitch, style)
+                                       pattern, vt_type, stack, parameters, pinswitch, bodyswitch)
 
-            
+
     elif 'CAP' == primitive.generator['name']:
         uc, _ = generate_Cap(pdkdir, block_name, value)
         uc.setBboxFromBoundary()

--- a/align/primitive/main.py
+++ b/align/primitive/main.py
@@ -22,13 +22,6 @@ logger = logging.getLogger(__name__)
 #     return x_cells, pattern
 
 
-# def get_parameters(primitive, parameters, nfin):
-#     if parameters is None:
-#         parameters = {}
-#     if 'model' not in parameters:
-#         parameters['model'] = 'NMOS' if 'NMOS' in primitive else 'PMOS'
-#     return parameters
-
 # TODO: Pass cell_pin and pattern to this function to begin with
 
 
@@ -57,9 +50,10 @@ def generate_MOS_primitive(pdkdir, block_name, primitive, height, nfin, x_cells,
     elif not input_pattern:
         input_pattern = 'cc'
     pattern_map = {'single_device':0, 'cc':1, 'id':2,'ratio_devices':3,'ncc':4}
-    pattern = pattern_map['input_pattern']
+    pattern = pattern_map[input_pattern]
     # parameters = get_parameters(primitive.name, parameters, nfin)
-    assert 'model' in parameters, f"unidentified primitive found {primitive}"
+    if 'model' not in parameters:
+        parameters['model'] = 'NMOS' if 'NMOS' in primitive.name else 'PMOS'
     def gen(pattern, routing):
         if 'NMOS' in primitive.name:
             uc.addNMOSArray(x_cells, y_cells, pattern, vt_type, routing, **parameters)

--- a/align/primitive/main.py
+++ b/align/primitive/main.py
@@ -56,7 +56,7 @@ def generate_MOS_primitive(pdkdir, block_name, primitive, height, nfin, x_cells,
         input_pattern = 'ratio_devices' #e.g. current mirror
     elif not input_pattern:
         input_pattern = 'cc'
-    pattern_map = {'single_device':0, 'cc':1, 'id':2,'ratio:devices':3,'ncc':4}
+    pattern_map = {'single_device':0, 'cc':1, 'id':2,'ratio_devices':3,'ncc':4}
     pattern = pattern_map['input_pattern']
     # parameters = get_parameters(primitive.name, parameters, nfin)
     assert 'model' in parameters, f"unidentified primitive found {primitive}"

--- a/align/primitive/main.py
+++ b/align/primitive/main.py
@@ -51,6 +51,13 @@ def generate_MOS_primitive(pdkdir, block_name, primitive, height, nfin, x_cells,
     gate = 1
     shared_diff = 0 if any(primitive.name.startswith(f'{x}_') for x in ["LS_S", "CMC_S", "CCP_S"]) else 1
     uc = generator(pdk, height, fin, gate, gateDummy, shared_diff, stack, bodyswitch)
+
+    assert not hasattr(uc, 'style'), f"Don't want to override 'style' field if it already exists"
+    assert not hasattr(uc, 'primitive_constraints'), f"Don't want to override 'primitive_constraints' field if it already exists"
+
+    uc.style = style
+    uc.primitive_constraints = primitive.constraints
+
     input_pattern = getattr(primitive, 'parameters', None)
     if not input_pattern and len(primitive.elements)==1:
         input_pattern = 'single_device'

--- a/align/primitive/main.py
+++ b/align/primitive/main.py
@@ -33,17 +33,7 @@ def generate_MOS_primitive(pdkdir, block_name, primitive, height, nfin, x_cells,
 
     pdk = Pdk().load(pdkdir / 'layers.json')
 
-    style = None
-    for const in primitive.constraints:
-        if const.constraint == 'generator':
-            p = const.parameters
-            if const.parameters is not None:
-                style = const.parameters.get('style')
-
-    if style is not None and style != '':
-        generator = get_generator(f'MOSGenerator_{style}', pdkdir)
-    else:
-        generator = get_generator('MOSGenerator', pdkdir)
+    generator = get_generator('MOSGenerator', pdkdir)
 
     # TODO: THIS SHOULD NOT BE NEEDED !!!
     fin = int(nfin)
@@ -52,11 +42,10 @@ def generate_MOS_primitive(pdkdir, block_name, primitive, height, nfin, x_cells,
     shared_diff = 0 if any(primitive.name.startswith(f'{x}_') for x in ["LS_S", "CMC_S", "CCP_S"]) else 1
     uc = generator(pdk, height, fin, gate, gateDummy, shared_diff, stack, bodyswitch)
 
-    assert not hasattr(uc, 'style'), f"Don't want to override 'style' field if it already exists"
     assert not hasattr(uc, 'primitive_constraints'), f"Don't want to override 'primitive_constraints' field if it already exists"
-
-    uc.style = style
     uc.primitive_constraints = primitive.constraints
+    if hasattr(uc, 'semantic'):
+        uc.semantic()
 
     input_pattern = getattr(primitive, 'parameters', None)
     if not input_pattern and len(primitive.elements)==1:

--- a/align/schema/constraint.py
+++ b/align/schema/constraint.py
@@ -501,6 +501,7 @@ class GroupBlocks(HardConstraint):
     Args:
       instances (list[str]): List of :obj:`instances`
       name (str): alias for the list of :obj:`instances`
+      generator (dict): adds a generator constraint to the created groupblock, look into the generator constraint for more options
 
     Example: ::
 
@@ -508,11 +509,18 @@ class GroupBlocks(HardConstraint):
             "constraint":"GroupBlocks",
             "name": "group1",
             "instances": ["MN0", "MN1", "MN3"]
+            "generator": {name: 'MOS',
+                        'parameters':
+                            {
+                            "pattern": "cc",
+                            }
+                        }
         }
     """
     name: str
     instances: List[str]
-    style: Optional[Literal["tbd_interdigitated", "tbd_common_centroid"]]
+    generator: Optional[dict]
+    # style: Optional[Literal["tbd_interdigitated", "tbd_common_centroid"]] added as part of generator
 
     @types.validator('name', allow_reuse=True)
     def group_block_name(cls, value):

--- a/align/schema/transistor.py
+++ b/align/schema/transistor.py
@@ -49,6 +49,6 @@ class TransistorArray(types.BaseModel):
         if set(v.keys()) != set(values['m'].keys()):
             raise ValueError('Number of devices and ports should match')
         for _, ports in v.items():
-            if set(ports.keys()) != {'S', 'D', 'G'} and set(ports.keys()) != {'S', 'D', 'G', 'B'} :
-                raise ValueError(f'Missing transistor terminal S/D/G: {ports}')
+            if set(ports.keys()) != {'S', 'D', 'G'} and set(ports.keys()) != {'S', 'D', 'G', 'B'}:
+                raise ValueError(f'Missing transistor terminal S/D/G: {ports} {v} {values}')
         return v

--- a/pdks/FinFET14nm_Mock_PDK/gen_param.py
+++ b/pdks/FinFET14nm_Mock_PDK/gen_param.py
@@ -91,7 +91,7 @@ def gen_param(subckt, primitives, pdk_dir):
         add_primitive(primitives, block_name, block_args)
 
     elif generator_name == 'RES':
-        assert float(values["VALUE"]) or float(values["R"]), f"unidentified size {values['VALUE']} for {name}"
+        assert float(values["VALUE"]) or float(values["R"]), f"unidentified size {values['VALUE']} for {block_name}"
         if "R" in values:
             size = round(float(values["R"]), 2)
         elif 'VALUE' in values:

--- a/pdks/FinFET14nm_Mock_PDK/gen_param.py
+++ b/pdks/FinFET14nm_Mock_PDK/gen_param.py
@@ -129,13 +129,13 @@ def gen_param(subckt, primitives, pdk_dir):
 
         if 'NF' in mvalues[device_name].keys():
             for key in mvalues:
-                assert int(mvalues[key]["NF"]), f"unrecognized NF of device {key}:{mvalues[key]['NF']} in {name}"
-                assert int(mvalues[key]["NF"]) % 2 == 0, f"NF must be even for device {key}:{mvalues[key]['NF']} in {name}"
+                assert int(mvalues[key]["NF"]), f"unrecognized NF of device {key}:{mvalues[key]['NF']} in {block_name}"
+                assert int(mvalues[key]["NF"]) % 2 == 0, f"NF must be even for device {key}:{mvalues[key]['NF']} in {block_name}"
             name_arg = name_arg+'_NF'+str(int(mvalues[device_name]["NF"]))
 
         if 'M' in mvalues[device_name].keys():
             for key in mvalues:
-                assert int(mvalues[key]["M"]), f"unrecognized M of device {key}:{mvalues[key]['M']} in {name}"
+                assert int(mvalues[key]["M"]), f"unrecognized M of device {key}:{mvalues[key]['M']} in {block_name}"
                 if "PARALLEL" in mvalues[key].keys() and int(mvalues[key]['PARALLEL']) > 1:
                     mvalues[key]["PARALLEL"] = int(mvalues[key]['PARALLEL'])
                     mvalues[key]['M'] = int(mvalues[key]['M'])*int(mvalues[key]['PARALLEL'])
@@ -145,7 +145,8 @@ def gen_param(subckt, primitives, pdk_dir):
         logger.debug(f"Generating lef for {block_name}")
         if isinstance(size, int):
             for key in mvalues:
-                assert int(mvalues[device_name]["NFIN"]) == int(mvalues[key]["NFIN"]), f"NFIN should be same for all devices in {name} {mvalues}"
+                assert int(mvalues[device_name]["NFIN"]) == int(mvalues[key]["NFIN"]
+                                                                ), f"NFIN should be same for all devices in {block_name} {mvalues}"
                 size_device = int(mvalues[key]["NF"])*int(mvalues[key]["M"])
                 size = size + size_device
             no_units = ceil(size / (2*len(mvalues)))  # Factor 2 is due to NF=2 in each unit cell; needs to be generalized

--- a/tests/compiler/test_auto_const.py
+++ b/tests/compiler/test_auto_const.py
@@ -78,6 +78,7 @@ def test_add_symmetry_const():
     clean_data(name)
 
 
+
 def test_match_start_points():
     name = f'ckt_{get_test_id()}'
     netlist = ota_six(name)
@@ -92,6 +93,7 @@ def test_match_start_points():
     ports_weight = get_ports_weight(graph)
     recursive_start_points(graph, match_pairs, stop_points, 'VIN', 'VIP', ports_weight)
     assert match_pairs[('VIN', 'VIP')] == {'MN4': 'MN3', 'VIN': 'VIP'}
+    clean_data(name)
 
 
 def test_filter_duplicate_instances():
@@ -105,6 +107,7 @@ def test_filter_duplicate_instances():
     pairs = [['MN3', 'MN4'], ['VIN', 'VIP'], ['MN4', 'MN4']]
     mpairs = add.filter_symblock_const(pairs)
     assert mpairs == [['MN3', 'MN4']]
+    clean_data(name)
 
 
 def test_symmnet_filters():
@@ -118,6 +121,7 @@ def test_symmnet_filters():
     add = add_symmetry_const(ckt, pairs, set(), [], None)
     add.loop_through_pairs()
     assert ckt.constraints[0].pairs == [['MN3', 'MN4']]
+    clean_data(name)
 
 
 def test_filter_dummy():
@@ -132,3 +136,4 @@ def test_filter_dummy():
     pairs = [['X_MN3_MN4', 'X_MN3_MN4'], ['X_MN3_DUMMY', 'X_MN4_DUMMY']]
     mpairs = add.filter_symblock_const(pairs)
     assert mpairs == [['X_MN3_MN4'], ['X_MN3_DUMMY', 'X_MN4_DUMMY']]
+    clean_data(name)

--- a/tests/compiler/test_database.py
+++ b/tests/compiler/test_database.py
@@ -170,6 +170,7 @@ def test_multipower_domain_propagation():
         elif isinstance(const, constraint.ClockPorts):
             special_ports["CLK"] = const.ports
     assert special_ports == {"PWR": ["D1", "D"], "GND": ["S1", "S"], "CLK": ["G1", "G"]}
+    clean_data(name)
 
 
 def test_power_and_signal_ckt():
@@ -203,6 +204,7 @@ def test_power_and_signal_ckt():
         elif isinstance(const, constraint.ClockPorts):
             special_ports["CLK"] = const.ports
     assert special_ports == {"PWR": ["D"], "GND": ["S"], "CLK": ["G"]}
+    clean_data(name)
 
 def test_multi_param():
     name = f'ckt_{get_test_id()}'.upper()
@@ -356,7 +358,7 @@ def test_subckt_generator():
     example = build_example(name, netlist, constraints)
     ckt_library, _ = compiler_input(example, name, pdk_dir, config_path)
     assert ckt_library.find('DIG22INV').generator['name'] == 'DIG22INV'
-
+    clean_data((name))
 
 def test_model_generator():
     name = f'ckt_{get_test_id()}'
@@ -409,7 +411,7 @@ def test_unimplemented_generator():
     example = build_example(name, netlist, constraints)
     with raises(AssertionError):
         generate_hierarchy(example, name, result_path, False, pdk_path)
-
+    clean_data(name)
 
 def test_global_param_2():
     name = f'ckt_{get_test_id()}'.upper()

--- a/tests/compiler/test_user_constraint.py
+++ b/tests/compiler/test_user_constraint.py
@@ -300,4 +300,3 @@ def test_groublock_generator():
     assert dp1.constraints.dict()['__root__'][0] == {'constraint':'generator' , 'name': 'MOS', 'parameters':{'pattern':'cc'}}, f"generator constraint error {dp1.constraints}"
 
     clean_data(name)
-    clean_data('run_'+name)

--- a/tests/compiler/test_user_constraint.py
+++ b/tests/compiler/test_user_constraint.py
@@ -278,3 +278,26 @@ def test_symmnet_translation():
     }
     assert symnet_const == modified_symmnet, f"incorrect ports identified for symmnet"
     clean_data(name)
+
+
+def test_groublock_generator():
+    name = f'ckt_{get_test_id()}'
+    netlist = textwrap.dedent(
+        f"""\
+        .subckt {name} a b g1 g2 vssx
+        mn1 a g1 vssx vssx n w=360e-9 nf=2 m=8
+        mn2 b g2 vssx vssx n w=360e-9 nf=2 m=8
+        .ends {name}
+    """
+    )
+    constraints = [{"constraint": "GroupBlocks",  "instances": ["mn1", "mn2"],   "name": "dp1", "generator":{"name":"MOS", "parameters":{"pattern":"cc"}}},
+    ]
+    example = build_example(name, netlist, constraints)
+    cktlib, prim_lib = compiler_input(example, name, pdk_dir, config_path)
+    annotate_library(cktlib, prim_lib)
+    dp1 = cktlib.find('DP1')
+    assert dp1.generator["name"] == 'MOS', f"generator defination error {dp1.generator}"
+    assert dp1.constraints.dict()['__root__'][0] == {'constraint':'generator' , 'name': 'MOS', 'parameters':{'pattern':'cc'}}, f"generator constraint error {dp1.constraints}"
+
+    clean_data(name)
+    clean_data('run_'+name)

--- a/tests/compiler/test_user_constraint.py
+++ b/tests/compiler/test_user_constraint.py
@@ -280,7 +280,7 @@ def test_symmnet_translation():
     clean_data(name)
 
 
-def test_groublock_generator():
+def test_groupblock_generator():
     name = f'ckt_{get_test_id()}'
     netlist = textwrap.dedent(
         f"""\
@@ -296,7 +296,7 @@ def test_groublock_generator():
     cktlib, prim_lib = compiler_input(example, name, pdk_dir, config_path)
     annotate_library(cktlib, prim_lib)
     dp1 = cktlib.find('DP1')
-    assert dp1.generator["name"] == 'MOS', f"generator defination error {dp1.generator}"
+    assert dp1.generator["name"] == 'MOS', f"generator definition error {dp1.generator}"
     assert dp1.constraints.dict()['__root__'][0] == {'constraint':'generator' , 'name': 'MOS', 'parameters':{'pattern':'cc'}}, f"generator constraint error {dp1.constraints}"
 
     clean_data(name)

--- a/tests/pdks/test_mos.py
+++ b/tests/pdks/test_mos.py
@@ -2,7 +2,6 @@ import pathlib
 import sys
 import pytest
 
-from align.primitive.main import get_xcells_pattern
 
 pdks = []
 for prim in (pathlib.Path(__file__).parent.parent.parent / 'pdks').iterdir():
@@ -18,7 +17,7 @@ def check_shorts(cmdlist):
     assert len(uc.rd.shorts) == 0, uc.rd.shorts
     assert len(uc.rd.opens) == 0, uc.rd.opens
     assert len(uc.rd.different_widths) == 0, uc.rd.different_widths
-    assert len(uc.rd.subinsts) == get_xcells_pattern(args.primitive, args.pattern, args.Xcells)[0] * args.Ycells, uc.rd.subinsts
+    assert len(uc.rd.subinsts) == 2*args.Xcells*args.Ycells, uc.rd.subinsts
     assert all(len(x.pins) == 4 for x in uc.rd.subinsts.values()), uc.rd.subinsts
     assert len(uc.drc.errors) == 0, uc.drc.errors
 


### PR DESCRIPTION
To enable RADHARD MOSGenerator in p1222, we set a field in the generator dictionary in `__primitives_library__.json` (in 1_topology).