### PR TITLE
Resistive Route Due to Redundant Layer Change

### DIFF
--- a/PlaceRouteHierFlow/router/A_star.cpp
+++ b/PlaceRouteHierFlow/router/A_star.cpp
@@ -1249,7 +1249,7 @@ void A_star::erase_candidate_node(std::set<int> &Close_set, std::vector<int> &ca
 std::vector<std::vector<int>> A_star::A_star_algorithm_Sym(Grid &grid, int left_up, int right_down, vector<RouterDB::Metal> &sym_path) {
   auto logger = spdlog::default_logger()->clone("router.A_star.A_star_algorithm_Sym");
 
-  int via_expand_effort = 100;
+  int via_expand_effort = 250;
   std::set<std::pair<int, int>, RouterDB::pairComp> L_list;
   std::set<int> close_set;
   std::pair<int, int> temp_pair;

--- a/tests/pnr/test_router.py
+++ b/tests/pnr/test_router.py
@@ -302,3 +302,24 @@ def test_ru_comparator_clock():
         cv.terminals.append(term)
     run_postamble(name, cv, max_errors=0)
     assert True
+
+
+def test_ru_resistive_route():
+    name = get_test_id()
+    cv = CanvasPDK()
+    cv.addWire(cv.m2, 'A', 6, (0, -1), (2, 1), netType='pin')
+    cv.addWire(cv.m2, 'A', 2, (0, -1), (2, 1), netType='pin')
+    cv.addWire(cv.m2, 'A', 6, (8, -1), (10, 1), netType='pin')
+    cv.addWire(cv.m2, 'A', 2, (8, -1), (10, 1), netType='pin')
+    cv.addWire(cv.m2, None, 6, (4, -1),  (6, 1), netType='blockage')
+    cv.addWire(cv.m2, None, 2, (4, -1),  (6, 1), netType='blockage')
+    cv.addWire(cv.m3, 'A',  1, (0, -1),  (7, 1),  netType='pin')
+    cv.addWire(cv.m3, 'A',  9, (0, -1),  (7, 1),  netType='pin')
+    cv.drop_via(cv.v2)
+    data = run_postamble(name, cv, max_errors=0)
+    cvr = CanvasPDK()
+    cvr.terminals = data['terminals']
+    cvr.removeDuplicates(allow_opens=True, silence_errors=True)
+    # Quantify route quality
+    for term in cvr.terminals:
+        assert term['layer'] != 'M4', 'Why use M4 but not M2?'


### PR DESCRIPTION
To reproduce: `pytest -v tests/pnr/test_router.py::test_ru_resistive_route`

Please see below for the routing problem and the solution. The solution is suboptimal in resistance as it uses two additional vias (two extra V2's).

Routing problem:
![image](https://user-images.githubusercontent.com/56893713/201445136-7d045b1f-a1d9-4540-b4c3-fd94bf586a54.png)

Routing solution:
![image](https://user-images.githubusercontent.com/56893713/201445160-e0447f78-a06a-4809-8c22-c53fa825ba82.png)
