### PR TITLE
Sequence Pair Enumeration Does Not Kick In

### DIFF
--- a/PlaceRouteHierFlow/placer/ILP_solver.cpp
+++ b/PlaceRouteHierFlow/placer/ILP_solver.cpp
@@ -2942,12 +2942,12 @@ double ILP_solver::GenerateValidSolution(const design& mydesign, const SeqPair& 
   area_norm = area * 0.1 / mydesign.GetMaxBlockAreaSum();
   // calculate ratio
   // ratio = std::max(double(UR.x - LL.x) / double(UR.y - LL.y), double(UR.y - LL.y) / double(UR.x - LL.x));
-  ratio = double(UR.x - LL.x) / double(UR.y - LL.y);
+  ratio = double(UR.x) / double(UR.y);
   if (ratio < Aspect_Ratio[0] || ratio > Aspect_Ratio[1]) {
     ++const_cast<design&>(mydesign)._infeasAspRatio;
     return -1;
   }
-  if (placement_box[0] > 0 && (UR.x - LL.x > placement_box[0]) || placement_box[1] > 0 && (UR.y - LL.y > placement_box[1])) {
+  if ((placement_box[0] > 0 && UR.x > placement_box[0]) || (placement_box[1] > 0 && UR.y > placement_box[1])) {
     ++const_cast<design&>(mydesign)._infeasPlBound;
     return -1;
   }

--- a/PlaceRouteHierFlow/placer/SeqPair.cpp
+++ b/PlaceRouteHierFlow/placer/SeqPair.cpp
@@ -133,17 +133,20 @@ SeqPairEnumerator::SeqPairEnumerator(const vector<int>& pair, design& casenl, co
     } else {
       _valid = 0;
     }
-    logger->debug("enumeration check valid : {0}\n maxIter : {1} seq pair size : {2} total enumerations : {3}", (_valid ? 1 : 0), maxIter, _posPair.size(),
-                  totEnum);
+    logger->debug("enumeration check valid : {0}\n maxIter : {1} seq pair size : {2} total enumerations : {3} total select : {4}", (_valid ? 1 : 0), maxIter, _posPair.size(),
+                  totEnum, totSel);
   } else {
     _maxEnum = _posEnumerator.NumSequences();
     totEnum = _maxEnum * totSel;
     if (maxIter < totEnum) {
       _valid = 0;
     }
-    logger->debug("ordered enumeration check valid : {0}\n maxIter : {1} seq pair size : {2} total enumerations : {3}", (_valid ? 1 : 0), maxIter, _maxEnum, totEnum);
+    logger->debug("ordered enumeration check valid : {0}\n maxIter : {1} seq pair size : {2} total enumerations : {3} total select : {4}", (_valid ? 1 : 0), maxIter, _maxEnum, totEnum, totSel);
   }
-  if (!_valid) return;
+  if (!_valid) {
+    _maxSize = 0;
+    return;
+  }
   std::sort(_posPair.begin(), _posPair.end());
   _negPair = _posPair;
   _selected.resize(casenl.Blocks.size(), 0);
@@ -153,7 +156,7 @@ SeqPairEnumerator::SeqPairEnumerator(const vector<int>& pair, design& casenl, co
     logger->debug("max number of seq pairs : {0} max number of seq pair / select combinations : {1}", _maxEnum, totEnum);
   }
 
-  _maxSize = 0;
+  //_maxSize = 0;
   //_hflip = 0;
   //_vflip = 0;
   //_maxFlip = (1 << casenl.GetSizeofBlocks());

--- a/align/pnr/build_pnr_model.py
+++ b/align/pnr/build_pnr_model.py
@@ -135,7 +135,7 @@ def _attach_constraint_files( DB, fpath):
         if fp.exists():
             with fp.open("rt") as fp:
                 jsonStr = fp.read()
-            logger.info(f"Reading contraint json file {curr_node.name}.pnr.const.json\n{jsonStr}")
+            logger.info(f"Reading contraint json file {curr_node.name}.pnr.const.json\n")
 
             DB.ReadConstraint_Json(curr_node, jsonStr)
             logger.debug(f"Finished reading contraint json file {curr_node.name}.pnr.const.json")

--- a/tests/pdk/finfet_pdk/test_placer.py
+++ b/tests/pdk/finfet_pdk/test_placer.py
@@ -462,3 +462,64 @@ def test_sub_1():
     if CLEANUP:
         shutil.rmtree(ckt_dir)
         shutil.rmtree(run_dir)
+
+
+def test_binary_pfet(caplog):
+    name = "binary"
+    netlist = textwrap.dedent(f"""\
+        .subckt power_cell vccx vcca vg
+        xmp0 vcca vg vccx vccx p m=4 nf=4 nfin=4
+        .ends
+        .subckt {name} vccx vcca vgfix vg[0] vg[1] vg[2] vg[3]
+        xi0fix vccx vcca vgfix power_cell
+        xi0[0] vccx vcca vg[0] power_cell
+        xi1[0] vccx vcca vg[1] power_cell
+        xi1[1] vccx vcca vg[1] power_cell
+        xi2[0] vccx vcca vg[2] power_cell
+        xi2[1] vccx vcca vg[2] power_cell
+        xi2[2] vccx vcca vg[2] power_cell
+        xi2[3] vccx vcca vg[2] power_cell
+        xi3[0] vccx vcca vg[3] power_cell
+        xi3[1] vccx vcca vg[3] power_cell
+        xi3[2] vccx vcca vg[3] power_cell
+        xi3[3] vccx vcca vg[3] power_cell
+        xi3[4] vccx vcca vg[3] power_cell
+        xi3[5] vccx vcca vg[3] power_cell
+        xi3[6] vccx vcca vg[3] power_cell
+        xi3[7] vccx vcca vg[3] power_cell
+        .ends {name}
+        .END
+    """)
+
+    constraints = [
+        {
+            "constraint": "ConfigureCompiler",
+            "propagate": True,
+            "auto_constraint": False,
+            "identify_array": False,
+            "fix_source_drain": False,
+            "merge_series_devices": False,
+            "merge_parallel_devices": False,
+            "remove_dummy_devices": False,
+            "remove_dummy_hierarchies": False,
+            "fix_source_drain": False
+        },
+        {"constraint": "PowerPorts", "ports": ["vccx"]},
+        {"constraint": "GroundPorts", "ports": ["vcca"]},
+        {"constraint": "DoNotRoute", "nets": ["vccx", "vcca"]},
+        {
+            "constraint": "Floorplan",
+            "order": True,
+            "regions": [
+                ["xi3[0]", "xi2[0]", "xi0fix", "xi3[4]"],
+                ["xi3[1]", "xi2[1]", "xi0[0]", "xi3[5]"],
+                ["xi3[2]", "xi2[2]", "xi1[0]", "xi3[6]"],
+                ["xi3[3]", "xi2[3]", "xi1[1]", "xi3[7]"]
+            ]
+        }
+    ]
+
+    example = build_example(name, netlist, constraints)
+    run_example(example, cleanup=False, log_level='DEBUG', n=4, additional_args=['--placer_sa_iterations', '10', '--router_mode', 'no_op'])
+    assert 'DEBUG    align.schema.constraint' in caplog.text, 'Log level must be DEBUG for this test'
+    assert 'sa__cost name=BINARY' not in caplog.text, 'Simulated Annealing should be bypassed for this test. Enumeration only.'


### PR DESCRIPTION
To reproduce: ` pytest -vvv -s tests/pdk/finfet_pdk/test_placer.py::test_binary_pfet`

The constraints (Floorplan and SameTemplate - auto-generated by compiler) should result in a single sequence pair for the top-level placement problem (with only three variants). Therefore, enumeration is expected. However, log file indicates that simulated annealing is used.

Netlist:
```spice
.subckt power_cell vccx vcca vg
xmp0 vcca vg vccx vccx p m=4 nf=4 nfin=4
.ends
.subckt binary vccx vcca vgfix vg[0] vg[1] vg[2] vg[3]
xi0fix vccx vcca vgfix power_cell
xi0[0] vccx vcca vg[0] power_cell
xi1[0] vccx vcca vg[1] power_cell
xi1[1] vccx vcca vg[1] power_cell
xi2[0] vccx vcca vg[2] power_cell
xi2[1] vccx vcca vg[2] power_cell
xi2[2] vccx vcca vg[2] power_cell
xi2[3] vccx vcca vg[2] power_cell
xi3[0] vccx vcca vg[3] power_cell
xi3[1] vccx vcca vg[3] power_cell
xi3[2] vccx vcca vg[3] power_cell
xi3[3] vccx vcca vg[3] power_cell
xi3[4] vccx vcca vg[3] power_cell
xi3[5] vccx vcca vg[3] power_cell
xi3[6] vccx vcca vg[3] power_cell
xi3[7] vccx vcca vg[3] power_cell
.ends binary
.END
```

Floorplan:
```python
        {
            "constraint": "Floorplan",
            "order": True,
            "regions": [
                ["xi3[0]", "xi2[0]", "xi0fix", "xi3[4]"],
                ["xi3[1]", "xi2[1]", "xi0[0]", "xi3[5]"],
                ["xi3[2]", "xi2[2]", "xi1[0]", "xi3[6]"],
                ["xi3[3]", "xi2[3]", "xi1[1]", "xi3[7]"]
            ]
        }
```
