### PR TITLE
DoNotIdentify Blocks in a Placement Constraint

### DIFF
--- a/align/pnr/checker.py
+++ b/align/pnr/checker.py
@@ -54,7 +54,7 @@ def check_placement(placement_verilog_d, scale_factor):
 
             bbox = transformation.Transformation(**t).hitRect(transformation.Rect(*r)).canonical()
 
-            # logger.info(f"{inst['instance_name']}: {bbox=}")
+            logger.debug(f"{inst['instance_name']}: {bbox=}")
 
             with types.set_context(constraints):
                 constraints.append(

--- a/examples/cascode_current_mirror_ota/cascode_current_mirror_ota.const.json
+++ b/examples/cascode_current_mirror_ota/cascode_current_mirror_ota.const.json
@@ -1,5 +1,6 @@
 [
     {"constraint": "PowerPorts", "ports": ["VDD"]},
     {"constraint": "GroundPorts", "ports": ["VSS"]},
-    {"constraint": "DoNotUseLib", "libraries": ["CASCODED_SCM_NMOS", "CASCODED_SCM_PMOS"]}
+    {"constraint": "DoNotUseLib", "libraries": ["CASCODED_SCM_NMOS", "CASCODED_SCM_PMOS"]},
+    {"constraint": "AspectRatio", "ratio_low": 0.5, "ratio_high": 2}
 ]


### PR DESCRIPTION
Identifying a block that is part of a placement constraint can break user intention and result in inconsistent constraints.
Example: Given
`{"constraint": "Floorplan", "symmetrize": True, "regions": [["M0", "M1", "M2"], ["M3"]}`
if annotation identifies 'M0' and 'M1', compiler changes the original constraint to:
`{"constraint": "Floorplan", "symmetrize": True, "regions": [["X_M0_M1", "M2"], ["M3"]]}`
which clearly breaks user intention.

This PR also retires Enclose, CreateAlias  constraints which are not planned to be implemented. 