### PR TITLE
Unable to turn off auto_constraint in virtual hierarchy 

### DIFF
--- a/align/compiler/match_graph.py
+++ b/align/compiler/match_graph.py
@@ -165,7 +165,7 @@ class Annotate:
         param = FlatDict({"_":all_properties})
         arg_str = '_'.join([k+':'+str(param[k]) for k in sorted(param.keys())])
         key = f"_{str(int(hashlib.sha256(arg_str.encode('utf-8')).hexdigest(), 16) % 10**8)}"
-        new_subckt_name = (const.template_name if const.template_name else 'primitive'+key)
+        new_subckt_name = (const.template_name if const.template_name else 'primitive')+key
         if self.ckt_data.find(new_subckt_name):
             new_subckt = self.ckt_data.find(new_subckt_name)
             logger.info(f"identical group found {new_subckt_name} {self.ckt_data.find(new_subckt_name)}")

--- a/align/compiler/match_graph.py
+++ b/align/compiler/match_graph.py
@@ -165,7 +165,7 @@ class Annotate:
         param = FlatDict({"_":all_properties})
         arg_str = '_'.join([k+':'+str(param[k]) for k in sorted(param.keys())])
         key = f"_{str(int(hashlib.sha256(arg_str.encode('utf-8')).hexdigest(), 16) % 10**8)}"
-        new_subckt_name = (const.template_name if const.template_name else 'primitive')+key
+        new_subckt_name = (const.template_name if const.template_name else 'primitive'+key)
         if self.ckt_data.find(new_subckt_name):
             new_subckt = self.ckt_data.find(new_subckt_name)
             logger.info(f"identical group found {new_subckt_name} {self.ckt_data.find(new_subckt_name)}")

--- a/align/schema/translator.py
+++ b/align/schema/translator.py
@@ -60,6 +60,8 @@ class ConstraintTranslator():
                         ]
                     ):
                         self.child_const.append(const)
