### PR TITLE
inverseBounds for non-monotonic grids

### DIFF
--- a/align/cell_fabric/grid.py
+++ b/align/cell_fabric/grid.py
@@ -1,10 +1,8 @@
-from . import transformation
 import copy
-import collections
 import operator
-
 import logging
 logger = logging.getLogger(__name__)
+
 
 class Grid:
     def __init__( self):
@@ -38,22 +36,17 @@ class Grid:
     def period( self):
         return self.grid[-1][0] - self.grid[0][0]
 
-    def inverseBounds( self, physical):
-        (q,r) = divmod(physical - self.grid[0][0], self.period)
-        last_lt = None
-        ge = None
-        for (idx,(c,_)) in enumerate(self.grid):
-            if c - self.grid[0][0] < r:
-                last_lt = idx
-            else:
-                ge = idx
-                break
-        assert ge is not None
-        if physical < self.value( (q,ge), check=False)[0]:
-            assert last_lt is not None
-            return ((q,last_lt), (q,ge))
-        else:
-            return ((q,ge), (q,ge))
+    def inverseBounds(self, physical):
+        offset = self.grid[0][0]
+        (q, r) = divmod(physical - offset, self.period)
+        monotonic_grid = [(i, v[0]) for i, v in enumerate(self.grid)]
+        monotonic_grid.sort(key=lambda x: x[1])
+        for i, (idx, val) in enumerate(monotonic_grid):
+            if val - offset == r:
+                return ((q, idx), (q, idx))
+            elif val - offset > r:
+                idx_prev = monotonic_grid[i-1][0]
+                return ((q, idx_prev), (q, idx))
 
     def snapToLegal(self, idx, direction):
         assert len(idx) == 2
@@ -80,12 +73,14 @@ class Grid:
         c += whole*self.period
         return (c,attrs)
 
+
 class CenteredGrid(Grid):
     def __init__( self, *, pitch, offset=0):
         super().__init__()
         self.addGridLine( offset,                     False)
         self.addGridLine( offset + pitch//2,          True)
         self.addGridLine( offset + pitch,             False)
+
 
 class CenterLineGrid(Grid):
 
@@ -97,6 +92,7 @@ class CenterLineGrid(Grid):
         assert self.n > 0
         # width and color both need to be the same
         assert self.grid[0][1] == self.grid[-1][1]
+
 
 class UncoloredCenterLineGrid(CenterLineGrid):
 
@@ -124,10 +120,8 @@ class ColoredCenterLineGrid(CenterLineGrid):
 class EnclosureGrid(Grid):
     def __init__(self, *, clg=None, pitch, offset=0, stoppoint, check=False):
         if check and 2*stoppoint > pitch:
-            logger.debug( f"Enclosure grid stop point ({stoppoint}) is more than half the pitch ({pitch}) causing the physical coordinate to be non-monotonic with the grid ordering")
-        if 2*stoppoint > pitch:
-            logger.debug("Updating stop point to keep the physical coordinate to be non-monotonic with the grid ordering")
-            stoppoint = pitch - stoppoint
+            logger.debug(f"Enclosure grid stop point ({stoppoint}) is more than half the pitch ({pitch}) causing the physical coordinate to be non-monotonic with the grid ordering")
+
         super().__init__()
         self.addGridLine(offset,                     False)
         self.addGridLine(offset + stoppoint,         True)

--- a/pdks/Bulk65nm_Mock_PDK/mos.py
+++ b/pdks/Bulk65nm_Mock_PDK/mos.py
@@ -1,10 +1,11 @@
 from align.primitive.default.canvas import DefaultCanvas
-from align.cell_fabric.generators import *
-from align.cell_fabric.grid import *
+from align.cell_fabric.generators import Region, Wire, Via
+from align.cell_fabric.grid import EnclosureGrid, UncoloredCenterLineGrid, SingleGrid, CenteredGrid, CenterLineGrid
 from math import floor
-
+import collections
 import logging
 logger = logging.getLogger(__name__)
+
 
 class MOSGenerator(DefaultCanvas):
 

--- a/pdks/FinFET14nm_Mock_PDK/mos.py
+++ b/pdks/FinFET14nm_Mock_PDK/mos.py
@@ -1,9 +1,10 @@
 from align.primitive.default.canvas import DefaultCanvas
-from align.cell_fabric.generators import *
-from align.cell_fabric.grid import *
-
+from align.cell_fabric.generators import Region, Wire, Via
+from align.cell_fabric.grid import EnclosureGrid, UncoloredCenterLineGrid, SingleGrid, CenteredGrid, CenterLineGrid
+import collections
 import logging
 logger = logging.getLogger(__name__)
+
 
 class MOSGenerator(DefaultCanvas):
 

--- a/pdks/FinFET14nm_Mock_PDK/res.py
+++ b/pdks/FinFET14nm_Mock_PDK/res.py
@@ -98,9 +98,9 @@ class ResGenerator(DefaultCanvas):
         grid_x1 = grid_x0 + last_x_track
         grid_y = (x_number%2)*last_y1_track
 
-        self.addWire(m2n, 'PLUS', 0, (-4, -1), (0, 3), netType='pin')
+        self.addWire(m2n, 'PLUS', 0, (-4, -1), (0, 1), netType='pin')
         self.addVia( self.v1res, None, 0, 0)
-        self.addWire(self.m2res, 'MINUS', grid_y, (grid_x1+p-1, 1), (grid_x1+p+4, 1), netType='pin')
+        self.addWire(self.m2res, 'MINUS', grid_y, (grid_x1+p, -1), (grid_x1+p+4, 1), netType='pin')
         self.addVia( self.v1res, None, grid_x1+p, grid_y)
 
         if draw_boundary:

--- a/tests/cell_fabric/test_grid.py
+++ b/tests/cell_fabric/test_grid.py
@@ -1,0 +1,43 @@
+import pathlib
+from align.cell_fabric import Canvas, Wire, UncoloredCenterLineGrid, EnclosureGrid
+
+mydir = pathlib.Path(__file__).resolve().parent
+
+
+def test_inverseBounds():
+
+    c = Canvas()
+
+    c.M1 = c.addGen(Wire(nm='m1', layer='M1', direction='v',
+                         clg=UncoloredCenterLineGrid(width=400, pitch=800),
+                         spg=EnclosureGrid(pitch=800, stoppoint=200)))
+
+    c.M2 = c.addGen(Wire(nm='m2', layer='M2', direction='h',
+                         clg=UncoloredCenterLineGrid(width=400, pitch=800),
+                         spg=EnclosureGrid(pitch=800, stoppoint=600)))
+
+    # M1 is monotonic
+    b, e = c.M1.spg.inverseBounds(600)
+    assert b == e == (0, 3)
+
+    b, e = c.M1.spg.inverseBounds(800)
+    assert b == e == (1, 0)
+
+    b, e = c.M1.spg.inverseBounds(900)
+    assert b == (1, 0) and e == (1, 1)
+
+    b, e = c.M1.spg.inverseBounds(1000)
+    assert b == e == (1, 1)
+
+    # M2 is not monotonic
+    b, e = c.M2.spg.inverseBounds(600)
+    assert b == e == (0, 1)
+
+    b, e = c.M2.spg.inverseBounds(800)
+    assert b == e == (1, 0)
+
+    b, e = c.M2.spg.inverseBounds(900)
+    assert b == (1, 0) and e == (1, 3)
+
+    b, e = c.M2.spg.inverseBounds(1000)
+    assert b == e == (1, 3)


### PR DESCRIPTION
This PR revises `inverseBounds` for enclosure grids that are not monotonic.