### PR TITLE
Halo in Boundary Constraint

### DIFF
--- a/PlaceRouteHierFlow/PnR-pybind11.cpp
+++ b/PlaceRouteHierFlow/PnR-pybind11.cpp
@@ -302,6 +302,10 @@ PYBIND11_MODULE(PnR, m) {
     .def_readwrite("blocks", &AlignBlock::blocks)
     .def_readwrite("horizon", &AlignBlock::horizon)
     .def_readwrite("line", &AlignBlock::line);
+  py::class_<BoundaryConstraint>( m, "BoundaryConstraint")
+    .def( py::init<>())
+    .def_readwrite("halo_horizontal", &BoundaryConstraint::halo_horizontal)
+    .def_readwrite("halo_vertical", &BoundaryConstraint::halo_vertical);
   py::class_<PortPos>( m, "PortPos")
     .def( py::init<>())
     .def_readwrite("tid", &PortPos::tid)

--- a/PlaceRouteHierFlow/PnRDB/ReadConstraint.cpp
+++ b/PlaceRouteHierFlow/PnRDB/ReadConstraint.cpp
@@ -608,6 +608,10 @@ void PnRdatabase::ReadConstraint_Json(PnRDB::hierNode& node, const string& jsonS
         logger->error("Wrong placement bounding box, width {0}, height {1}", node.placement_box[0], node.placement_box[1]);
       node.placement_box[0] *= unitScale;
       node.placement_box[1] *= unitScale;
+      if (constraint.find("halo_horizontal") != constraint.end())
+        node.boundary.halo_horizontal = static_cast<double>(constraint["halo_horizontal"]) * unitScale;
+      if (constraint.find("halo_vertical") != constraint.end())
+        node.boundary.halo_vertical = static_cast<double>(constraint["halo_vertical"]) * unitScale;
     } else if (constraint["const_name"] == "SameTemplate") {
       set<int> temp_const;
       for (auto b : constraint["blocks"]) {
@@ -616,7 +620,7 @@ void PnRdatabase::ReadConstraint_Json(PnRDB::hierNode& node, const string& jsonS
       node.Same_Template_Constraints.push_back(temp_const);
     } else if (constraint["const_name"] == "CompactPlacement") {
       node.compact_style = constraint["style"];
-    } else if(constraint["const_name"] == "DoNotRoute"){
+    } else if (constraint["const_name"] == "DoNotRoute") {
       vector<string> DoNotRoute;
       for(auto net : constraint["nets"]){
          DoNotRoute.push_back(net);
@@ -655,7 +659,7 @@ void PnRdatabase::ReadConstraint_Json(PnRDB::hierNode& node, const string& jsonS
         if (!found) logger->error("Block {0} in Spread not found in netlist", block);
       }
       node.SpreadConstraints.push_back(s);
-    } else if(constraint["const_name"] == "Route"){
+    } else if (constraint["const_name"] == "Route") {
       PnRDB::Routing_Layers_Info tmp_routing;
       tmp_routing.global_min_layer = constraint["min_layer"];
       tmp_routing.global_max_layer = constraint["max_layer"];

--- a/PlaceRouteHierFlow/PnRDB/datatype.h
+++ b/PlaceRouteHierFlow/PnRDB/datatype.h
@@ -499,7 +499,7 @@ struct hierNode {
   int bias_Vgraph = 0;
   double Aspect_Ratio_weight = 1000;
   double Aspect_Ratio[2] = {0, 100};
-  double placement_box[2] = {DBL_MIN, DBL_MAX};
+  double placement_box[2] = {DBL_MAX, DBL_MAX};
   vector<Router_report> router_report;
   vector<Multi_connection> Multi_connections;
   int placement_id = 0;

--- a/PlaceRouteHierFlow/PnRDB/datatype.h
+++ b/PlaceRouteHierFlow/PnRDB/datatype.h
@@ -7,6 +7,7 @@
 #include <utility>
 #include <vector>
 #include <tuple>
+#include <cfloat>
 
 #include "limits.h"
 //#include "../router/Rdatatype.h"
@@ -42,6 +43,7 @@ struct AlignBlock;
 struct Abument;
 struct MatchBlock;
 struct SpreadConstraint;
+struct BoundaryConstraint;
 struct lefMacro;
 struct blockComplex;
 struct CCCap;
@@ -433,6 +435,11 @@ struct Routing_Layers_Info{
   string global_max_layer;
 };
 
+struct BoundaryConstraint {
+  double halo_horizontal = 0;
+  double halo_vertical = 0;
+};
+
 struct hierNode {
   bool isCompleted = false;
   bool isTop = false;
@@ -492,7 +499,7 @@ struct hierNode {
   int bias_Vgraph = 0;
   double Aspect_Ratio_weight = 1000;
   double Aspect_Ratio[2] = {0, 100};
-  double placement_box[2] = {-1, -1};
+  double placement_box[2] = {DBL_MIN, DBL_MAX};
   vector<Router_report> router_report;
   vector<Multi_connection> Multi_connections;
   int placement_id = 0;
@@ -509,6 +516,7 @@ struct hierNode {
 //  vector<Min_Max_Routing_Layer> Routing_Layers;
   vector<Min_Max_Routing_Layer_Per_Net> Routing_Layer_Per_Net;
   Routing_Layers_Info Routing_Layers;
+  BoundaryConstraint boundary;
 };  // structure of vertex in heirarchical tree
 
 /// Part 3: declaration of structures for constraint data

--- a/PlaceRouteHierFlow/placer/ILP_solver.cpp
+++ b/PlaceRouteHierFlow/placer/ILP_solver.cpp
@@ -1816,6 +1816,10 @@ bool ILP_solver::FrameSolveILPCore(const design& mydesign, const SeqPair& curr_s
   if (flushbl) {
     for (const auto& id : curr_sp.negPair) {
       if (id < int(mydesign.Blocks.size())) {
+        collb[id * 4] = mydesign.halo_horizontal;
+        colub[id * 4] = mydesign.placement_box[0] - mydesign.halo_horizontal - mydesign.Blocks[id][curr_sp.selected[id]].width;
+        collb[id * 4 + 1] = mydesign.halo_vertical;
+        colub[id * 4 + 1] = mydesign.placement_box[1] - mydesign.halo_vertical - mydesign.Blocks[id][curr_sp.selected[id]].height;
         if (prev) {
           collb[id * 4] = (*prev)[id].x;
           collb[id * 4 + 1] = (*prev)[id].y;

--- a/PlaceRouteHierFlow/placer/ILP_solver.cpp
+++ b/PlaceRouteHierFlow/placer/ILP_solver.cpp
@@ -2856,7 +2856,7 @@ bool ILP_solver::GenerateValidSolutionCore(const design& mydesign, const SeqPair
   ++const_cast<design&>(mydesign)._totalNumCostCalc;
   if (snapGridILP) ++const_cast<design&>(mydesign)._numSnapGridFail;
   if (mydesign.Blocks.size() == 1 && mydesign.Blocks[0][0].xoffset.empty() && mydesign.Blocks[0][0].yoffset.empty()) {
-    Blocks[0].x = 0; Blocks[0].y = 0;
+    Blocks[0].x = mydesign.halo_horizontal; Blocks[0].y = mydesign.halo_vertical;
     Blocks[0].H_flip = 0; Blocks[0].V_flip = 0;
     area_ilp = ((double)mydesign.Blocks[0][curr_sp.selected[0]].width) * ((double)mydesign.Blocks[0][curr_sp.selected[0]].height);
   } else {

--- a/PlaceRouteHierFlow/placer/ILP_solver.cpp
+++ b/PlaceRouteHierFlow/placer/ILP_solver.cpp
@@ -5545,8 +5545,8 @@ void ILP_solver::updateTerminalCenter(design& mydesign, SeqPair& curr_sp) {
 }
 
 void ILP_solver::UpdateHierNode(design& mydesign, SeqPair& curr_sp, PnRDB::hierNode& node, PnRDB::Drc_info& drcInfo) {
-  node.width = UR.x;
-  node.height = UR.y;
+  node.width = UR.x + mydesign.halo_horizontal;
+  node.height = UR.y + mydesign.halo_vertical;
   node.HPWL = HPWL;
   node.HPWL_extend = HPWL_extend;
   node.HPWL_extend_wo_terminal = node.HPWL_extend - HPWL_extend_terminal;  // HPWL without terminal nets' HPWL

--- a/PlaceRouteHierFlow/placer/design.cpp
+++ b/PlaceRouteHierFlow/placer/design.cpp
@@ -32,6 +32,8 @@ design::design(PnRDB::hierNode& node, PnRDB::Drc_info& drcInfo, const int seed) 
   Same_Template_Constraints = node.Same_Template_Constraints;
   grid_unit_x = drcInfo.Metal_info[0].grid_unit_x;
   grid_unit_y = drcInfo.Metal_info[1].grid_unit_y;
+  halo_horizontal = node.boundary.halo_horizontal;
+  halo_vertical = node.boundary.halo_vertical;
   mixFlag = false;
   double averageWL = 0;
   double macroThreshold = 0.5;  // threshold to filter out small blocks

--- a/PlaceRouteHierFlow/placer/design.h
+++ b/PlaceRouteHierFlow/placer/design.h
@@ -129,7 +129,7 @@ class design {
   int placement_id = -1;
   bool is_first_ILP = true;
   double Aspect_Ratio[2] = {0, 100};
-  double placement_box[2] = {DBL_MIN, DBL_MAX};
+  double placement_box[2] = {DBL_MAX, DBL_MAX};
   double halo_horizontal = 0;
   double halo_vertical = 0;
   double maxBlockAreaSum = 0.;

--- a/PlaceRouteHierFlow/placer/design.h
+++ b/PlaceRouteHierFlow/placer/design.h
@@ -15,6 +15,7 @@
 #include <string>
 #include <utility>  // pair, make_pair
 #include <vector>
+#include <cfloat>
 
 #include "../PnRDB/datatype.h"
 #include "../PnRDB/readfile.h"
@@ -128,7 +129,9 @@ class design {
   int placement_id = -1;
   bool is_first_ILP = true;
   double Aspect_Ratio[2] = {0, 100};
-  double placement_box[2] = {-1.0, -1.0};
+  double placement_box[2] = {DBL_MIN, DBL_MAX};
+  double halo_horizontal = 0;
+  double halo_vertical = 0;
   double maxBlockAreaSum = 0.;
   double maxBlockHPWLSum = 0.;
   string name = "";

--- a/Viewer/index.html
+++ b/Viewer/index.html
@@ -132,8 +132,8 @@
       { layer: "m11", master: "M11" },
       { layer: "m12", master: "M12" },
       { layer: "m13", master: "M13" },
-      { layer: "Boundary", master: "diearea" },
-      { layer: "boundary", master: "diearea" },
+      { layer: "Boundary", master: "cellarea" },
+      { layer: "boundary", master: "cellarea" },
       { layer: "diffcon", master: "Diffcon" },
       { layer: "pc", master: "Polycon" },
       { layer: "poly", master: "Poly" },
@@ -141,6 +141,7 @@
       { layer: "nwell", master: "Nwell" },
       { layer: "VG", master: "Polycon" },
       { layer: "VT", master: "Diffcon" },
+      { layer: "Outline", master: "diearea" },
     ];
 
     var metalStack = [
@@ -185,8 +186,8 @@
       { layer: "LISD", tag: "LSD", color: "orange" },
       { layer: "SDT", tag: "SDT", color: "orange" },
       { layer: "GCUT", tag: "CUT", color: "purple" },
-      { layer: "cellarea", tag: "C", color: colorbrewer.Reds[3][1] },
-      { layer: "diearea", tag: "D", color: colorbrewer.Greens[3][1] },
+      { layer: "cellarea", tag: "C", color: colorbrewer.Reds[7][1] },
+      { layer: "diearea", tag: "D", color: colorbrewer.Greens[7][1] },
       { layer: "Nwell", tag: "NW", color: colorbrewer.Greens[3][1] },
       { layer: "Basepitchid", tag: "BPID", color: "yellow" },
       { layer: "Devflavn1id", tag: "DFNID", color: "orange" },

--- a/align/pnr/main.py
+++ b/align/pnr/main.py
@@ -31,8 +31,8 @@ def _generate_json(*, hN, variant, primitive_dir, pdk_dir, output_dir, extract=F
     if gds_json and toplevel:
         # Hack in Outline layer
         # Should be part of post processor
-        d['terminals'].append(
-            {"layer": "Outline", "netName": None, "netType": "drawing", "rect": d['bbox']})
+        # insert is slower than append but it improves the visulazation by drawing outline behind the other rectangles
+        d['terminals'].insert(0, {"layer": "Outline", "netName": None, "netType": "drawing", "rect": d['bbox']})
 
     ret = {}
 

--- a/align/pnr/write_constraint.py
+++ b/align/pnr/write_constraint.py
@@ -100,7 +100,7 @@ class PnRConstraintWriter:
                 const["const_name"] = 'Aspect_Ratio'
 
             elif const["const_name"] == 'Boundary':
-                for key in ['max_width', 'max_height']:
+                for key in ['halo_vertical', 'halo_horizontal', 'max_width', 'max_height']:
                     if const[key] is None:
                         del const[key]
 

--- a/align/schema/constraint.py
+++ b/align/schema/constraint.py
@@ -424,8 +424,8 @@ class Boundary(HardConstraint):
 
         {"constraint": "Boundary", "max_height": 100 }
     """
-    max_width: Optional[float] = 10000
-    max_height: Optional[float] = 10000
+    max_width: Optional[float] = 100000  # 100mm
+    max_height: Optional[float] = 100000  # 100mm
     halo_horizontal: Optional[float] = 0
     halo_vertical: Optional[float] = 0
 
@@ -445,12 +445,10 @@ class Boundary(HardConstraint):
 
     def translate(self, solver):
         bbox = solver.bbox_vars('subcircuit')
-        if self.max_width is not None:
-            yield solver.cast(bbox.urx-bbox.llx, float) <= 1000*self.max_width  # in nanometer
-        if self.max_height is not None:
-            yield solver.cast(bbox.ury-bbox.lly, float) <= 1000*self.max_height  # in nanometer
+        yield solver.cast(bbox.urx-bbox.llx, float) <= 1000*self.max_width  # convert to nanometer
+        yield solver.cast(bbox.ury-bbox.lly, float) <= 1000*self.max_height  # convert to nanometer
 
-        instances = get_instances_from_hacked_dataclasses(self._validator_ctx())
+        instances = get_instances_from_hacked_dataclasses(self)
         bvars = solver.iter_bbox_vars(instances)
         for b in bvars:
             yield b.llx >= bbox.llx + int(1000*self.halo_horizontal)

--- a/align/schema/constraint.py
+++ b/align/schema/constraint.py
@@ -1427,6 +1427,7 @@ class GroupBlocks(HardConstraint):
     constraints: Optional[List[Union[
         Align,
         Order,
+        Boundary,
         AlignInOrder,
         Floorplan,
         SymmetricBlocks,

--- a/tests/constraints/test_constraint.py
+++ b/tests/constraints/test_constraint.py
@@ -73,6 +73,14 @@ def test_boundary_max_height():
     run_example(example)
 
 
+def test_boundary_halo():
+    name = f'ckt_{get_test_id()}'
+    netlist = circuits.cascode_amplifier(name)
+    constraints = [{"constraint": "Boundary", "halo_vertical": 0.63, "halo_horizontal": 0.216}]
+    example = build_example(name, netlist, constraints)
+    run_example(example)
+
+
 def test_do_not_identify():
     name = f'ckt_{get_test_id()}'
     netlist = circuits.ota_five(name)

--- a/tests/pdk/finfet_pdk/test_circuits.py
+++ b/tests/pdk/finfet_pdk/test_circuits.py
@@ -179,7 +179,9 @@ def test_ota_six():
     constraints = [
         {"constraint": "ConfigureCompiler", "auto_constraint": False, "propagate": True},
         {"constraint": "GroupBlocks", "instances": ["mn1", "mn2"], "instance_name": "xtail"},
-        {"constraint": "GroupBlocks", "instances": ["mn3", "mn4"], "instance_name": "xdiffpair"},
+        {"constraint": "GroupBlocks", "instances": ["mn3", "mn4"], "instance_name": "xdiffpair", "template_name": "diffpair", "constraints": [
+            {"constraint": "Boundary", "halo_vertical": 0.63}
+        ]},
         {"constraint": "GroupBlocks", "instances": ["mp5", "mp6"], "instance_name": "xload"},
         {"constraint": "Floorplan", "order": True, "symmetrize": True, "regions": [["xload"], ["xdiffpair"], ["xtail"]]},
         {"constraint": "AspectRatio", "ratio_low": 0.5, "ratio_high": 2}
@@ -228,6 +230,7 @@ def test_ro_simple():
     constraints = {
         'ro_stage': [
             {"constraint": "Order", "direction": "top_to_bottom", "instances": ["mp0", "mn0"]},
+            {"constraint": "Boundary", "halo_horizontal": 0.108}
         ],
         name: [
             {"constraint": "Order", "direction": "left_to_right", "instances": [f'xi{k}' for k in range(5)]},

--- a/tests/pdk/finfet_pdk/test_placement_grid.py
+++ b/tests/pdk/finfet_pdk/test_placement_grid.py
@@ -208,7 +208,6 @@ def test_cs_on_grid_v(place_on_grid_v_half):
     run_example(example, cleanup=CLEANUP)
 
 
-@pytest.mark.skip(reason="This test is too slow. For a future PR.")
 def test_one_to_four():
     name = f'ckt_{get_test_id()}'
     netlist = textwrap.dedent(f"""\
@@ -235,10 +234,11 @@ def test_one_to_four():
         },
         {"constraint": "PowerPorts", "ports": ["vccx"]},
         {"constraint": "GroundPorts", "ports": ["vssx"]},
-        {"constraint": "DoNotRoute", "nets": ["vssx", "vccx"]}
+        {"constraint": "DoNotRoute", "nets": ["vssx", "vccx"]},
+        {"constraint": "Boundary", "halo_vertical": 0.3, "halo_horizontal": 0.216}
     ]
     example = build_example(name, netlist, constraints)
-    run_example(example, cleanup=CLEANUP, n=1)
+    run_example(example, cleanup=False, n=1)
 
 
 @pytest.mark.skip(reason="This test is too slow. For a future PR.")


### PR DESCRIPTION
To drive development, please use the test: `tests/constraints/test_constraint.py::test_boundary_halo`
Boundary constraint definition is extended to enable horizontal and vertical halo around a subcircuit.
Example constraint:
```
{
  "constraints": [
    {
      "max_width": 100000.0,
      "max_height": 100000.0,
      "halo_horizontal": 0.216,
      "halo_vertical": 0.63,
      "const_name": "Boundary"
    }
  ]
}
```
For any block:
```
llx >= top_level_llx + halo_horizontal
urx <= top_level_urx - halo_horizontal
lly >= top_level_lly + halo_vertical
ury <= top_level_ury - halo_vertical
```