+                    elif isinstance(const,constraint.ConfigureCompiler) and const.propagate:
+                        self.child_const.append(const)
                     elif hasattr(const, "instances") and not isinstance(const,constraint.GroupBlocks):
                         # checking if sub hierarchy instances are in const defined
                         _child_const = {

--- a/tests/compiler/test_auto_const.py
+++ b/tests/compiler/test_auto_const.py
@@ -166,7 +166,7 @@ def test_filter_dummy():
 def test_disable_auto_constraint_virtual():
     name = f'ckt_{get_test_id()}'
     netlist = comparator(name)
-   
+
     # Sanity check: compler should auto-generate for cmp_inp
     constraints = [
         {"constraint": "PowerPorts", "ports": ["vccx"]},
@@ -179,7 +179,8 @@ def test_disable_auto_constraint_virtual():
     annotate_library(ckt_library, primitive_library)
     primitives = PrimitiveLibrary(ckt_library, pdk_path).gen_primitive_collateral()
     constraint_generator(ckt_library)
-    ckt = ckt_library.find("CMP_INP")
+    assert len([sckt for sckt in ckt_library if 'CMP_INP' in sckt.name]) == 1, f"no CMP_INP hierarchy found {[sckt.name for sckt in ckt_library]}"
+    ckt = [sckt for sckt in ckt_library if 'CMP_INP' in sckt.name][0]
     constraints = {c.constraint for c in ckt.constraints}
     assert "SymmetricNets" in constraints or "SymmetricBlocks" in constraints
 
@@ -195,7 +196,7 @@ def test_disable_auto_constraint_virtual():
     annotate_library(ckt_library, primitive_library)
     primitives = PrimitiveLibrary(ckt_library, pdk_path).gen_primitive_collateral()
     constraint_generator(ckt_library)
-    ckt = ckt_library.find("CMP_INP")
+    ckt = [sckt for sckt in ckt_library if 'CMP_INP' in sckt.name][0]
     constraints = {c.constraint for c in ckt.constraints}
     assert "SymmetricNets" not in constraints
     assert "SymmetricBlocks" not in constraints
@@ -205,7 +206,7 @@ def test_disable_auto_constraint_virtual():
 def test_disable_auto_constraint_physical():
     name = f'ckt_{get_test_id()}'
     netlist = comparator_hier(name)
-   
+
     # Sanity check: compler should auto-generate for cmp_inp
     constraints = [
         {"constraint": "PowerPorts", "ports": ["vccx"]},

--- a/tests/compiler/test_auto_const.py
+++ b/tests/compiler/test_auto_const.py
@@ -8,7 +8,7 @@ from align.compiler.compiler import compiler_input, annotate_library
 from align.compiler.find_constraint import add_or_revert_const, symmnet_device_pairs, recursive_start_points, add_symmetry_const, constraint_generator
 from align.compiler.gen_abstract_name import PrimitiveLibrary
 
-from utils import clean_data, build_example, ota_six, get_test_id, ota_dummy
+from utils import clean_data, build_example, ota_six, get_test_id, ota_dummy, comparator
 
 align_home = pathlib.Path(__file__).resolve().parent.parent.parent
 pdk_path = align_home / "pdks" / "FinFET14nm_Mock_PDK"
@@ -160,4 +160,44 @@ def test_filter_dummy():
     pairs = [['X_MN3_MN4', 'X_MN3_MN4'], ['X_MN3_DUMMY', 'X_MN4_DUMMY']]
     mpairs = add.filter_symblock_const(pairs)
     assert mpairs == [['X_MN3_MN4'], ['X_MN3_DUMMY', 'X_MN4_DUMMY']]
+    clean_data(name)
+
+
+def test_disable_auto_constraint():
+    name = f'ckt_{get_test_id()}'
+    netlist = comparator(name)
+   
+    # Sanity check: compler should auto-generate for cmp_inp
+    constraints = [
+        {"constraint": "PowerPorts", "ports": ["vccx"]},
+        {"constraint": "GroundPorts", "ports": ["vssx"]},
+        {"constraint": "GroupBlocks", "instances": ["mn0", "mn1", "mn2", "mn3", "mn4"], "instance_name": "x0", "template_name": "cmp_inp"},
+        {"constraint": "ConfigureCompiler", "auto_constraint": True, "propagate": True}
+    ]
+    example = build_example(name, netlist, constraints)
+    ckt_library, primitive_library = compiler_input(example, name, pdk_path, config_path)
+    annotate_library(ckt_library, primitive_library)
+    primitives = PrimitiveLibrary(ckt_library, pdk_path).gen_primitive_collateral()
+    constraint_generator(ckt_library)
+    ckt = ckt_library.find("CMP_INP")
+    constraints = {c.constraint for c in ckt.constraints}
+    assert "SymmetricNets" in constraints
+    assert "SymmetricBlocks" in constraints
+
+    # Test disabling
+    constraints = [
+        {"constraint": "PowerPorts", "ports": ["vccx"]},
+        {"constraint": "GroundPorts", "ports": ["vssx"]},
+        {"constraint": "GroupBlocks", "instances": ["mn0", "mn1", "mn2", "mn3", "mn4"], "instance_name": "x0", "template_name": "cmp_inp"},
+        {"constraint": "ConfigureCompiler", "auto_constraint": False, "propagate": True}
+    ]
+    example = build_example(name, netlist, constraints)
+    ckt_library, primitive_library = compiler_input(example, name, pdk_path, config_path)
+    annotate_library(ckt_library, primitive_library)
+    primitives = PrimitiveLibrary(ckt_library, pdk_path).gen_primitive_collateral()
+    constraint_generator(ckt_library)
+    ckt = ckt_library.find("CMP_INP")
+    constraints = {c.constraint for c in ckt.constraints}
+    assert "SymmetricNets" not in constraints
+    assert "SymmetricBlocks" not in constraints
     clean_data(name)

--- a/tests/compiler/utils.py
+++ b/tests/compiler/utils.py
@@ -14,6 +14,29 @@ config_path = pathlib.Path(__file__).resolve().parent.parent / "files"
 out_path = pathlib.Path(__file__).resolve().parent / "Results"
 
 
+def comparator(name):
+    netlist = textwrap.dedent(f"""\
+        .subckt {name} clk vccx vin vip von vop vssx
+        mn0 vcom clk vssx vssx n w=2.88e-6 m=1 nf=16
+        mn1 vin_d vin vcom vssx n w=360e-9 m=18 nf=2
+        mn2 vip_d vip vcom vssx n w=360e-9 m=18 nf=2
+        mn3 vin_o vip_o vin_d vssx n w=360e-9 m=8 nf=2
+        mn4 vip_o vin_o vip_d vssx n w=360e-9 m=8 nf=2
+        mp5 vin_o vip_o vccx vccx p w=360e-9 m=6 nf=2
+        mp6 vip_o vin_o vccx vccx p w=360e-9 m=6 nf=2
+        mp7 vin_d clk vccx vccx p w=360e-9 m=1 nf=2
+        mp8 vip_d clk vccx vccx p w=360e-9 m=1 nf=2
+        mp9 vin_o clk vccx vccx p w=360e-9 m=2 nf=2
+        mp10 vip_o clk vccx vccx p w=360e-9 m=2 nf=2
+        mn11 von vin_o vssx vssx n w=360e-9 m=1 nf=2
+        mn12 vop vip_o vssx vssx n w=360e-9 m=1 nf=2
+        mp13 von vin_o vccx vccx p w=360e-9 m=1 nf=2
+        mp14 vop vip_o vccx vccx p w=360e-9 m=1 nf=2
+        .ends {name}
+    """)
+    return netlist
+
+
 def ota_six(name):
     netlist = textwrap.dedent(
         f"""\

--- a/tests/compiler/utils.py
+++ b/tests/compiler/utils.py
@@ -37,6 +37,34 @@ def comparator(name):
     return netlist
 
 
+def comparator_hier(name):
+    netlist = textwrap.dedent(f"""\
+        .subckt comparator clk vccx vin vip von vop vssx
+        mn0 vcom clk vssx vssx n w=2.88e-6 m=1 nf=16
+        mn1 vin_d vin vcom vssx n w=360e-9 m=18 nf=2
+        mn2 vip_d vip vcom vssx n w=360e-9 m=18 nf=2
+        mn3 vin_o vip_o vin_d vssx n w=360e-9 m=8 nf=2
+        mn4 vip_o vin_o vip_d vssx n w=360e-9 m=8 nf=2
+        mp5 vin_o vip_o vccx vccx p w=360e-9 m=6 nf=2
+        mp6 vip_o vin_o vccx vccx p w=360e-9 m=6 nf=2
+        mp7 vin_d clk vccx vccx p w=360e-9 m=1 nf=2
+        mp8 vip_d clk vccx vccx p w=360e-9 m=1 nf=2
+        mp9 vin_o clk vccx vccx p w=360e-9 m=2 nf=2
+        mp10 vip_o clk vccx vccx p w=360e-9 m=2 nf=2
+        mn11 von vin_o vssx vssx n w=360e-9 m=1 nf=2
+        mn12 vop vip_o vssx vssx n w=360e-9 m=1 nf=2
+        mp13 von vin_o vccx vccx p w=360e-9 m=1 nf=2
+        mp14 vop vip_o vccx vccx p w=360e-9 m=1 nf=2
+        .ends
+        .subckt {name} clk vccx vin vip von vop vssx
+        i0 clk vccx vin vip von vop vssx comparator
+        mn0 vssx von vssx vssx n w=360e-9 m=1 nf=2
+        mn1 vssx vop vssx vssx n w=360e-9 m=1 nf=2
+        .ends {name}
+    """)
+    return netlist
+
+
 def ota_six(name):
     netlist = textwrap.dedent(
         f"""\


### PR DESCRIPTION
Please see the failing test: `test_auto_const.py::test_disable_auto_constraint_virtual`

Despite the constraint: `{"constraint": "ConfigureCompiler", "auto_constraint": False, "propagate": True}`

compiler is still generating auto-constraints for virtual hierarchy.