### PR TITLE
use long int to calculate tile size; width * height causes int overflow

### DIFF
--- a/PlaceRouteHierFlow/router/GlobalGrid.cpp
+++ b/PlaceRouteHierFlow/router/GlobalGrid.cpp
@@ -298,7 +298,7 @@ GlobalGrid::GlobalGrid(PnRDB::Drc_info& drc_info, int LLx, int LLy, int URx, int
         int viaNo = this->tiles_total.at(i).metal.back();
         int viaSize = (drc_info.Via_info.at(viaNo).width + drc_info.Via_info.at(viaNo).dist_ss) *
                       (drc_info.Via_info.at(viaNo).width_y + drc_info.Via_info.at(viaNo).dist_ss_y);
-        int tileSize = this->tiles_total.at(i).width * this->tiles_total.at(i).height;
+        long tileSize = this->tiles_total.at(i).width * this->tiles_total.at(i).height;
         int cap = tileSize / viaSize;
         tmpE.next = mit->second;
         tmpE.capacity = cap;

--- a/PlaceRouteHierFlow/router/Rdatatype.h
+++ b/PlaceRouteHierFlow/router/Rdatatype.h
@@ -75,8 +75,8 @@ struct tileEdge {
 struct tile {
   int x = -1;
   int y = -1;
-  int width;
-  int height;
+  long width;
+  long height;
   std::vector<int> metal;
   std::vector<int> origin_metal;
   int tileLayer = -1;


### PR DESCRIPTION
Fix integer overflow in GR edge capacity calculation.