### PR TITLE
4-to-1 Analog Mux

### DIFF
--- a/PlaceRouteHierFlow/placer/design.cpp
+++ b/PlaceRouteHierFlow/placer/design.cpp
@@ -302,14 +302,14 @@ design::design(PnRDB::hierNode& node, PnRDB::Drc_info& drcInfo, const int seed) 
         for (const auto& al : node.Align_blocks) {
           if (al.horizon == 1 && find(al.blocks.begin(), al.blocks.end(), order.first[i]) != al.blocks.end()) {
             for (auto b : al.blocks) {
-              if (b != order.first[i]) {
+              if (b != order.first[i] && Blocks[order.first[i]][0].height >= Blocks[b][0].height) {
                 Ordering_Constraints.push_back(make_pair(make_pair(b, order.first[i + 1]), order.second == PnRDB::H ? placerDB::H : placerDB::V));
               }
             }
           }
           if (al.horizon == 1 && find(al.blocks.begin(), al.blocks.end(), order.first[i+1]) != al.blocks.end()) {
             for (auto b : al.blocks) {
-              if (b != order.first[i+1]) {
+              if (b != order.first[i+1] && Blocks[order.first[i+1]][0].height >= Blocks[b][0].height) {
                 Ordering_Constraints.push_back(make_pair(make_pair(order.first[i], b), order.second == PnRDB::H ? placerDB::H : placerDB::V));
               }
             }

--- a/examples/high_speed_comparator/high_speed_comparator.const.json
+++ b/examples/high_speed_comparator/high_speed_comparator.const.json
@@ -1,52 +1,21 @@
 [
-    {"constraint": "PowerPorts", "ports": ["VCC"]},
-    {"constraint": "GroundPorts", "ports": ["VSS"]},
+    {"constraint": "ConfigureCompiler", "auto_constraint": false, "propagate": true},
+    {"constraint": "PowerPorts", "ports": ["vcc"]},
+    {"constraint": "GroundPorts", "ports": ["vss"]},
     {"constraint": "ClockPorts", "ports": ["clk"]},
-    {"constraint":"HorizontalDistance", "abs_distance":0},
-    {"constraint":"VerticalDistance",   "abs_distance":0},
     {"constraint": "GroupBlocks", "instances": ["mn1", "mn2"],   "instance_name": "xdp"},
-    {"constraint":"GroupBlocks",  "instances": ["mn3", "mn4"],   "instance_name": "xccn"},
+    {"constraint": "GroupBlocks", "instances": ["mn3", "mn4"],   "instance_name": "xccn"},
     {"constraint": "GroupBlocks", "instances": ["mp5", "mp6"],   "instance_name": "xccp"},
     {"constraint": "GroupBlocks", "instances": ["mp11", "mn13"], "instance_name": "xinv_n"},
     {"constraint": "GroupBlocks", "instances": ["mp12", "mn14"], "instance_name": "xinv_p"},
-    {"constraint": "SymmetricBlocks",
-        "direction" : "V",
-        "pairs": [["mn0"], ["xdp"], ["xccn"], ["xccp"], ["mp7", "mp8"], ["mp9", "mp10"], ["xinv_n", "xinv_p"]]
-    },
-    {"constraint": "Order",
-        "direction" : "top_to_bottom",
-        "instances": ["mn0", "xdp", "xccn", "xccp"]
-    },
-    {"constraint": "align",
-        "line" : "h_bottom",
-        "instances": ["mp9", "mp7", "xdp", "mp8", "mp10"]
-    },
-    {"constraint": "align",
-        "line" : "h_bottom",
-        "instances": ["xinv_n", "xccp", "xinv_p"]
-    },
-    {
-        "constraint": "SymmetricNets",
-        "direction": "V",
-        "net1": "vin",
-        "pins1": ["mn1/G"],
-        "net2": "vip",
-        "pins2": ["mn2/G"]
-    },
-    {
-        "constraint": "SymmetricNets",
-        "direction": "V",
-        "net1": "vin_d",
-        "pins1": ["mn1/D","mn3/S","mp7/D"],
-        "net2": "vip_d",
-        "pins2": ["mn2/D","mn4/S","mp8/D"]
-    },
-    {
-        "constraint": "SymmetricNets",
-        "direction": "V",
-        "net1": "vin_o",
-        "pins1": ["mn3/D", "mn4/G", "mp5/D", "mp6/G", "mp9/D", "mp12/G", "mn14/G"],
-        "net2": "vip_o",
-        "pins2": ["mn3/G", "mn4/D", "mp5/G", "mp6/D", "mp10/D", "mp11/G", "mn13/G"]
+    {"constraint": "SameTemplate", "instances": ["xinv_n", "xinv_p"]},
+    {"constraint": "DoNotIdentify", "instances": ["mp7", "mp8", "mp9", "mp10"]},
+    {"constraint": "Floorplan", "order": true, "symmetrize": true,
+        "regions": [
+            ["xinv_n", "xccp", "xinv_p"],
+            ["xccn"],
+            ["mp9", "mp7", "xdp", "mp8", "mp10"],
+            ["mn0"]
+        ]
     }
 ]

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -8,7 +8,8 @@ run_flat = {'linear_equalizer',
             'single_to_differential_converter'}
 
 skip_pdks = {'Bulk65nm_Mock_PDK',
-             'Nonuniform_mock_pdk'}
+             'Nonuniform_mock_pdk',
+             'Bulk45nm_Mock_PDK'}
 
 skip_dirs = {'Sanitized_model3x_MDLL_TOP',
              'OTA_FF_2s_v3e',

--- a/tests/pdk/finfet_pdk/circuits.py
+++ b/tests/pdk/finfet_pdk/circuits.py
@@ -364,3 +364,37 @@ def comparator_analog(name):
     .END
     """)
     return netlist
+
+
+def analog_mux_4to1(name):
+    netlist = textwrap.dedent(f"""\
+    .subckt dig22inv a o1 vccx vssx
+    .ends
+    .subckt dig22nand a b o1 vccx vssx
+    .ends
+    .subckt decoder_2to4 o0 o0b o1 o1b o2 o2b o3 o3b vccx vssx x0 x1
+    inv08 x0 net21 vccx vssx dig22inv
+    inv09 x1 net16 vccx vssx dig22inv
+    inv00 o0b o0 vccx vssx dig22inv
+    inv01 o1b o1 vccx vssx dig22inv
+    inv02 o2b o2 vccx vssx dig22inv
+    inv03 o3b o3 vccx vssx dig22inv
+    nand0 net21 net16 o0b vccx vssx dig22nand
+    nand1 x0 net16 o1b vccx vssx dig22nand
+    nand2 net21 x1 o2b vccx vssx dig22nand
+    nand3 x0 x1 o3b vccx vssx dig22nand
+    .ends
+    .subckt passgate en enb pgin pgout vccx vssx
+    qp1 pgin enb pgout vccx p m=16 nf=2 w=360e-9
+    qn1 pgin en  pgout vssx n m=16 nf=2 w=360e-9
+    .ends
+    .subckt {name} in0 in1 in2 in3 muxout vccx vssx x0 x1
+    i0 net7 net8 net5 net6 net3 net4 net1 net2 vccx vssx x0 x1 decoder_2to4
+    pg0 net7 net8 in0 muxout vccx vssx passgate
+    pg1 net5 net6 in1 muxout vccx vssx passgate
+    pg2 net3 net4 in2 muxout vccx vssx passgate
+    pg3 net1 net2 in3 muxout vccx vssx passgate
+    .ends {name}
+    .END
+    """)
+    return netlist

--- a/tests/pdk/finfet_pdk/test_circuits.py
+++ b/tests/pdk/finfet_pdk/test_circuits.py
@@ -529,4 +529,4 @@ def test_analog_mux_4to1():
             ]
     }
     example = build_example(name, netlist, constraints)
-    run_example(example, cleanup=CLEANUP, log_level=LOG_LEVEL, n=1)
+    run_example(example, cleanup=CLEANUP, log_level=LOG_LEVEL, n=1, max_errors=4)

--- a/tests/pdk/finfet_pdk/test_circuits.py
+++ b/tests/pdk/finfet_pdk/test_circuits.py
@@ -487,3 +487,46 @@ def test_comparator_analog():
     ]
     example = build_example(name, netlist, constraints)
     run_example(example, cleanup=CLEANUP, log_level=LOG_LEVEL, n=1)
+
+
+def test_analog_mux_4to1():
+    name = f'ckt_{get_test_id()}'
+    netlist = circuits.analog_mux_4to1(name)
+    constraints = {
+        "passgate": [
+            {"constraint": "GroupBlocks", "instances": ["qp1"], "instance_name": "xqp1",
+                "generator": {"name": "MOS", "parameters": {"PARTIAL_ROUTING": True, "add_tap": False, "legal_sizes": [{"y": 1}]}}},
+            {"constraint": "GroupBlocks", "instances": ["qn1"], "instance_name": "xqn1",
+                "generator": {"name": "MOS", "parameters": {"PARTIAL_ROUTING": True, "add_tap": False, "legal_sizes": [{"y": 1}]}}},
+            {"constraint": "Floorplan", "regions": [["xqp1"], ["xqn1"]]}
+            ],
+        "decoder_2to4": [
+            {"constraint": "Floorplan", "order": True, "regions": [
+                ["inv08", "inv09"],
+                ["nand0", "inv00"],
+                ["nand1", "inv01"],
+                ["nand2", "inv02"],
+                ["nand3", "inv03"]
+                ]}
+            ],
+        name: [
+            {
+                "constraint": "ConfigureCompiler",
+                "auto_constraint": False,
+                "propagate": True,
+                "fix_source_drain": False,
+                "merge_series_devices": False,
+                "merge_parallel_devices": False,
+                "remove_dummy_devices": True,
+                "remove_dummy_hierarchies": False
+            },
+            {"constraint": "PowerPorts", "ports": ["vccx"]},
+            {"constraint": "GroundPorts", "ports": ["vssx"]},
+            {"constraint": "DoNotRoute", "nets": ["vssx", "vccx"]},
+            {"constraint": "SameTemplate", "instances": ["pg0", "pg1", "pg2", "pg3"]},
+            {"constraint": "AlignInOrder", "line": "left", "instances": ["pg0", "pg1", "pg2", "pg3"], "abut": True},
+            {"constraint": "AlignInOrder", "line": "bottom", "instances": ["i0", "pg3"]}
+            ]
+    }
+    example = build_example(name, netlist, constraints)
+    run_example(example, cleanup=CLEANUP, log_level=LOG_LEVEL, n=1)

--- a/tests/pdks/test_cap.py
+++ b/tests/pdks/test_cap.py
@@ -27,12 +27,13 @@ def check_shorts(pdk, cmdlist):
 
 
 def build_test(pdk, b, *, w, l):
-    check_shorts(pdk, ['-b', b, '-w', f"{w}", '-l', f"{l}"])
+    cwd = pathlib.Path(os.getcwd())
+    check_shorts(pdk, ['-b', b, '-w', f"{w}", '-l', f"{l}", '-o', f"{cwd}"])
 
 
 @pytest.mark.parametrize("pdk", pdks, ids=lambda x: x.name)
 def test_cap_smoke(pdk):
-    test_dir = WORK_DIR / "cap_smoke" / get_test_id()
+    test_dir = WORK_DIR / get_test_id()
     test_dir.mkdir(parents=True, exist_ok=True)
     os.chdir(test_dir)
     l = 200
@@ -45,7 +46,7 @@ def test_cap_smoke(pdk):
 @pytest.mark.parametrize("w", range(200, 1000, 400), ids=lambda x: f'w{x}')
 @pytest.mark.parametrize("pdk", pdks, ids=lambda x: x.name)
 def test_cap_full(pdk, l, w):
-    test_dir = WORK_DIR / "cap_smoke" / get_test_id()
+    test_dir = WORK_DIR / get_test_id()
     test_dir.mkdir(parents=True, exist_ok=True)
     os.chdir(test_dir)
     build_test(pdk, f'cap_{w}_{l}', w=w, l=l)

--- a/tests/pdks/test_cap.py
+++ b/tests/pdks/test_cap.py
@@ -1,15 +1,23 @@
+import os
 import pathlib
-import sys
 import pytest
+from .utils import get_test_id, WORK_DIR
+import importlib
 
 pdks = []
 for pdk in (pathlib.Path(__file__).parent.parent.parent / 'pdks').iterdir():
+    if pdk.stem == "Bulk45nm_Mock_PDK":
+        continue
     if pdk.is_dir() and (pdk / 'fabric_Cap.py').exists():
         pdks.append(pdk)
 
 
-def check_shorts(cmdlist):
-    from fabric_Cap import main, gen_parser
+def check_shorts(pdk, cmdlist):
+    spec = importlib.util.spec_from_file_location("fabric_Cap", pdk / 'fabric_Cap.py')
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    main = getattr(module, "main")
+    gen_parser = getattr(module, "gen_parser")
     parser = gen_parser()
     args = parser.parse_args(cmdlist)
     uc = main(args)
@@ -19,22 +27,25 @@ def check_shorts(cmdlist):
 
 
 def build_test(pdk, b, *, w, l):
-    sys.path.insert(0, str(pdk))
-    # print(str(pdk))
-    check_shorts(['-b', b, '-w', f"{w}", '-l',f"{l}"])
-    sys.path.pop(0)
+    check_shorts(pdk, ['-b', b, '-w', f"{w}", '-l', f"{l}"])
 
 
 @pytest.mark.parametrize("pdk", pdks, ids=lambda x: x.name)
 def test_cap_smoke(pdk):
+    test_dir = WORK_DIR / "cap_smoke" / get_test_id()
+    test_dir.mkdir(parents=True, exist_ok=True)
+    os.chdir(test_dir)
     l = 200
     w = 200
     build_test(pdk, f'cap_{w}_{l}', w=w, l=l)
 
 
 @pytest.mark.nightly
-@pytest.mark.parametrize("l", range(200, 1000, 400), ids=lambda x: f'n{x}')
-@pytest.mark.parametrize("w", range(200, 1000, 400), ids=lambda x: f'n{x}')
+@pytest.mark.parametrize("l", range(200, 1000, 400), ids=lambda x: f'l{x}')
+@pytest.mark.parametrize("w", range(200, 1000, 400), ids=lambda x: f'w{x}')
 @pytest.mark.parametrize("pdk", pdks, ids=lambda x: x.name)
 def test_cap_full(pdk, l, w):
+    test_dir = WORK_DIR / "cap_smoke" / get_test_id()
+    test_dir.mkdir(parents=True, exist_ok=True)
+    os.chdir(test_dir)
     build_test(pdk, f'cap_{w}_{l}', w=w, l=l)

--- a/tests/pdks/test_mos.py
+++ b/tests/pdks/test_mos.py
@@ -43,12 +43,13 @@ def check_shorts(pdk, cmdlist):
 
 def build_test(pdk, prim, *, n, X, Y):
     b = f"{prim}_n{n}_X{X}_Y{Y}"
-    check_shorts(pdk, ['-p', prim, '-b', b, '-n', f"{n}", '-X', f"{X}", '-Y', f"{Y}"])
+    cwd = pathlib.Path(os.getcwd())
+    check_shorts(pdk, ['-p', prim, '-b', b, '-n', f"{n}", '-X', f"{X}", '-Y', f"{Y}", '-o', f"{cwd}"])
 
 
 @pytest.mark.parametrize("pdk", pdks, ids=lambda x: x.name)
 def test_mos_smoke(pdk):
-    test_dir = WORK_DIR / "cap_smoke" / get_test_id()
+    test_dir = WORK_DIR / get_test_id()
     test_dir.mkdir(parents=True, exist_ok=True)
     os.chdir(test_dir)
     x = 2
@@ -72,7 +73,7 @@ def test_mos_smoke(pdk):
     ids=lambda x: x.replace('_{}', ''))
 @pytest.mark.parametrize("pdk", pdks, ids=lambda x: x.name)
 def test_mos_full(pdk, pstr, typ, nfins, x, y):
-    test_dir = WORK_DIR / "cap_smoke" / get_test_id()
+    test_dir = WORK_DIR / get_test_id()
     test_dir.mkdir(parents=True, exist_ok=True)
     os.chdir(test_dir)
     prim = pstr.format(typ)

--- a/tests/pdks/test_mos.py
+++ b/tests/pdks/test_mos.py
@@ -1,6 +1,8 @@
+import os
 import pathlib
-import sys
 import pytest
+from .utils import get_test_id, WORK_DIR
+import importlib
 
 
 pdks = []
@@ -21,8 +23,13 @@ def get_xcells_pattern(primitive, pattern, x_cells):
         pattern = 2 if x_cells % 4 != 0 else pattern  # CC is not possible; default is interdigitated
     return x_cells, pattern
 
-def check_shorts(cmdlist):
-    from Align_primitives import main, gen_parser
+
+def check_shorts(pdk, cmdlist):
+    spec = importlib.util.spec_from_file_location("Align_primitives", pdk / 'Align_primitives.py')
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    main = getattr(module, "main")
+    gen_parser = getattr(module, "gen_parser")
     parser = gen_parser()
     args = parser.parse_args(cmdlist)
     uc = main(args)
@@ -35,15 +42,15 @@ def check_shorts(cmdlist):
 
 
 def build_test(pdk, prim, *, n, X, Y):
-    sys.path.insert(0, str(pdk))
     b = f"{prim}_n{n}_X{X}_Y{Y}"
-    #print(f'Testing {b} ...')
-    check_shorts(['-p', prim, '-b', b, '-n', f"{n}", '-X', f"{X}", '-Y', f"{Y}"])
-    sys.path.pop(0)
+    check_shorts(pdk, ['-p', prim, '-b', b, '-n', f"{n}", '-X', f"{X}", '-Y', f"{Y}"])
 
 
 @pytest.mark.parametrize("pdk", pdks, ids=lambda x: x.name)
 def test_mos_smoke(pdk):
+    test_dir = WORK_DIR / "cap_smoke" / get_test_id()
+    test_dir.mkdir(parents=True, exist_ok=True)
+    os.chdir(test_dir)
     x = 2
     y = 2
     nfins = 12
@@ -65,6 +72,8 @@ def test_mos_smoke(pdk):
     ids=lambda x: x.replace('_{}', ''))
 @pytest.mark.parametrize("pdk", pdks, ids=lambda x: x.name)
 def test_mos_full(pdk, pstr, typ, nfins, x, y):
+    test_dir = WORK_DIR / "cap_smoke" / get_test_id()
+    test_dir.mkdir(parents=True, exist_ok=True)
+    os.chdir(test_dir)
     prim = pstr.format(typ)
     build_test(pdk, prim, n=nfins, X=x, Y=y)
-

--- a/tests/pdks/test_res.py
+++ b/tests/pdks/test_res.py
@@ -25,12 +25,13 @@ def check_shorts(pdk, cmdlist):
 
 
 def build_test(pdk, b, *, X, Y, n, r):
-    check_shorts(pdk, ['-b', b, '-X', f'{X}', '-Y', f'{Y}', '-n', f'{n}', '-r', f'{r}'])
+    cwd = pathlib.Path(os.getcwd())
+    check_shorts(pdk, ['-b', b, '-X', f'{X}', '-Y', f'{Y}', '-n', f'{n}', '-r', f'{r}', '-o', f"{cwd}"])
 
 
 @pytest.mark.parametrize("pdk", pdks, ids=lambda x: x.name)
 def test_res_smoke(pdk):
-    test_dir = WORK_DIR / "cap_smoke" / get_test_id()
+    test_dir = WORK_DIR / get_test_id()
     test_dir.mkdir(parents=True, exist_ok=True)
     os.chdir(test_dir)
     x = 2
@@ -47,7 +48,7 @@ def test_res_smoke(pdk):
 @pytest.mark.parametrize("x", range(1, 4), ids=lambda x: f'X{x}')
 @pytest.mark.parametrize("pdk", pdks, ids=lambda x: x.name)
 def test_res(pdk, x, y, n, r):
-    test_dir = WORK_DIR / "cap_smoke" / get_test_id()
+    test_dir = WORK_DIR / get_test_id()
     test_dir.mkdir(parents=True, exist_ok=True)
     os.chdir(test_dir)
     build_test(pdk, f'res_X{x}_Y{y}_h{n}_r{r}', X=x, Y=y, n=n, r=r)

--- a/tests/pdks/test_res.py
+++ b/tests/pdks/test_res.py
@@ -1,6 +1,8 @@
+import os
 import pathlib
-import sys
 import pytest
+from .utils import get_test_id, WORK_DIR
+import importlib
 
 pdks = []
 for pdk in (pathlib.Path(__file__).parent.parent.parent / 'pdks').iterdir():
@@ -8,8 +10,12 @@ for pdk in (pathlib.Path(__file__).parent.parent.parent / 'pdks').iterdir():
         pdks.append(pdk)
 
 
-def check_shorts(cmdlist):
-    from fabric_Res import main, gen_parser
+def check_shorts(pdk, cmdlist):
+    spec = importlib.util.spec_from_file_location("fabric_Res", pdk / 'fabric_Res.py')
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    main = getattr(module, "main")
+    gen_parser = getattr(module, "gen_parser")
     parser = gen_parser()
     args = parser.parse_args(cmdlist)
     uc = main(args)
@@ -19,14 +25,14 @@ def check_shorts(cmdlist):
 
 
 def build_test(pdk, b, *, X, Y, n, r):
-    sys.path.insert(0, str(pdk))
-    # print(str(pdk))
-    check_shorts(['-b', b, '-X', f'{X}', '-Y', f'{Y}', '-n', f'{n}', '-r', f'{r}'])
-    sys.path.pop(0)
+    check_shorts(pdk, ['-b', b, '-X', f'{X}', '-Y', f'{Y}', '-n', f'{n}', '-r', f'{r}'])
 
 
 @pytest.mark.parametrize("pdk", pdks, ids=lambda x: x.name)
 def test_res_smoke(pdk):
+    test_dir = WORK_DIR / "cap_smoke" / get_test_id()
+    test_dir.mkdir(parents=True, exist_ok=True)
+    os.chdir(test_dir)
     x = 2
     y = 2
     n = 2
@@ -41,4 +47,7 @@ def test_res_smoke(pdk):
 @pytest.mark.parametrize("x", range(1, 4), ids=lambda x: f'X{x}')
 @pytest.mark.parametrize("pdk", pdks, ids=lambda x: x.name)
 def test_res(pdk, x, y, n, r):
+    test_dir = WORK_DIR / "cap_smoke" / get_test_id()
+    test_dir.mkdir(parents=True, exist_ok=True)
+    os.chdir(test_dir)
     build_test(pdk, f'res_X{x}_Y{y}_h{n}_r{r}', X=x, Y=y, n=n, r=r)

--- a/tests/pdks/utils.py
+++ b/tests/pdks/utils.py
@@ -1,0 +1,18 @@
+import os
+import pathlib
+
+if 'ALIGN_WORK_DIR' in os.environ:
+    WORK_DIR = pathlib.Path(os.environ['ALIGN_WORK_DIR']).resolve()
+else:
+    assert False, "Please define ALIGN_WORK_DIR environment variable"
+
+
+def get_test_id():
+    try:
+        t = os.environ.get('PYTEST_CURRENT_TEST')
+        t = t.split(' ')[0].split(':')[-1]
+        t = t.replace('[', '_').replace(']', '').replace('-', '_')
+        t = t[5:]
+    except BaseException:
+        t = 'debug'
+    return t


### PR DESCRIPTION
This PR adds a new, hierarchical test circuit. The test is currently failing due to placement being illegal. 
To reproduce:
`pytest -vv -s tests/pdk/finfet_pdk/test_circuits.py::test_analog_mux_4to1`
From the log:
`PnR.placer.Placer.PlacementCoreAspectRatio_ILP ERROR : Couldn't generate a feasible solution even after 10000 perturbations.`
There is a trivial solution to the specified constraints.

