### PR TITLE
fix: migrate ILP_solver to Symphony-less ILPSolverInterface API

### DIFF
--- a/PlaceRouteHierFlow/placer/ILP_solver.cpp
+++ b/PlaceRouteHierFlow/placer/ILP_solver.cpp
@@ -1777,7 +1777,7 @@ bool ILP_solver::FrameSolveILPCore(const design& mydesign, const SeqPair& curr_s
   const unsigned N_area_x = N_var - 2;
   const unsigned N_area_y = N_var - 1;
 
-  ILPSolverIf solverif(solvertouse == SYMPHONY  ? SOLVER_ENUM::SYMPHONY : SOLVER_ENUM::Cbc);
+  ILPSolverIf solverif;
   const double infty{solverif.getInfinity()};
   // set integer constraint, H_flip and V_flip can only be 0 or 1
   std::vector<int> rowindofcol[N_var];
@@ -2557,11 +2557,7 @@ bool ILP_solver::FrameSolveILPCore(const design& mydesign, const SeqPair& curr_s
     }
     PlacerHyperparameters hyper;
     solverif.setTimeLimit(std::max(hyper.ILP_runtime_limit, static_cast<int>(Blocks.size())));
-    if (solvertouse == SYMPHONY) {
-      solverif.loadProblemSym(N_var, (int)rhs.size(), starts.data(), indices.data(),
-          values.data(), collb.data(), colub.data(),
-          intvars.data(), objective.data(), sens.data(), rhs.data());
-    } else if (solvertouse == CBC) {
+    if (solvertouse == SYMPHONY || solvertouse == CBC) {
       double rhslb[rhs.size()], rhsub[rhs.size()];
       for (unsigned i = 0;i < sens.size(); ++i) {
         switch (sens[i]) {

--- a/PlaceRouteHierFlow/thirdparty/ilpif.cmake
+++ b/PlaceRouteHierFlow/thirdparty/ilpif.cmake
@@ -1,6 +1,7 @@
 FetchContent_Declare(
   ilpsolverif
   GIT_REPOSITORY https://github.com/ALIGN-analoglayout/ILPSolverInterface.git
+  GIT_TAG 4d82906a97a971c3ab54a7629a4c96edeed71cac
 )
 include(ProcessorCount)
 ProcessorCount(N)

--- a/PlaceRouteHierFlow/thirdparty/ilpif.cmake
+++ b/PlaceRouteHierFlow/thirdparty/ilpif.cmake
@@ -1,7 +1,7 @@
 FetchContent_Declare(
   ilpsolverif
   GIT_REPOSITORY https://github.com/ALIGN-analoglayout/ILPSolverInterface.git
-  GIT_TAG 4d82906a97a971c3ab54a7629a4c96edeed71cac
+  GIT_TAG 57de83f43dd1d05fa63295d7d55f58da2edf632c
 )
 include(ProcessorCount)
 ProcessorCount(N)

--- a/PlaceRouteHierFlow/thirdparty/ilpif.cmake
+++ b/PlaceRouteHierFlow/thirdparty/ilpif.cmake
@@ -38,15 +38,15 @@ endif()
 ]=])
       file(WRITE "${_ilpif_cbc_cmake}" "${_ilpif_cbc_content}")
 
-      # ILPSolverIf/CMakeLists.txt adds build deps on cbc/symphony for
-      # ILPSolverIf_shared but never calls target_link_libraries for it.
-      # macOS ld requires all symbols resolved at shared-lib link time.
+      # ILPSolverIf/CMakeLists.txt adds a build dep on cbc for ILPSolverIf_shared
+      # but never calls target_link_libraries for it.  macOS ld requires all
+      # symbols resolved at shared-lib link time.
       set(_ilpif_cmake "${ilpsolverif_SOURCE_DIR}/ILPSolverIf/CMakeLists.txt")
       file(READ "${_ilpif_cmake}" _ilpif_content)
       string(REPLACE
-        [=[target_link_libraries(ILPSolverIf INTERFACE ${symphony_LIBRARIES} ${cbc_LIBRARIES})]=]
-        [=[target_link_libraries(ILPSolverIf INTERFACE ${symphony_LIBRARIES} ${cbc_LIBRARIES})
-target_link_libraries(ILPSolverIf_shared PRIVATE ${symphony_LIBRARIES} ${cbc_LIBRARIES})]=]
+        [=[target_link_libraries(ILPSolverIf INTERFACE ${cbc_LIBRARIES})]=]
+        [=[target_link_libraries(ILPSolverIf INTERFACE ${cbc_LIBRARIES})
+target_link_libraries(ILPSolverIf_shared PRIVATE ${cbc_LIBRARIES})]=]
         _ilpif_content "${_ilpif_content}")
       file(WRITE "${_ilpif_cmake}" "${_ilpif_content}")
     endif()


### PR DESCRIPTION
## Summary
Unblocks the wheel build (and the v0.9.8 PyPI publish) by migrating `PlaceRouteHierFlow/placer/ILP_solver.cpp` to the Symphony-less ILPSolverInterface API and re-pinning the FetchContent SHA so future upstream churn can't silently break us again.

Two commits:
1. **Interim pin (bc5ed169)** — pin `GIT_TAG` to `4d82906a` (last commit with Symphony API). Kept as a clean revert point.
2. **Migration (df1b3e31)** — drop Symphony code paths, re-pin to `57de83f4` (current upstream HEAD without Symphony).

## Root cause
`PlaceRouteHierFlow/thirdparty/ilpif.cmake` declared `FetchContent_Declare(ilpsolverif ...)` with **no `GIT_TAG`**, so CMake always pulled the moving `ALIGN-analoglayout/ILPSolverInterface@master`. Upstream merged a "remove Symphony solver" series on 2026-05-12 (`66696bcc`, `37fa82ec`, `5ebe164f`, `89d584da`) that deleted `SOLVER_ENUM`, the `SOLVER_ENUM`-taking `ILPSolverIf` ctor, and `loadProblemSym()`. Our `ILP_solver.cpp` still used all three (lines 1780, 2560-2563), so every wheel build started failing with:

```
error: 'SOLVER_ENUM' has not been declared
error: 'class ILPSolverIf' has no member named 'loadProblemSym'
```

Last green PR build: 2026-05-08 (run 25530839828). First failure: 2026-05-22 (run 26307409727) — consistent with the May 12-13 upstream push.

## Migration scope
The Symphony backend is gone upstream; new API is Cbc-only via `loadProblem(...)`. Changes:

- `ILP_solver.cpp:1780` — drop `SOLVER_ENUM` ctor arg → `ILPSolverIf solverif;`
- `ILP_solver.cpp:2560` — collapse `if (SYMPHONY) { loadProblemSym(...) } else if (CBC) { loadProblem(...) }` into a single branch that uses the existing sens→rhslb/rhsub conversion + `loadProblem(...)`. The `LPSOLVE` branch is untouched.
- `ilpif.cmake` — pin `GIT_TAG` to the current upstream HEAD `57de83f4` for reproducibility.

The local `enum SOLVERTOUSE {SYMPHONY = 0, LPSOLVE, CBC}` in `ILP_solver.h` is intentionally left alone — the `SYMPHONY` value now silently routes through Cbc, but the `FrameSolveILP()` dispatcher still uses it to pick offset vs no-offset placement paths. Renaming to drop `SYMPHONY` is a cosmetic follow-up.

## Behavioral note
Any placement that previously took the SYMPHONY branch now runs Cbc. Cbc is the actively-maintained COIN-OR MILP solver, generally faster than Symphony on serial workloads, and is what upstream has standardized on. The CircleCI integration suite (`tests/integration/test_integration.py`, `tests/flow/test_flow.py`) exercises this on `five_transistor_ota` and other examples end-to-end and will catch any real placement-quality regression.

## Test plan
- [ ] `Build and Publish Wheels` is green on `ubuntu-latest` and `macos-14`
- [ ] CircleCI placement regression suite passes (5t-OTA, switched-capacitor filter, etc.)
- [ ] After merge: delete and re-create `v0.9.8` tag at new master HEAD; verify the tag-triggered run publishes `align-analoglayout 0.9.8` to PyPI