### PR TITLE
Placer To Satisfy Spread Constraint

### DIFF
--- a/tests/constraints/test_constraint.py
+++ b/tests/constraints/test_constraint.py
@@ -270,6 +270,31 @@ def test_placecloser():
     shutil.rmtree(ckt_dir)
 
 
+def test_spread():
+    name = f'ckt_{get_test_id()}'
+    netlist = textwrap.dedent(f"""\
+    .subckt dig22inv a o vccx vssx
+    .ends
+    .subckt {name} vi vo vccx vssx
+    xi0 vi v1 vccx vssx dig22inv
+    xi1 v1 v2 vccx vssx dig22inv
+    xi2 v2 vo vccx vssx dig22inv
+    .ends {name}
+    .END
+    """)
+    constraints = [
+        {"constraint": "ConfigureCompiler", "auto_constraint": False, "propagate": True},
+        {"constraint": "PowerPorts", "ports": ["vccx"]},
+        {"constraint": "GroundPorts", "ports": ["vssx"]},
+        {"constraint": "DoNotRoute", "nets": ["vccx", "vssx"]},
+        {"constraint": "AlignInOrder", "line": "bottom", "instances": ["xi0", "xi1", "xi2"]},
+        {"constraint": "Spread", "instances": ["xi0", "xi1"], "direction": "horizontal", "distance": 100},
+        {"constraint": "Spread", "instances": ["xi1", "xi2"], "direction": "horizontal", "distance": 200}
+    ]
+    example = build_example(name, netlist, constraints)
+    run_example(example, cleanup=False)
+
+
 @pytest.mark.skip(reason='Failing test to be enabled in a follow up next PR')
 def test_portlocation():
     name = f'ckt_{get_test_id()}'


### PR DESCRIPTION
Please see the failing test for development:
`pytest -vv -s tests/constraints/test_constraint.py::test_spread`

Example:
```javascript
{
  "constraint": "spread",
  "instances": ["XI0", "XI1" ],
  "direction": "horizontal",
  "distance": 100
}
```
XI0 and XI1 should be at least 100nm apart.