### PR TITLE
Fix ratio current-mirror over-provisioning: skip x_cells doubling for ratio SCM

### DIFF
--- a/align/primitive/main.py
+++ b/align/primitive/main.py
@@ -60,8 +60,21 @@ def generate_MOS_primitive(pdkdir, block_name, primitive, height, nfin, x_cells,
     pattern_map = {'single_device':0, 'cc':1, 'id':2,'ratio_devices':3,'ncc':4}
     pattern = pattern_map[input_pattern]
     if len(primitive.elements) ==2:
-        x_cells = 2*x_cells
-        pattern = 2 if x_cells % 4 != 0 else pattern  # CC is not possible; default is interdigitated
+        # For ratio current-mirrors (SCM with unequal finger counts), the PDK gen_param sizes
+        # x_cells to the EXACT total finger count (no ceil over-provision). Skip the *2 doubling
+        # here: doubling assumes an equal A/B split and re-introduces a 4-finger granularity that
+        # over-provisions any mirror whose finger sum isn't a multiple of 4. Pass ratio_a_cells
+        # (cells for device 'M1') so the generator can split the array proportionally.
+        def _fcount(e):
+            p = e.parameters
+            return int(float(p.get('NF', 1))) * int(float(p.get('M', 1)))
+        _is_ratio_scm = ('SCM' in primitive.name) and (_fcount(primitive.elements[0]) != _fcount(primitive.elements[1]))
+        if not _is_ratio_scm:
+            x_cells = 2*x_cells
+            pattern = 2 if x_cells % 4 != 0 else pattern  # CC is not possible; default is interdigitated
+        else:
+            _elem = {e.name: e for e in primitive.elements}
+            parameters['ratio_a_cells'] = _fcount(_elem.get('M1', primitive.elements[0])) // 2
         #TODO do this double during x_cells generation in gen_param.py/add_primitive()
 
     logger.debug(


### PR DESCRIPTION
## Problem

For a 2-element primitive, `generate_MOS_primitive` (align/primitive/main.py) unconditionally doubles `x_cells`. Combined with 2 fingers per unit cell this forces a **4-finger granularity**, so any ratio current-mirror (SCM) whose total finger count is not a multiple of 4 is **over-provisioned with extra, electrically-connected fingers** — the layout is no longer electrically equal to the schematic and fails LVS.

The existing PDK comment (`# Factor 2 is due to NF=2 in each unit cell; needs to be generalized`) flags the same root cause.

**Example** (`ALIGN-pdk-sky130/examples/current_mirror_ota`): the pfet mirrors are 6:12 = 18 fingers each. `ceil(18 / (2*2)) = 5` → array built with 20 fingers → **+2 fingers/mirror × 2 mirrors = +8 transistors**. Measured pfet effective width 42.0 µm vs schematic 37.8 µm. nfet pairs all had finger sums divisible by 4 and matched exactly, masking the bug.

## Change

Skip the `*2` doubling for **ratio SCM** (SCM with unequal device finger counts), and pass `ratio_a_cells` (the cell count for device `M1`) so the MOS generator can split the array proportionally to the f0:f1 ratio. Gated on `'SCM' in name AND unequal finger counts`, so equal-ratio and non-SCM primitives are untouched.

## Coordination

This is one half of a coordinated pair and requires the companion **ALIGN-pdk-sky130** PR (gen_param.py exact tiling `no_units = size//2`, and mos.py pattern-3 proportional split). Both are required together; merged alone, either changes behavior. Happy to squash/restructure if you'd prefer a single coordinated change or a different split.

## Validation (sky130A, magic + netgen)

| metric | before | after |
|---|---|---|
| total devices | 192 | **184** (exact match to schematic) |
| pfet eff. width | 42.0 µm | **37.8 µm** |
| diode:mirror split | wrong | **6:12** |
| magic DRC | — | **0 violations** |
| netgen | mismatch | **Netlists match** |

No regression: `five_transistor_ota` (equal 1:1 mirrors) produces byte-identical concrete templates on patched vs unpatched.