### PR TITLE
Change name of leaves introduced for checking to 'flat_leaves'

### DIFF
--- a/tests/pnr/test_check_place_on_grid.py
+++ b/tests/pnr/test_check_place_on_grid.py
@@ -53,7 +53,7 @@ def test_flatten_leaves():
         {'concrete_name': 'INV', 'name': 'XI2/XI0/INV', 'transformation': {'oX': 0, 'oY': 10000, 'sX': 1, 'sY': -1}}
     ]
 
-    placement['leaves'] = {x['concrete_name']: x for x in placement['leaves']}
+    placement['flat_leaves'] = {x['concrete_name']: x for x in placement['leaves']}
     placement['modules'] = {x['concrete_name']: x for x in placement['modules']}
     leaves = _flatten_leaves(placement, 'CKT_TOP_0')
     assert leaves == leaves_gold, 'Value does not match golden'


### PR DESCRIPTION
@soneryaldiz Renamed the 'leaves' dictionary entry for each module to 'flat_leaves' as this is very different that the top level 'leaves' entry to verilog_json_d. I also make a copy of 'verilog_json_d' and use the copy in the checker routine so that these entries (which can be large) are not propagated to the down stream flows (like PnR.)

We might what to add a simple dictionary on the side to keep this information so we don't have to do the copy, but this seems to work now.