### PR TITLE
Fix test_order_abut failing test case

### DIFF
--- a/PlaceRouteHierFlow/placer/Placer.cpp
+++ b/PlaceRouteHierFlow/placer/Placer.cpp
@@ -70,7 +70,7 @@ void Placer::setPlacementInfoFromJson(std::vector<PnRDB::hierNode>& nodeVec, str
   auto logger = spdlog::default_logger()->clone("placer.Placer.setPlacementInfoFromJson");
   logger->debug("Calling setPlacementInfoFromJson");
   json modules = json::parse(hyper.placement_info_json);
-  design designData(nodeVec.back());
+  design designData(nodeVec.back(), drcInfo);
   int idx = 0;
   //pad nodeVec to match the number of concretes in JSON file
   for (const auto& m : modules) {
@@ -426,7 +426,7 @@ void Placer::PlacementRegularAspectRatio_ILP(std::vector<PnRDB::hierNode>& nodeV
 #endif
   int mode = 0;
   // Read design netlist and constraints
-  design designData(nodeVec.back(), hyper.SEED);
+  design designData(nodeVec.back(), drcInfo, hyper.SEED);
   _rng.seed(hyper.SEED);
   //designData.PrintDesign();
   // Initialize simulate annealing with initial solution
@@ -476,7 +476,7 @@ void Placer::PlacementRegularAspectRatio_ILP_Analytical(std::vector<PnRDB::hierN
 #endif
   // int mode=0;
   // Read design netlist and constraints
-  design designData(nodeVec.back());
+  design designData(nodeVec.back(),drcInfo);
   // designData.PrintDesign();
   // Initialize simulate annealing with initial solution
   // SeqPair curr_sp(designData);

--- a/PlaceRouteHierFlow/placer/SeqPair.cpp
+++ b/PlaceRouteHierFlow/placer/SeqPair.cpp
@@ -1280,6 +1280,15 @@ bool SeqPair::CheckSymm(design& caseNL) {
     posPosition[posPair[i]] = i;
     negPosition[negPair[i]] = i;
   }
+  //check abut&sympair at the same time
+  for (const auto& abut: caseNL.Abut_Constraints){
+    if(abut.second == placerDB::H && caseNL.Blocks[abut.first.first][0].counterpart==abut.first.second){
+      int first_id = abut.first.first, second_id = abut.first.second;
+      if ((caseNL.Blocks[first_id][selected[first_id]].width + caseNL.Blocks[second_id][selected[second_id]].width) % (4*caseNL.grid_unit_x)) {
+        return false;
+      }
+    }
+  }
   for (const auto& sb : caseNL.SBlocks) {
     // self symm blocks should be (above/below for vertical axis) or (left/right for horizontal axis)
     // self symm blocks to the (left/right for vertical axis) or (above/below) for horizontal) is a violation

--- a/PlaceRouteHierFlow/placer/SeqPair.cpp
+++ b/PlaceRouteHierFlow/placer/SeqPair.cpp
@@ -592,6 +592,11 @@ void SeqPair::SameSelected(design& caseNL) {
     int id = selected[*group.begin()];
     for (const auto& i : group) selected[i] = id;
   }
+  for(const auto& group:caseNL.SPBlocks){
+    for(const auto& p:group.sympair){
+      selected[p.second] = selected[p.first];
+    }
+  }
 }
 
 int SeqPair::GetBlockSelected(int blockNo) {

--- a/PlaceRouteHierFlow/placer/SeqPair.cpp
+++ b/PlaceRouteHierFlow/placer/SeqPair.cpp
@@ -592,11 +592,13 @@ void SeqPair::SameSelected(design& caseNL) {
     int id = selected[*group.begin()];
     for (const auto& i : group) selected[i] = id;
   }
+  /**
   for(const auto& group:caseNL.SPBlocks){
     for(const auto& p:group.sympair){
       selected[p.second] = selected[p.first];
     }
   }
+  **/
 }
 
 int SeqPair::GetBlockSelected(int blockNo) {

--- a/PlaceRouteHierFlow/placer/design.cpp
+++ b/PlaceRouteHierFlow/placer/design.cpp
@@ -18,7 +18,7 @@ design::design() {
   noSymGroup4FullMove = 0;
 }
 
-design::design(PnRDB::hierNode& node, const int seed) {
+design::design(PnRDB::hierNode& node, PnRDB::Drc_info& drcInfo, const int seed) {
   auto logger = spdlog::default_logger()->clone("placer.design.design");
   _rng.seed(seed);
   is_first_ILP = node.isFirstILP;
@@ -30,6 +30,8 @@ design::design(PnRDB::hierNode& node, const int seed) {
   memcpy(Aspect_Ratio, node.Aspect_Ratio, sizeof(node.Aspect_Ratio));
   memcpy(placement_box, node.placement_box, sizeof(node.placement_box));
   Same_Template_Constraints = node.Same_Template_Constraints;
+  grid_unit_x = drcInfo.Metal_info[0].grid_unit_x;
+  grid_unit_y = drcInfo.Metal_info[1].grid_unit_y;
   mixFlag = false;
   double averageWL = 0;
   double macroThreshold = 0.5;  // threshold to filter out small blocks

--- a/PlaceRouteHierFlow/placer/design.h
+++ b/PlaceRouteHierFlow/placer/design.h
@@ -179,6 +179,7 @@ class design {
   vector<MatchBlock> Match_blocks;
   int bias_Hgraph;
   int bias_Vgraph;
+  int grid_unit_x = 1, grid_unit_y = 1;
   bool mixFlag;
   // above is added by yg
 
@@ -209,7 +210,7 @@ class design {
   public:
   std::chrono::nanoseconds ilp_runtime{0}, gen_valid_runtime{0}, ilp_solve_runtime{0};
   design();
-  design(PnRDB::hierNode& node, const int seed = 0);
+  design(PnRDB::hierNode& node, PnRDB::Drc_info& drcInfo, const int seed = 0);
   design(string blockfile, string netfile);
   design(string blockfile, string netfile, string cfile);
   int rand();

--- a/tests/constraints/test_constraint.py
+++ b/tests/constraints/test_constraint.py
@@ -81,7 +81,6 @@ def test_do_not_identify():
     run_example(example)
 
 
-@pytest.mark.skip("Failing placement constraint check")
 def test_order_abut():
     name = f'ckt_{get_test_id()}'
     netlist = circuits.comparator(name)


### PR DESCRIPTION
Changes in previous PR exposed latent issue with this test case. See #1102 for discussion.
```
pytest -n 1 -vv tests/constraints/test_constraint.py::test_order_abut
```
fails with hard constraint placement violations in the _5 placement.
```
ERROR    align.schema.hacks:hacks.py:115 Solution not found due to conflict between:
ERROR    align.schema.hacks:hacks.py:117 {"constraint": "symmetric_blocks", "pairs": [["X_CCP_MP5_MP6"], ["X_CCN_MN3_MN4"], ["X_DP_MN1_MN2"], ["X_MN0"], ["X_INVN_MN12_MP14", "X_INVP_MN11_MP13"], ["X_MP7", "X_MP8"], ["X_MP9", "X_MP10"]], "direction": "V"}
ERROR    align.schema.hacks:hacks.py:117 {"constraint": "order", "instances": ["X_INVN_MN12_MP14", "X_INVP_MN11_MP13"], "direction": "left_to_right", "abut": true}
ERROR    align.schema.hacks:hacks.py:117 {"constraint": "assign_bbox_variables", "bbox_name": "X_DP_MN1_MN2", "llx": 324, "lly": 1260, "urx": 5724, "ury": 3780}
ERROR    align.schema.hacks:hacks.py:117 {"constraint": "assign_bbox_variables", "bbox_name": "X_CCP_MP5_MP6", "llx": 1080, "lly": 6930, "urx": 4968, "ury": 8820}
ERROR    align.schema.hacks:hacks.py:117 {"constraint": "assign_bbox_variables", "bbox_name": "X_INVP_MN11_MP13", "llx": 2916, "lly": 9450, "urx": 4212, "ury": 10710}
ERROR    align.schema.hacks:hacks.py:117 {"constraint": "assign_bbox_variables", "bbox_name": "X_INVN_MN12_MP14", "llx": 2268, "lly": 8820, "urx": 2916, "ury": 11340}
ERROR    align.cmdline:cmdline.py:168 Fatal Error. Cannot proceed
```
