### PR TITLE
Allow Constraints for GroupBlocks

### DIFF
--- a/align/compiler/match_graph.py
+++ b/align/compiler/match_graph.py
@@ -166,8 +166,7 @@ class Annotate:
         key = f"_{str(int(hashlib.sha256(arg_str.encode('utf-8')).hexdigest(), 16) % 10**8)}"
         new_subckt_name = (const.template_name if const.template_name else 'primitive')+key
         if self.ckt_data.find(new_subckt_name):
-            # TODO: What is the usecase? Please comment
-            # TODO: Isn't it required to check the existing circuit is identical?
+            # Matching hash based names ensures the new subckt name is identical or different
             new_subckt = self.ckt_data.find(new_subckt_name)
             logger.info(f"identical group found {new_subckt_name} {self.ckt_data.find(new_subckt_name)}")
         else:
@@ -250,7 +249,8 @@ class Annotate:
                 ckt_ele
             ), f"Constraint instances: {const_insts} not in subcircuit {parent_subckt.name} with elements {ckt_ele}"
             if const.template_name and const.template_name.upper() in self.lib_names:
-                # TODO: What is the usecase? Please comment
+                # Create virtual hierarchies with user defined template name
+                # Reusing primitives defined in ALIGN library
                 child_subckt_graph = Graph([l for l in self.lib if l.name==const.template_name.upper()][0])
                 skip_insts = [e.name for e in parent_subckt.elements if e.name not in const_insts]
                 group_block_name = Graph(parent_subckt).replace_matching_subgraph(
@@ -264,6 +264,7 @@ class Annotate:
                 rename_inst(auto_generated_name, const.instance_name.upper())
                 continue
             else:
+                # For any new virtual hierarchy definition
                 self.create_canonical_primitive(parent_subckt, const)
         logger.debug(f"reduced constraints of design {parent_subckt_name} {parent_subckt.constraints}")
 

--- a/align/compiler/match_graph.py
+++ b/align/compiler/match_graph.py
@@ -324,10 +324,10 @@ class Annotate:
 
 
 def recursive_replace(items, update_map):
-    assert isinstance(items, list)
     for idx, item in enumerate(items):
         if isinstance(item, str):
-            assert item in update_map
-            items[idx] = update_map[item]
+            item_upper = item.upper()
+            assert item_upper in update_map
+            items[idx] = update_map[item_upper]
         elif isinstance(item, list):
             recursive_replace(item, update_map)

--- a/align/compiler/match_graph.py
+++ b/align/compiler/match_graph.py
@@ -11,7 +11,6 @@ import logging
 from ..schema import constraint
 from align.schema.graph import Graph
 from align.schema import ConstraintTranslator
-from .util import gen_group_key
 from flatdict import FlatDict
 import hashlib
 logger = logging.getLogger(__name__)
@@ -220,6 +219,8 @@ class Annotate:
         for c in list(parent_subckt.constraints):
             tr._add_const(parent_subckt.constraints, c)
 
+        # TODO: parent_subckt.verify()  # This call is to reset the formulae to exclude the bbox variables for removed elements
+
     def _group_block_const(self, parent_subckt_name):
         parent_subckt = self.ckt_data.find(parent_subckt_name)
         const_list = parent_subckt.constraints
@@ -266,6 +267,7 @@ class Annotate:
                 self.create_canonical_primitive(parent_subckt, const)
         logger.debug(f"reduced constraints of design {parent_subckt_name} {parent_subckt.constraints}")
 
+        # TODO: parent_subckt.verify()  # This call is to reset the formulae to exclude the bbox variables for removed elements
 
 
     def _group_cap_const(self, parent_subckt_name):

--- a/align/pnr/write_constraint.py
+++ b/align/pnr/write_constraint.py
@@ -58,7 +58,7 @@ class PnRConstraintWriter:
         for input_const in constraint.expand_user_constraints(all_const):
 
             # Create dict for PnR constraint and rename constraint to const_name
-            const = input_const.dict(exclude={'constraint'}, exclude_unset=False)
+            const = input_const.dict(exclude={'constraint', '_instance_attribute'}, exclude_unset=False)
             const['const_name'] = input_const.__class__.__name__
 
             # Rename instances to blocks

--- a/align/schema/constraint.py
+++ b/align/schema/constraint.py
@@ -955,8 +955,6 @@ class DoNotIdentify(SoftConstraint):
     instances: List[str]
     _instance_attribute: str = "instances"
 
-    _inst_validator = types.validator('instances', allow_reuse=True)(validate_instances)
-
 
 class SymmetricBlocks(HardConstraint):
     """SymmetricBlocks

--- a/align/schema/constraint.py
+++ b/align/schema/constraint.py
@@ -1465,7 +1465,6 @@ class GroupBlocks(HardConstraint):
         yield bb.lly < bb.ury
         # Grouping into common bbox
         for b in solver.iter_bbox_vars((x for x in self.instances if x in instances)):
-            assert False, "IS THIS CODE EVER EXECUTED???"
             yield b.urx <= bb.urx
             yield b.llx >= bb.llx
             yield b.ury <= bb.ury

--- a/align/schema/constraint.py
+++ b/align/schema/constraint.py
@@ -617,7 +617,6 @@ class Floorplan(UserConstraint):
     def _check_instance(cls, value):
         new_rows = list()
         for row in value:
-            assert row, f"Empty region is not allowed {row} in {value}"
             new_rows.append(validate_instances(cls, row))
         return new_rows
 

--- a/align/schema/constraint.py
+++ b/align/schema/constraint.py
@@ -617,6 +617,7 @@ class Floorplan(UserConstraint):
     def _check_instance(cls, value):
         new_rows = list()
         for row in value:
+            assert row, f"Empty region is not allowed {row} in {value}"
             new_rows.append(validate_instances(cls, row))
         return new_rows
 

--- a/align/schema/translator.py
+++ b/align/schema/translator.py
@@ -31,53 +31,37 @@ class ConstraintTranslator():
             self.child_name = child.name
             self.child_const = self.child.constraints
         else:
-            self.child=None
+            self.child = None
 
     def _top_to_bottom_translation(self, node_map):
         """
-        Update instance names in the child constraints
-
+        Inherit constraints from parent
         Args:
             node_map (dict): dict of mapping from parent instance names to child instance names
-
         """
 
-        logger.debug(
-            f"transferring constraints from top subckt: {self.parent_name} to bottom subckt: {self.child_name} "
-        )
+        logger.debug(f"Propagate constraints from parent: {self.parent_name} to child: {self.child_name}")
 
-        if not self.child_const:
-            with set_context(self.child_const):
-                for const in list(self.parent_const):
-                    if any(
-                        isinstance(const, x)
-                        for x in [
-                            constraint.HorizontalDistance,
-                            constraint.VerticalDistance,
-                            constraint.BlockDistance,
-                            constraint.CompactPlacement,
-                        ]
-                    ):
-                        self.child_const.append(const)
-                    elif isinstance(const,constraint.ConfigureCompiler) and const.propagate:
-                        self.child_const.append(const)
-                    elif hasattr(const, "instances") and not isinstance(const,constraint.GroupBlocks):
-                        # checking if sub hierarchy instances are in const defined
-                        _child_const = {
-                            x: [
-                                node_map[block]
-                                for block in const.instances
-                                if block in node_map.keys()
-                            ]
-                            if x == "instances"
-                            else getattr(const, x)
-                            for x in const.__fields_set__
-                        }
-                        assert "constraint" in _child_const, f"format check failed"
-                        logger.debug(f"transferred constraint instances {node_map} from {const} to {_child_const}")
-                        self._add_const(self.child_const, _child_const)
+        constraints_to_propagate = [
+                "HorizontalDistance",
+                "VerticalDistance",
+                "BlockDistance",
+                "CompactPlacement",
+                "ConfigureCompiler"
+            ]
+        constraint_exists = {c: False for c in constraints_to_propagate}
+        for const in self.child_const:
+            if const.constraint in constraint_exists:
+                constraint_exists[const.constraint] = True
 
         for const in list(self.parent_const):
+            if const.constraint in constraint_exists and not constraint_exists[const.constraint]:
+                if isinstance(const, constraint.ConfigureCompiler) and not const.propagate:
+                    continue
+                else:
+                    logger.debug(f"Propagating parent constraint to child: {const}")
+                    self.child_const.append(const)
+
             if hasattr(const, "pin_current"):
                 logger.debug(f"transferring charge flow constraints {const.pin_current.keys()}")
                 pin_map = {}
@@ -87,13 +71,10 @@ class ConstraintTranslator():
                     if parent_inst_name in node_map.keys():
                         child_inst_name = node_map[parent_inst_name]
                         assert parent_pin in self.child.get_element(child_inst_name).pins
-                        pin_map[pin] = child_inst_name+'/'+ parent_pin
-                _child_const = {x: {pin_map[pin]:current for pin, current in getattr(const,x).items() if pin in pin_map}
-                                if x== "pin_current" else getattr(const, x) for x in const.__fields_set__}
+                        pin_map[pin] = child_inst_name+'/'+parent_pin
+                _child_const = {x: {pin_map[pin]: current for pin, current in getattr(const, x).items() if pin in pin_map}
+                                if x == "pin_current" else getattr(const, x) for x in const.__fields_set__}
                 self._add_const(self.child_const, _child_const)
-
-        if self.child_const:
-            logger.debug(f"transferred constraints to {self.child_name} {self.child_const}")
 
     def _update_const(self, new_inst_name, node_map):
         """

--- a/align/schema/translator.py
+++ b/align/schema/translator.py
@@ -4,7 +4,6 @@ Created on Fri Nov  2 21:33:22 2018
 @author: kunal
 """
 
-from operator import sub
 from .types import set_context
 import logging
 from align.schema import constraint

--- a/tests/compiler/test_auto_const.py
+++ b/tests/compiler/test_auto_const.py
@@ -276,6 +276,7 @@ def test_group_with_constraint():
 
     ckt = [ckt for ckt in ckt_library if ckt.name.startswith("MYGROUP")][0]
     constraints = {c.constraint for c in ckt.constraints}
-    assert constraints.issuperset({"Floorplan", "DoNotIdentify", "ConfigureCompiler"}), f"{ckt.constraints}"
+    assert "Floorplan" in constraints, f"{ckt.constraints}"
+    assert "DoNotIdentify" in constraints, f"{ckt.constraints}"
 
     clean_data(name)

--- a/tests/compiler/test_auto_const.py
+++ b/tests/compiler/test_auto_const.py
@@ -81,7 +81,6 @@ def test_add_symmetry_const():
     clean_data(name)
 
 
-
 def test_match_start_points():
     name = f'ckt_{get_test_id()}'
     netlist = ota_six(name)
@@ -146,7 +145,6 @@ def test_reusable_const():
     constraint_generator(ckt_library1)
     constraints1 = ckt_library1.find(name).constraints
     assert constraints == constraints1
-
 
 
 def test_filter_dummy():
@@ -262,8 +260,10 @@ def test_group_with_constraint():
             "instances": ["mn1", "mn2", "mn3", "mn4"],
             "instance_name": "xm",
             "template_name": "mygroup",
-            "constraints": [{"constraint": "Floorplan", "order": True,"regions": [["mn1", "mn2", "mn3"], ["mn4"]]}]
-        }
+            "constraints": [
+                {"constraint": "DoNotIdentify", "instances": ["mn1", "mn2", "mn3", "mn4"]},
+                {"constraint": "Floorplan", "order": True, "symmetrize": True, "regions": [["mn1", "mn2", "mn3"], ["mn4"]]}
+            ]}
     ]
 
     example = build_example(name, netlist, constraints)
@@ -277,5 +277,6 @@ def test_group_with_constraint():
     ckt = [ckt for ckt in ckt_library if ckt.name.startswith("MYGROUP")][0]
     constraints = {c.constraint for c in ckt.constraints}
     assert "Floorplan" in constraints, f"{ckt.constraints}"
+    assert "DoNotIdentify" in constraints, f"{ckt.constraints}"
 
     clean_data(name)

--- a/tests/compiler/test_auto_const.py
+++ b/tests/compiler/test_auto_const.py
@@ -276,7 +276,6 @@ def test_group_with_constraint():
 
     ckt = [ckt for ckt in ckt_library if ckt.name.startswith("MYGROUP")][0]
     constraints = {c.constraint for c in ckt.constraints}
-    assert "Floorplan" in constraints, f"{ckt.constraints}"
-    assert "DoNotIdentify" in constraints, f"{ckt.constraints}"
+    assert constraints.issuperset({"Floorplan", "DoNotIdentify", "ConfigureCompiler"}), f"{ckt.constraints}"
 
     clean_data(name)

--- a/tests/compiler/test_auto_const.py
+++ b/tests/compiler/test_auto_const.py
@@ -7,6 +7,7 @@ from align.compiler.util import get_ports_weight
 from align.compiler.compiler import compiler_input, annotate_library
 from align.compiler.find_constraint import add_or_revert_const, symmnet_device_pairs, recursive_start_points, add_symmetry_const, constraint_generator
 from align.compiler.gen_abstract_name import PrimitiveLibrary
+import textwrap
 
 from utils import clean_data, build_example, ota_six, get_test_id, ota_dummy, comparator, comparator_hier
 
@@ -237,4 +238,44 @@ def test_disable_auto_constraint_physical():
     constraints = {c.constraint for c in ckt.constraints}
     assert "SymmetricNets" not in constraints
     assert "SymmetricBlocks" not in constraints
+    clean_data(name)
+
+
+def test_group_with_constraint():
+    name = f'ckt_{get_test_id()}'
+    netlist = textwrap.dedent(
+        f"""\
+        .subckt {name} vi vo vccx vssx
+        mp0 vo vo vccx vccx p w=360e-9 nf=2 m=1
+        mn1 vo vi vssx vssx n w=360e-9 nf=2 m=1
+        mn2 vo vi vssx vssx n w=360e-9 nf=2 m=1
+        mn3 vo vi vssx vssx n w=360e-9 nf=2 m=1
+        mn4 vo vi vssx vssx n w=360e-9 nf=2 m=1
+        .ends {name}
+    """)
+    constraints = [
+        {"constraint": "ConfigureCompiler", "auto_constraint": False, "propagate": True, "merge_parallel_devices": False},
+        {"constraint": "PowerPorts", "ports": ["vccx"]},
+        {"constraint": "GroundPorts", "ports": ["vssx"]},
+        {"constraint": "DoNotRoute", "nets": ["vssx", "vccx"]},
+        {"constraint": "GroupBlocks",
+            "instances": ["mn1", "mn2", "mn3", "mn4"],
+            "instance_name": "xm",
+            "template_name": "mygroup",
+            "constraints": [{"constraint": "Floorplan", "order": True,"regions": [["mn1", "mn2", "mn3"], ["mn4"]]}]
+        }
+    ]
+
+    example = build_example(name, netlist, constraints)
+    ckt_library, primitive_library = compiler_input(example, name, pdk_path, config_path)
+    annotate_library(ckt_library, primitive_library)
+
+    ckt = ckt_library.find(name)
+    constraints = {c.constraint for c in ckt.constraints}
+    assert "Floorplan" not in constraints, f"{ckt.constraints}"
+
+    ckt = [ckt for ckt in ckt_library if ckt.name.startswith("MYGROUP")][0]
+    constraints = {c.constraint for c in ckt.constraints}
+    assert "Floorplan" in constraints, f"{ckt.constraints}"
+
     clean_data(name)

--- a/tests/compiler/test_compiler.py
+++ b/tests/compiler/test_compiler.py
@@ -30,6 +30,6 @@ def test_compiler():
 
 def test_recursive_replace():
     items = ["a", "b", ["c"], [["d"], "e"]]
-    update_map = { item:item+item for item in ["a", "b", "c", "d", "e"]}
+    update_map = {item: item+item for item in ["A", "B", "C", "D", "E"]}
     recursive_replace(items, update_map)
-    assert items == ["aa", "bb", ["cc"], [["dd"], "ee"]]
+    assert items == ["AA", "BB", ["CC"], [["DD"], "EE"]]

--- a/tests/compiler/test_compiler.py
+++ b/tests/compiler/test_compiler.py
@@ -3,6 +3,7 @@ import textwrap
 import shutil
 
 from align.compiler.compiler import compiler_input, annotate_library, compiler_output, PrimitiveLibrary
+from align.compiler.match_graph import recursive_replace
 
 test_dir = pathlib.Path(__file__).resolve().parent.parent
 pdk_dir = test_dir.parent / "pdks" / "FinFET14nm_Mock_PDK"
@@ -27,4 +28,8 @@ def test_compiler():
     assert (out_path / 'OTA.verilog.json').exists()
 
 
-
+def test_recursive_replace():
+    items = ["a", "b", ["c"], [["d"], "e"]]
+    update_map = { item:item+item for item in ["a", "b", "c", "d", "e"]}
+    recursive_replace(items, update_map)
+    assert items == ["aa", "bb", ["cc"], [["dd"], "ee"]]

--- a/tests/constraints/test_constraint.py
+++ b/tests/constraints/test_constraint.py
@@ -330,8 +330,8 @@ def test_group_blocks():
         module = [module for module in verilog_json['modules'] if module['name'].startswith("MYGROUP")][0]
         constraints = [constraint["constraint"] for constraint in module["constraints"]]
         assert "Floorplan" in constraints
-    # shutil.rmtree(run_dir)
-    # shutil.rmtree(ckt_dir)
+    shutil.rmtree(run_dir)
+    shutil.rmtree(ckt_dir)
 
 
 @pytest.mark.skip(reason='Failing test to be enabled in a follow up next PR')

--- a/tests/constraints/test_constraint.py
+++ b/tests/constraints/test_constraint.py
@@ -295,6 +295,45 @@ def test_spread():
     run_example(example, cleanup=False)
 
 
+def test_group_blocks():
+    name = f'ckt_{get_test_id()}'
+    netlist = textwrap.dedent(
+        f"""\
+        .subckt {name} vi v0 v1 v2 v3 v4 vccx vssx
+        mp0 v0 vi vccx vccx p w=360e-9 nf=2 m=1
+        mn1 v1 vi vssx vssx n w=360e-9 nf=2 m=1
+        mn2 v2 vi vssx vssx n w=360e-9 nf=2 m=1
+        mn3 v3 vi vssx vssx n w=360e-9 nf=2 m=1
+        mn4 v4 vi vssx vssx n w=360e-9 nf=2 m=1
+        .ends {name}
+    """)
+    constraints = [
+        {"constraint": "ConfigureCompiler", "auto_constraint": False, "propagate": True, "merge_parallel_devices": False},
+        {"constraint": "PowerPorts", "ports": ["vccx"]},
+        {"constraint": "GroundPorts", "ports": ["vssx"]},
+        {"constraint": "DoNotRoute", "nets": ["vssx", "vccx"]},
+        {"constraint": "GroupBlocks",
+            "instances": ["mn1", "mn2", "mn3", "mn4"],
+            "instance_name": "xm",
+            "template_name": "mygroup",
+            "constraints": [
+                {"constraint": "DoNotIdentify", "instances": ["mn1", "mn2", "mn3", "mn4"]},
+                {"constraint": "Floorplan", "order": True, "symmetrize": True, "regions": [["mn1", "mn2", "mn3"], ["mn4"]]}
+            ]}
+    ]
+
+    example = build_example(name, netlist, constraints)
+    ckt_dir, run_dir = run_example(example, cleanup=False)
+    name = name.upper()
+    with (run_dir / '1_topology' / f'{name.upper()}.verilog.json').open('rt') as fp:
+        verilog_json = json.load(fp)
+        module = [module for module in verilog_json['modules'] if module['name'].startswith("MYGROUP")][0]
+        constraints = [constraint["constraint"] for constraint in module["constraints"]]
+        assert "Floorplan" in constraints
+    # shutil.rmtree(run_dir)
+    # shutil.rmtree(ckt_dir)
+
+
 @pytest.mark.skip(reason='Failing test to be enabled in a follow up next PR')
 def test_portlocation():
     name = f'ckt_{get_test_id()}'

--- a/tests/schema/test_constraint.py
+++ b/tests/schema/test_constraint.py
@@ -190,6 +190,17 @@ def test_Route(db):
         db.append(constraint.Route(max_layer="M5", min_layer="M1", customize=[constraint.CustomizeRoute(nets=["a", "b"], min_layer="M2", max_layer="M3", shield=True, match=True)]))
 
 
+def test_GroupBlocks(db):
+    with set_context(db):
+        fp = constraint.Floorplan(regions=[["M1"], ["M2"]])
+        pg = constraint.GroupBlocks(
+            instance_name="xyz",
+            instances=["a", "b"],
+            constraints=[fp]
+        )
+    assert pg
+
+
 def test_ConstraintDB_incremental_checking(db):
     '''
     ConstraintDB can be used to run experiments

--- a/tests/schema/test_constraint.py
+++ b/tests/schema/test_constraint.py
@@ -198,7 +198,7 @@ def test_GroupBlocks(db):
             instances=["a", "b"],
             constraints=[fp]
         )
-    assert pg
+        db.append(pg)
 
 
 def test_ConstraintDB_incremental_checking(db):


### PR DESCRIPTION
This PR allows user to specify select placement constraints for a virtual hierarchy defined by `GroupBlocks`.
Example:
```python
{"constraint": "GroupBlocks",
    "instances": ["mn1", "mn2", "mn3", "mn4"],
    "instance_name": "xm",
    "template_name": "mygroup",
    "constraints": [
        {"constraint": "DoNotIdentify", "instances": ["mn1", "mn2", "mn3", "mn4"]},
        {"constraint": "Floorplan", "order": True, "symmetrize": True, "regions": [["mn1", "mn2", "mn3"], ["mn4"]]}
    ]
}
```